### PR TITLE
1.0-rc2

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,8 +292,10 @@ Next, we define the location where we observe from. Here we can (but don't have 
  make_observer_on_surface(50.7374, 7.0982, 60.0, 0.0, 0.0, &obs);
 ```
 
-We also need to set the time of observation. Out clocks usually measure UTC, but for NOVAS we usually need time 
-measured based on Terrestrial Time (TT) or Barycentric Time (TDB) or UT1. So 
+We also need to set the time of observation. Our clocks usually measure UTC, but for NOVAS we usually need time 
+measured based on Terrestrial Time (TT) or Barycentric Time (TDB) or UT1. Typically you will have to provide
+NOVAS with the TT - UT1 time difference, which can be calculated from the current leap seconds and the UT1 - UTC 
+time difference (a.k.a. DUT1): 
 
 ```c
  // The current value for the leap seconds (UTC - TAI)
@@ -344,8 +346,8 @@ distance (e.g. for apparent-to-physical size conversion):
  }
 ```
 
-Finally, we may want to calculate the astrometric zenith distance (= 90&deg; - azimuth) and elevation angles of the source
-at the specified observing location (without refraction correction):
+Finally, we may want to calculate the astrometric azimuth and zenith distance (= 90&deg; - azimuth) angles of the 
+source at the specified observing location (without refraction correction):
 
 ```c
  double itrs[3];  // ITRS position vector of source to populate
@@ -378,7 +380,7 @@ want, e.g.:
 Solar-system sources work similarly to the above with a few important differences.
 
 First, You will have to provide one or more functions to obtain the barycentric ICRS positions for your Solar-system 
-source of interest for the specific Barycentric Dynamical Time (TDB) of observation. See Section on integrating 
+source(s) of interest for the specific Barycentric Dynamical Time (TDB) of observation. See section on integrating 
 [External Solar-system ephemeris data or services](#solarsystem) with SuperNOVAS. You can specify the functions
 that will handle the respective ephemeris data at runtime before making the NOVAS calls that need them, e.g.:
 
@@ -410,11 +412,11 @@ more generic ephemeris handling via a user-provided `novas_ephem_provider`. E.g.
  object mars, ceres; // Hold data on solar-system bodies.
   
  // Mars will be handled by hte planet calculator function
- make_object(NOVAS_PLANET_MARS, NOVAS_MARS, "Mars", NULL, &mars);
+ make_planet(NOVAS_MARS, &mars);
   
  // Ceres will be handled by the generic ephemeris reader, which say uses the 
  // NAIF ID of 2000001
- make_object(NOVAS_EPHEM_OBJECT, 2000001, "Ceres", NULL, &ceres);
+ make_ephem_object("Ceres", 2000001, &ceres);
 ```
 
 Other than that, it's the same spiel as before, except using the appropriate `place()` for generic celestial
@@ -460,7 +462,8 @@ Therefore, when calculating positions for a large number of sources at different
 
 The IAU 2000 and 2006 resolutions have completely overhauled the system of astronomical coordinate transformations
 to enable higher precision astrometry. (Super)NOVAS supports coordinate calculations both in the old (pre IAU 2000) 
-ways, and in the new IAU standard method.
+ways, and in the new IAU standard method. Here is an overview of how the old and new methods define some of the
+terms differently:
 
  | Concept                    | Old standard                  | New IAU standard                                  |
  | -------------------------- | ----------------------------- | ------------------------------------------------- |

--- a/include/novas.h
+++ b/include/novas.h
@@ -773,7 +773,7 @@ void novas_case_sensitive(int value);
 
 int make_planet(enum novas_planet num, object *planet);
 
-int make_ephem_body(const char *name, long num, object *body);
+int make_ephem_object(const char *name, long num, object *body);
 
 int set_cio_locator_file(const char *filename);
 
@@ -812,10 +812,10 @@ int gal2equ(double glon, double glat, double *ra, double *dec);
 // GCRS - CIRS - ITRS conversions
 int gcrs_to_cirs(double jd_tt, enum novas_accuracy accuracy, const double *in, double *out);
 
-int cirs_to_itrs(double jd_tt, double ut1_to_tt, enum novas_accuracy accuracy, double xp, double yp, const double *vec1,
+int cirs_to_itrs(double jd_tt_high, double jd_tt_low, double ut1_to_tt, enum novas_accuracy accuracy, double xp, double yp, const double *vec1,
         double *vec2);
 
-int itrs_to_cirs(double jd_tt, double ut1_to_tt, enum novas_accuracy accuracy, double xp, double yp, const double *vec1,
+int itrs_to_cirs(double jd_tt_high, double jd_tt_low, double ut1_to_tt, enum novas_accuracy accuracy, double xp, double yp, const double *vec1,
         double *vec2);
 
 int cirs_to_gcrs(double jd_tt, enum novas_accuracy accuracy, const double *in, double *out);
@@ -825,10 +825,10 @@ int gcrs_to_j2000(const double *in, double *out);
 
 int j2000_to_tod(double jd_tt, enum novas_accuracy accuracy, const double *in, double *out);
 
-int tod_to_itrs(double jd_tt, double ut1_to_tt, enum novas_accuracy accuracy, double xp, double yp, const double *vec1,
+int tod_to_itrs(double jd_tt_high, double jd_tt_low, double ut1_to_tt, enum novas_accuracy accuracy, double xp, double yp, const double *vec1,
         double *vec2);
 
-int itrs_to_tod(double jd_tt, double ut1_to_tt, enum novas_accuracy accuracy, double xp, double yp, const double *vec1,
+int itrs_to_tod(double jd_tt_high, double jd_tt_low, double ut1_to_tt, enum novas_accuracy accuracy, double xp, double yp, const double *vec1,
         double *vec2);
 
 int tod_to_j2000(double jd_tt, enum novas_accuracy accuracy, const double *in, double *out);

--- a/include/solarsystem.h
+++ b/include/solarsystem.h
@@ -133,7 +133,7 @@ typedef short (*novas_planet_provider_hp)(const double jd_tdb[2], enum novas_pla
  * @since 1.0
  * @author Attila Kovacs
  */
-typedef int (*novas_ephem_provider)(long id, const char *name, double jd_tdb_high, double jd_tdb_low, enum novas_origin *origin, double *pos, double *vel);
+typedef int (*novas_ephem_provider)(const char *name, long id, double jd_tdb_high, double jd_tdb_low, enum novas_origin *origin, double *pos, double *vel);
 
 
 

--- a/src/novas.c
+++ b/src/novas.c
@@ -2513,6 +2513,11 @@ short ter2cel(double jd_ut1_high, double jd_ut1_low, double ut1_to_tt, enum nova
  *
  * If both 'xp' and 'yp' are set to 0 no polar motion is included in the transformation.
  *
+ * If extreme (sub-microarcsecond) accuracy is not required, you can use UT1-based Julian date
+ * instead of the TT-based Julian date and set the 'ut1_to_tt' argument to 0.0. and you can
+ * use UTC-based Julian date the same way.for arcsec-level precision also.
+ *
+ *
  * REFERENCES:
  *  <ol>
  *   <li>Kaplan, G. H. et. al. (1989). Astron. Journ. 97, 1197-1210.</li>
@@ -2520,7 +2525,8 @@ short ter2cel(double jd_ut1_high, double jd_ut1_low, double ut1_to_tt, enum nova
  *   XXV Joint Discussion 16.</li>
  *  </ol>
  *
- * @param jd_tt         [day] Terrestrial Time (TT) based Julian date.
+ * @param jd_tt_high    [day] High-order part of Terrestrial Time (TT) based Julian date.
+ * @param jd_tt_low     [day] Low-order part of Terrestrial Time (TT) based Julian date.
  * @param ut1_to_tt     [s] TT - UT1 Time difference in seconds
  * @param accuracy      NOVAS_FULL_ACCURACY (0) or NOVAS_REDUCED_ACCURACY (1)
  * @param xp            [arcsec] Conventionally-defined X coordinate of celestial intermediate
@@ -2542,16 +2548,21 @@ short ter2cel(double jd_ut1_high, double jd_ut1_low, double ut1_to_tt, enum nova
  * @since 1.0
  * @author Attila Kovacs
  */
-int itrs_to_cirs(double jd_tt, double ut1_to_tt, enum novas_accuracy accuracy, double xp,
+int itrs_to_cirs(double jd_tt_high, double jd_tt_low, double ut1_to_tt, enum novas_accuracy accuracy, double xp,
         double yp, const double *vec1, double *vec2) {
-  return ter2cel(jd_tt, -ut1_to_tt, ut1_to_tt, EROT_ERA, accuracy, CELESTIAL_APPARENT, xp, yp, vec1, vec2);
+  return ter2cel(jd_tt_high, jd_tt_low - ut1_to_tt, ut1_to_tt, EROT_ERA, accuracy, CELESTIAL_APPARENT, xp, yp, vec1, vec2);
 }
+
 
 /**
  * Rotates a position vector from the Earth-fixed ITRS frame to the dynamical True of Date
  * (TOD) frame of date (pre IAU 2000 method).
  *
  * If both 'xp' and 'yp' are set to 0 no polar motion is included in the transformation.
+ *
+ * If extreme (sub-microarcsecond) accuracy is not required, you can use UT1-based Julian date
+ * instead of the TT-based Julian date and set the 'ut1_to_tt' argument to 0.0. and you can
+ * use UTC-based Julian date the same way.for arcsec-level precision also.
  *
  * REFERENCES:
  *  <ol>
@@ -2560,7 +2571,8 @@ int itrs_to_cirs(double jd_tt, double ut1_to_tt, enum novas_accuracy accuracy, d
  *   XXV Joint Discussion 16.</li>
  *  </ol>
  *
- * @param jd_tt         [day] Terrestrial Time (TT) based Julian date.
+ * @param jd_tt_high    [day] High-order part of Terrestrial Time (TT) based Julian date.
+ * @param jd_tt_low     [day] Low-order part of Terrestrial Time (TT) based Julian date.
  * @param ut1_to_tt     [s] TT - UT1 Time difference in seconds
  * @param accuracy      NOVAS_FULL_ACCURACY (0) or NOVAS_REDUCED_ACCURACY (1)
  * @param xp            [arcsec] Conventionally-defined X coordinate of celestial intermediate
@@ -2582,10 +2594,11 @@ int itrs_to_cirs(double jd_tt, double ut1_to_tt, enum novas_accuracy accuracy, d
  * @since 1.0
  * @author Attila Kovacs
  */
-int itrs_to_tod(double jd_tt, double ut1_to_tt, enum novas_accuracy accuracy, double xp,
+int itrs_to_tod(double jd_tt_high, double jd_tt_low, double ut1_to_tt, enum novas_accuracy accuracy, double xp,
         double yp, const double *vec1, double *vec2) {
-  return ter2cel(jd_tt, -ut1_to_tt, ut1_to_tt, EROT_GST, accuracy, CELESTIAL_APPARENT, xp, yp, vec1, vec2);
+  return ter2cel(jd_tt_high, jd_tt_low - ut1_to_tt, ut1_to_tt, EROT_GST, accuracy, CELESTIAL_APPARENT, xp, yp, vec1, vec2);
 }
+
 
 /**
  * Rotates a vector from the celestial to the terrestrial system.  Specifically, it transforms
@@ -2712,6 +2725,11 @@ short cel2ter(double jd_ut1_high, double jd_ut1_low, double ut1_to_tt, enum nova
  *
  * If both 'xp' and 'yp' are set to 0 no polar motion is included in the transformation.
  *
+ * If extreme (sub-microarcsecond) accuracy is not required, you can use UT1-based Julian date
+ * instead of the TT-based Julian date and set the 'ut1_to_tt' argument to 0.0. and you can
+ * use UTC-based Julian date the same way.for arcsec-level precision also.
+ *
+ *
  * REFERENCES:
  *  <ol>
  *   <li>Kaplan, G. H. et. al. (1989). Astron. Journ. 97, 1197-1210.</li>
@@ -2719,7 +2737,8 @@ short cel2ter(double jd_ut1_high, double jd_ut1_low, double ut1_to_tt, enum nova
  *   Joint Discussion 16.</li>
  *  </ol>
  *
- * @param jd_tt         [day] Terrestrial Time (TT) based Julian date.
+ * @param jd_tt_high    [day] High-order part of Terrestrial Time (TT) based Julian date.
+ * @param jd_tt_low     [day] Low-order part of Terrestrial Time (TT) based Julian date.
  * @param ut1_to_tt     [s] TT - UT1 Time difference in seconds
  * @param accuracy      NOVAS_FULL_ACCURACY (0) or NOVAS_REDUCED_ACCURACY (1)
  * @param xp            [arcsec] Conventionally-defined X coordinate of celestial intermediate
@@ -2742,16 +2761,21 @@ short cel2ter(double jd_ut1_high, double jd_ut1_low, double ut1_to_tt, enum nova
  * @since 1.0
  * @author Attila Kovacs
  */
-int cirs_to_itrs(double jd_tt, double ut1_to_tt, enum novas_accuracy accuracy, double xp,
+int cirs_to_itrs(double jd_tt_high, double jd_tt_low, double ut1_to_tt, enum novas_accuracy accuracy, double xp,
         double yp, const double *vec1, double *vec2) {
-  return cel2ter(jd_tt, -ut1_to_tt, ut1_to_tt, EROT_ERA, accuracy, CELESTIAL_APPARENT, xp, yp, vec1, vec2);
+  return cel2ter(jd_tt_high, jd_tt_low - ut1_to_tt, ut1_to_tt, EROT_ERA, accuracy, CELESTIAL_APPARENT, xp, yp, vec1, vec2);
 }
+
 
 /**
  * Rotates a position vector from the dynamical True of Date (TOD) frame of date the Earth-fixed
  * ITRS frame (pre IAU 2000 method).
  *
  * If both 'xp' and 'yp' are set to 0 no polar motion is included in the transformation.
+ *
+ * If extreme (sub-microarcsecond) accuracy is not required, you can use UT1-based Julian date
+ * instead of the TT-based Julian date and set the 'ut1_to_tt' argument to 0.0. and you can
+ * use UTC-based Julian date the same way.for arcsec-level precision also.
  *
  * REFERENCES:
  *  <ol>
@@ -2760,8 +2784,9 @@ int cirs_to_itrs(double jd_tt, double ut1_to_tt, enum novas_accuracy accuracy, d
  *   Joint Discussion 16.</li>
  *  </ol>
  *
- * @param jd_tt         [day] Terrestrial Time (TT) based Julian date.
- * @param ut1_to_tt     [s] TT - UT1 Time difference in seconds
+ * @param jd_tt_high    [day] High-order part of Terrestrial Time (TT) based Julian date.
+ * @param jd_tt_low     [day] Low-order part of Terrestrial Time (TT) based Julian date.
+ * @param ut1_to_tt     [s] TT - UT1 Time difference in seconds.
  * @param accuracy      NOVAS_FULL_ACCURACY (0) or NOVAS_REDUCED_ACCURACY (1)
  * @param xp            [arcsec] Conventionally-defined X coordinate of celestial intermediate
  *                      pole with respect to ITRS pole, in arcseconds.
@@ -2783,9 +2808,9 @@ int cirs_to_itrs(double jd_tt, double ut1_to_tt, enum novas_accuracy accuracy, d
  * @since 1.0
  * @author Attila Kovacs
  */
-int tod_to_itrs(double jd_tt, double ut1_to_tt, enum novas_accuracy accuracy, double xp,
+int tod_to_itrs(double jd_tt_high, double jd_tt_low, double ut1_to_tt, enum novas_accuracy accuracy, double xp,
         double yp, const double *vec1, double *vec2) {
-  return cel2ter(jd_tt, -ut1_to_tt, ut1_to_tt, EROT_ERA, accuracy, CELESTIAL_APPARENT, xp, yp, vec1, vec2);
+  return cel2ter(jd_tt_high, jd_tt_low - ut1_to_tt, ut1_to_tt, EROT_ERA, accuracy, CELESTIAL_APPARENT, xp, yp, vec1, vec2);
 }
 
 /**
@@ -5414,7 +5439,7 @@ short ephemeris(const double jd_tdb[2], const object *body, enum novas_origin or
   }
 
   // Check the value of 'origin'.
-  if((origin < 0) || (origin >= NOVAS_ORIGIN_TYPES)) {
+  if(origin < 0 || origin >= NOVAS_ORIGIN_TYPES) {
     errno = EINVAL;
     return 1;
   }
@@ -5452,7 +5477,7 @@ short ephemeris(const double jd_tdb[2], const object *body, enum novas_origin or
       error = -1;
       if(readeph2_call) {
         // If there is a newstyle epehemeris access routine set, we will prefer it.
-        error = readeph2_call(body->number, body->name, jd_tdb[0], jd_tdb[1], &eph_origin, posvel, &posvel[3]);
+        error = readeph2_call(body->name, body->number, jd_tdb[0], jd_tdb[1], &eph_origin, posvel, &posvel[3]);
       }
 #     ifdef DEFAULT_READEPH
       else {
@@ -6116,7 +6141,7 @@ void novas_case_sensitive(int value) {
  * @sa novas_case_sensitive()
  * @sa make_cat_entry()
  * @sa make_planet()
- * @sa make_ephem_body()
+ * @sa make_ephem_object()
  * @sa place()
  *
  */
@@ -6186,7 +6211,7 @@ short make_object(enum novas_object_type type, long number, const char *name, co
  * @param[out] planet   Pointer to structure to populate.
  * @return              0 if successful, or else -1 if the 'planet' pointer is NULL.
  *
- * @sa make_ephem_body()
+ * @sa make_ephem_object()
  * @sa make_cat_entry()
  * @sa place()
  *
@@ -6224,7 +6249,7 @@ int make_planet(enum novas_planet num, object *planet) {
  * @since 1.0
  * @author Attila Kovacs
  */
-int make_ephem_body(const char *name, long num, object *body) {
+int make_ephem_object(const char *name, long num, object *body) {
   if(!name || !body) {
     errno = EINVAL;
     return -1;

--- a/src/solsys-ephem.c
+++ b/src/solsys-ephem.c
@@ -41,7 +41,7 @@
 short planet_ephem_provider_hp(const double jd_tdb[2], enum novas_planet body, enum novas_origin origin, double *position, double *velocity) {
   static const char *names[] = NOVAS_PLANET_NAMES_INIT;
 
-  novas_ephem_provider f;
+  novas_ephem_provider ephem_call;
   enum novas_origin o = NOVAS_BARYCENTER;
   int error;
 
@@ -55,13 +55,13 @@ short planet_ephem_provider_hp(const double jd_tdb[2], enum novas_planet body, e
     return -1;
   }
 
-  f = get_ephem_provider();
-  if(!f) {
+  ephem_call = get_ephem_provider();
+  if(!ephem_call) {
     errno = ENOSYS;
     return -1;
   }
 
-  error = f(body, names[body], jd_tdb[0], jd_tdb[1], &o, position, velocity);
+  error = ephem_call(names[body], body, jd_tdb[0], jd_tdb[1], &o, position, velocity);
   if(error) return 2;
 
   if(o != origin) {
@@ -69,7 +69,7 @@ short planet_ephem_provider_hp(const double jd_tdb[2], enum novas_planet body, e
     int i;
     int ref = (origin == NOVAS_BARYCENTER) ? NOVAS_SSB : NOVAS_SUN;
 
-    error = f(ref, names[origin], jd_tdb[0], jd_tdb[1], &o, pos0, vel0);
+    error = ephem_call(names[origin], ref, jd_tdb[0], jd_tdb[1], &o, pos0, vel0);
     if(error) return 2;
 
     for(i = 0; i < 3; i++) {


### PR DESCRIPTION
- Go back to split date for `cirs_to_itrs()` / `itrs_to_cirs()` and `tod_to_itrs()` / `itrs_to_tod()`.
- Rename `make_ephem_body()` to `make_ephem_object()` to consistency with enum `NOVAS_EPHEM_OBJECT`.
- Switch body name and ID order in `novas_ephem_provider()` to match `make_ephem_object()`
- README fixes