### PR TITLE
Default build 'dox' target conditional on doxygen being present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,29 @@
 
 include config.mk
 
-
 # ===============================================================================
 # Specific build targets and recipes below...
 # ===============================================================================
 
+# The targets to build by default if not otherwise specified to 'make'
+DEFAULT_TARGETS := static shared cio_ra.bin
+
+# Check if there is a doxygen we can run
+ifndef DOXYGEN
+  DOXYGEN := $(shell which doxygen)
+else
+  $(shell test -f $(DOXYGEN))
+endif
+
+# If there is doxygen, build the API documentation also by default
+ifeq ($(.SHELLSTATUS),0)
+  DEFAULT_TARGETS += dox
+else
+  $(info WARNING! Doxygen is not available. Will skip 'dox' target) 
+endif
 
 .PHONY: api
-api: static shared cio_ra.bin dox
+api: $(DEFAULT_TARGETS)
 
 .PHONY: static
 static: lib/novas.a

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,31 @@ README-headless.md: README.md
 
 dox: README-headless.md
 
+.PHONY: help
+help:
+	@echo
+	@echo "Syntax: make [target]"
+	@echo
+	@echo "The following targets are available:"
+	@echo
+	@echo "  api           (default) 'static', 'shared', 'cio_ra.bin' targets, and also" 
+	@echo "                'dox' if 'doxygen' is available, or was specified via the"
+	@echo "                DOXYGEN variable (e.g. in 'config.mk')."
+	@echo "  static        Builds the static 'lib/novas.a' library."
+	@echo "  shared        Builds the shared 'lib/novas.so' library."
+	@echo "  cio_ra.bin    Generates the CIO locator lookup data file 'cio_ra.bin', in the"
+	@echo "                destination specified in 'config.mk'."
+	@echo "  dox           Compiles HTML API documentation using 'doxygen'."
+	@echo "  solsys        Builds only the objects that may provide 'solarsystem()' call"
+	@echo "                implemtations (e.g. 'solsys1.o', 'eph_manager.o'...)."
+	@echo "  check         Performs static analysis with 'cppcheck'."
+	@echo "  test          Runs regression tests."
+	@echo "  coverage      Runs 'gcov' to analyze regression test coverage."
+	@echo "  all           All of the above."
+	@echo "  clean         Removes intermediate products."
+	@echo "  distclean     Deletes all generated files."
+	@echo
+
 Makefile: config.mk build.mk
 
 vpath %.c $(SRC)

--- a/build.mk
+++ b/build.mk
@@ -43,7 +43,7 @@ check:
 .PHONY: dox
 dox: README.md | apidoc
 	@echo "   [doxygen]"
-	@doxygen
+	@$(DOXYGEN)
 
 # Automatic dependence on included header files.
 .PRECIOUS: dep/%.d

--- a/config.mk
+++ b/config.mk
@@ -5,6 +5,16 @@
 # You can include this snipplet in your Makefile also.
 # ============================================================================
 
+# The targets to build by default if not otherwise specified to 'make'
+DEFAULT_TARGETS := static shared cio_ra.bin
+
+# Check if there is a doxygen we can run
+DOXYGEN := $(shell which doxygen)
+
+# If there is doxygen, build the API documentation also by default
+ifeq ($(.SHELLSTATUS),0)
+  DEFAULT_TARGETS += dox
+endif
 
 # Folders in which sources and headers are located, respectively
 SRC = src

--- a/config.mk
+++ b/config.mk
@@ -5,23 +5,15 @@
 # You can include this snipplet in your Makefile also.
 # ============================================================================
 
-# The targets to build by default if not otherwise specified to 'make'
-DEFAULT_TARGETS := static shared cio_ra.bin
-
-# Check if there is a doxygen we can run
-DOXYGEN := $(shell which doxygen)
-
-# If there is doxygen, build the API documentation also by default
-ifeq ($(.SHELLSTATUS),0)
-  DEFAULT_TARGETS += dox
-endif
-
 # Folders in which sources and headers are located, respectively
 SRC = src
 INC = include
 
 # Compiler options
 CFLAGS = -Os -Wall -I$(INC)
+
+# Specific Doxygen to use if not the default one
+#DOXYGEN = /opt/bin/doxygen
 
 # Extra warnings (not supported on all compilers)
 #CFLAGS += -Wextra
@@ -31,7 +23,7 @@ CFLAGS = -Os -Wall -I$(INC)
 
 # To make SuperNOVAS thread-safe, we use thread-local storage modifier
 # keywords. These were not standardized prior to C11. So while we automatically
-# recognize C11 or CC >= 3.3 to use the correct thread-local modifier keyword,
+# recognize C11 or GCC >= 3.3 to use the correct thread-local modifier keyword,
 # for other compilers (e.g. Intel C, LLVM) you may need to specify it 
 # explicitly here by passing the keyword via the THREAD_LOCAL definition
 #


### PR DESCRIPTION
This way the default 'make' does not require special build dependencies (like doxygen) being present.

Also, `make help` can now be used to show and explain the available build targets.