### PR TITLE
grav_undef() to gravitationally unbend observed light

### DIFF
--- a/.settings/language.settings.xml
+++ b/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="([^/\\\\]*)((g?cc)|([gc]\+\+)|(clang))" prefer-non-shared="true"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="533185552473084254" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="533226736933884254" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,7 +9,7 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 0.1%
+        threshold: 0.3%
         removed_code_behavior: adjust_base
 
 parsers:

--- a/config.mk
+++ b/config.mk
@@ -97,8 +97,10 @@ DEFAULT_SOLSYS ?= 3
 
 # cppcheck options for 'check' target
 CHECKOPTS ?= --enable=performance,warning,portability,style --language=c \
-            --error-exitcode=1 --check-level=exhaustive
+            --error-exitcode=1
 
+# Exhaustive checking for newer cppcheck
+#CHECKOPTS += --check-level=exhaustive
 
 # ============================================================================
 # END of user config section. 

--- a/config.mk
+++ b/config.mk
@@ -97,7 +97,7 @@ DEFAULT_SOLSYS ?= 3
 
 # cppcheck options for 'check' target
 CHECKOPTS ?= --enable=performance,warning,portability,style --language=c \
-            --error-exitcode=1
+            --error-exitcode=1 --check-level=exhaustive
 
 
 # ============================================================================

--- a/include/novas.h
+++ b/include/novas.h
@@ -903,6 +903,10 @@ double cirs_to_app_ra(double jd_tt, enum novas_accuracy accuracy, double ra);
 
 double app_to_cirs_ra(double jd_tt, enum novas_accuracy accuracy, double ra);
 
+// ---------------------- Added in 1.1.0 -------------------------
+int grav_undef(double jd_tdb, enum novas_observer_place loc_type, enum novas_accuracy accuracy, const double *pos_app,
+        const double *pos_obs, double *out);
+
 
 // <================= END of SuperNOVAS API =====================>
 

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -782,9 +782,9 @@ static int test_grav_undef() {
   double p[3] = {2.0}, po[3] = {0.0, 1.0}, pb[3] = {};
   int n = 0;
 
-  if(check("grav_def:pos", -1, grav_def(NOVAS_JD_J2000, NOVAS_OBSERVER_AT_GEOCENTER, NOVAS_FULL_ACCURACY, NULL, po, p))) n++;
-  if(check("grav_def:po", -1, grav_def(NOVAS_JD_J2000, NOVAS_OBSERVER_AT_GEOCENTER, NOVAS_FULL_ACCURACY, p, NULL, p))) n++;
-  if(check("grav_def:out", -1, grav_def(NOVAS_JD_J2000, NOVAS_OBSERVER_AT_GEOCENTER, NOVAS_FULL_ACCURACY, p, po, NULL))) n++;
+  if(check("grav_def:pos", -1, grav_undef(NOVAS_JD_J2000, NOVAS_OBSERVER_AT_GEOCENTER, NOVAS_FULL_ACCURACY, NULL, po, p))) n++;
+  if(check("grav_def:po", -1, grav_undef(NOVAS_JD_J2000, NOVAS_OBSERVER_AT_GEOCENTER, NOVAS_FULL_ACCURACY, p, NULL, p))) n++;
+  if(check("grav_def:out", -1, grav_undef(NOVAS_JD_J2000, NOVAS_OBSERVER_AT_GEOCENTER, NOVAS_FULL_ACCURACY, p, po, NULL))) n++;
 
   return n;
 }

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -778,6 +778,17 @@ static int test_grav_def() {
   return n;
 }
 
+static int test_grav_undef() {
+  double p[3] = {2.0}, po[3] = {0.0, 1.0}, pb[3] = {};
+  int n = 0;
+
+  if(check("grav_def:pos", -1, grav_def(NOVAS_JD_J2000, NOVAS_OBSERVER_AT_GEOCENTER, NOVAS_FULL_ACCURACY, NULL, po, p))) n++;
+  if(check("grav_def:po", -1, grav_def(NOVAS_JD_J2000, NOVAS_OBSERVER_AT_GEOCENTER, NOVAS_FULL_ACCURACY, p, NULL, p))) n++;
+  if(check("grav_def:out", -1, grav_def(NOVAS_JD_J2000, NOVAS_OBSERVER_AT_GEOCENTER, NOVAS_FULL_ACCURACY, p, po, NULL))) n++;
+
+  return n;
+}
+
 static int test_earth_sun_calc() {
   double p[3], v[3];
   int n = 0;
@@ -903,6 +914,7 @@ int main() {
   if(test_aberration()) n++;
   if(test_grav_vec()) n++;
   if(test_grav_def()) n++;
+  if(test_grav_undef()) n++;
 
   if(test_earth_sun_calc()) n++;
   if(test_earth_sun_calc_hp()) n++;

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -871,6 +871,10 @@ static int test_grav_undef() {
   if(!is_ok("grav_invdef:undef:zero", grav_undef(tdb, NOVAS_OBSERVER_AT_GEOCENTER, NOVAS_REDUCED_ACCURACY, pos_app, pos_obs, pos0))) return 1;
   if(!is_ok("grav_invdef:check:zero", check_equal_pos(pos0, pos_app, 1e-9))) return 1;
 
+  memset(pos_app, 0, sizeof(pos_app));
+  if(!is_ok("grav_invdef:undef:zero", grav_undef(tdb, NOVAS_OBSERVER_AT_GEOCENTER, NOVAS_REDUCED_ACCURACY, pos_app, pos_obs, pos_app))) return 1;
+  if(!is_ok("grav_invdef:check:zero", check_equal_pos(pos0, pos_app, 1e-9))) return 1;
+
   return 0;
 }
 

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -851,6 +851,29 @@ static int test_grav_vec() {
   return 0;
 }
 
+static int test_grav_undef() {
+  double pos_src[3], pos_obs[3], pos_app[3] = {}, pos0[3] = {}, v[3];
+  double tdb2[2] = { tdb };
+  object earth = {};
+  int i;
+
+  if(!is_ok("grav_invdef:make_planet", make_planet(NOVAS_EARTH, &earth))) return 1;
+  if(!is_ok("grav_invdef:ephemeris", ephemeris(tdb2, &earth, NOVAS_HELIOCENTER, NOVAS_REDUCED_ACCURACY, pos_obs, v))) return 1;
+
+  for(i = 0; i < 3; i++) pos_src[i] = -(2.001 * pos_obs[i]);
+
+  if(!is_ok("grav_invdef:def", grav_def(tdb, NOVAS_OBSERVER_AT_GEOCENTER, NOVAS_REDUCED_ACCURACY, pos_src, pos_obs, pos_app))) return 1;
+  if(!is_ok("grav_invdef:undef", grav_undef(tdb, NOVAS_OBSERVER_AT_GEOCENTER, NOVAS_REDUCED_ACCURACY, pos_app, pos_obs, pos0))) return 1;
+
+  if(!is_ok("grav_invdef:check", check_equal_pos(pos_src, pos0, 1e-9))) return 1;
+
+  memset(pos_app, 0, sizeof(pos_app));
+  if(!is_ok("grav_invdef:undef:zero", grav_undef(tdb, NOVAS_OBSERVER_AT_GEOCENTER, NOVAS_REDUCED_ACCURACY, pos_app, pos_obs, pos0))) return 1;
+  if(!is_ok("grav_invdef:check:zero", check_equal_pos(pos0, pos_app, 1e-9))) return 1;
+
+  return 0;
+}
+
 static int test_novas_debug() {
   int n = 0;
 
@@ -893,6 +916,7 @@ int main() {
   if(test_nu2000k()) n++;
   if(test_tdb2tt()) n++;
   if(test_grav_vec()) n++;
+  if(test_grav_undef()) n++;
 
   n += test_dates();
 


### PR DESCRIPTION
The inverse function for `grav_def()`.

Also:

 - Fix up test cases but initializing all data to avoid unreproducible behavior in tests.
 - Use precompiler constants to define max number of iterations for inverse methods.