### PR TITLE
v1.1.0 release composition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ README-headless.md
 README-orig.md
 TODO
 VERSION
+RELEASE-HOWTO.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,47 +7,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 
 
-## [Unreleased]
+## [1.1.0] -- 2024-08-11
 
-Changes coming to the next quarterly release, expected around 1 September 2024. Some or all of these may be readily 
-available on the `main` branch.
+Feature release, introducing a more efficient and elegant approach to position and velocity calculations using 
+observer frames, versatile handling of astronomical timescales, as well as support for further observer locations, 
+coordinate reference systems and atmospheric refraction models. The release also fixes a number of bugs, of varying
+severity, which affected prior SuperNOVAS releases.
 
 
 ### Fixed
 
- - #41: `grav_def()` gravitating body position antedated somewhat incorrectly (in v1.0) when observed source is a 
-   Solar-system object between the observer and the gravitating body. The resulting positional error is typically 
-   small at below 10 uas.
-
- - #39: `tod_to_itrs()` used wrong Earth rotation measure (`NOVAS_ERA` instead of `NOVAS_GST`).
+ - #29: Fix portability to non-Intel x86 platforms. Previously, SuperNOVAS used `char` for storing integer 
+   coefficients, assuming `char` was signed. However, on some platforms like ARM and PowerPC `char` is unsigned, 
+   which broke many calculations badly for such platforms. As of now, we use the explicit platform independent 
+   `int8_t` storage type for these coefficients.
 
  - #38: `gcrs_to_j2000` transformed in the wrong direction.
 
- - #37: `gcrs_to_cirs()` did not handle well if input and output vectors were the same.
+ - #39: `tod_to_itrs()` used wrong Earth rotation measure (`NOVAS_ERA` instead of `NOVAS_GST`).
 
  - #36: `tt2tdb()` Had a wrong scaling in sinusoidal period, resulting in an error of up to +/- 1.7 ms.
-   
- - #34: Radial velocity calculation to precede aberration and gravitational bending in `place()`, since the radial 
-   velocity that is observed is in the geometric direction towards the source (unaffected by aberration). A precise 
-   accounting of the gravitational effects would require figuring out the direction in which the observed light was 
-   emitted from the source before it was bent by gravitating bodies along the way. In practice, this may be difficult 
-   to generalize. For a single gravitationg body the geometric direction of the source is between the direction in 
-   which the light is emitted, and the observed deflected direction. Therefore, for the time being, the radial 
-   velocity calculated via the geometric direction is closer to the actual value.
-   
- - #29: Fix portability to non-Intel x86 platforms (see Issue #29). Previously, SuperNOVAS used `char` for storing 
-   integer coefficients, assuming `char` was signed. However, on some platforms like ARM and PowerPC `char` is 
-   unsigned, which broke many calculations badly for such platforms. As of now, we use the explicit platform
-   independent `int8_t` storage type for these coefficients.
+ 
+ - #37: `gcrs_to_cirs()` did not handle well if input and output vectors were the same.
 
  - #28: Division by zero bug in `d_light()` (since NOVAS C 3.1) if the first position argument is the ephemeris 
    reference position (e.g. the Sun for `solsys3.c`). The bug affects for example `grav_def()`, where it effectively 
    results in the gravitational deflection due to the Sun being skipped. See Issue #28.
-
- - `PSI_COR` and `EPS_COR` made globally visible again, thus improving NOVAS C 3.1 compatibility.
-
- - Adjusted regression testing to treat `nan` and `-nan` effectively the same. They both represent an equally invalid 
-   result regardless of the sign.
+ 
+ - #41: `grav_def()` gravitating body position antedated somewhat incorrectly (in v1.0) when observed source is a 
+   Solar-system object between the observer and the gravitating body. The resulting positional error is typically 
+   small at below 10 uas.
 
  - #24: Bungled definition of `SUPERNOVAS_VERSION_STRING` in `novas.h`. 
  
@@ -78,7 +67,7 @@ available on the `main` branch.
    
  - Added `obs_posvel()` to calculate the observer position and velocity relative to the Solar System Barycenter (SSB).
  
- - Added `obs_planets()` to calculate planet positions (relative to observer) and velocities (w.r.t. SSB).
+ - Added `obs_planets()` to calculate apparent planet positions (relative to observer) and velocities (w.r.t. SSB).
  
  - Added new observer locations `NOVAS_AIRBORNE_OBSERVER` for an observer moving relative to the surface of Earth e.g.
    in an aircraft or balloon based telescope platform, and `NOVAS_SOLAR_SYSTEM_OBSERVER` for spacecraft orbiting the 
@@ -101,14 +90,15 @@ available on the `main` branch.
  - New set of built-in refraction models to use with the frame-based `novas_app_to_hor()` function. The models
    `novas_standard_refraction()` and `novas_optical_refraction()` implement the same refraction model as `refract()` 
    in NOVAS C 3.1, with `NOVAS_STANDARD_ATMOSPHERE` and `NOVAS_WEATHER_AT_LOCATION` respectively, including the 
-   reversed direction provided by `refract_astro()`. The user may supply their own refraction models to
-   `novas_app_to_hor()` also, and may make used of the generic reversal function `novas_inv_refract` to calculate
-   refraction in the reverse direction (observer vs astrometric elevations) as needed.
+   reversed direction provided by `refract_astro()`. The user may supply their own custom refraction models to
+   `novas_app_to_hor()` or `novas_hor_to_app()` also, and may make use of the generic reversal function 
+   `novas_inv_refract()` to calculate refraction in the reverse direction (observer vs astrometric elevations) as 
+   needed.
 
  - Added radio refraction model `novas_radio_refraction()` based on the formulae by Berman &amp; Rockwell 1976.
  
- - #42: `cio_array()` can now parse the original ASCII CIO locator data file (`data/CIO_RA.TXT`) efficiently also, 
-   thus no longer requiring a platform-specific binary translation via the `cio_file` tool.
+ - Added `cirs_to_tod()` and `tod_to_cirs()` functions for efficient tranformation between True of Date (TOD) and
+   Celestial Intermediate Reference System (CIRS), and vice versa.
  
  - `make help` to provide a brief list and explanation of the available build targets. (Thanks to `@teuben` for 
    suggesting this.)
@@ -118,6 +108,17 @@ available on the `main` branch.
    
 
 ### Changed
+
+ - #34: Radial velocity calculation to precede aberration and gravitational bending in `place()`, since the radial 
+   velocity that is observed is in the geometric direction towards the source (unaffected by aberration). A precise 
+   accounting of the gravitational effects would require figuring out the direction in which the observed light was 
+   emitted from the source before it was bent by gravitating bodies along the way. In practice, this may be difficult 
+   to generalize. For a single gravitationg body the geometric direction of the source is between the direction in 
+   which the light is emitted, and the observed deflected direction. Therefore, for the time being, the radial 
+   velocity calculated via the geometric direction is closer to the actual value.
+
+ - #42: `cio_array()` can now parse the original ASCII CIO locator data file (`data/CIO_RA.TXT`) efficiently also, 
+   thus no longer requiring a platform-specific binary translation via the `cio_file` tool.
 
  - `cio_file` tool parses interval from header rather than the less precise differencing of the first two record
    timestamps. This leads to `cio_array()` being more accurately centered on matching date entries, e.g. J2000.
@@ -136,12 +137,17 @@ available on the `main` branch.
    about the order in which terms are accumulated and combined, resulting in a small improvement on the few uas 
    (micro-arcsecond) level.
    
- - The `ra` or `dec` arguments passed to `vector2radec()` may now be NULL if not required.
+ - `vector2radec()`: `ra` or `dec` arguments may now be NULL if not required.
 
- - `tt2tdb()` Now uses the same more precise series as the original NOVAS C `tdb2tt()`.
+ - `tt2tdb()` Now uses the same, slightly more precise series as the original NOVAS C `tdb2tt()`.
+
+ - `PSI_COR` and `EPS_COR` made globally visible again, thus improving NOVAS C 3.1 compatibility.
+
+ - Adjusted regression testing to treat `nan` and `-nan` effectively the same. They both represent an equally invalid 
+   result regardless of the sign.
 
  - The default make target is now `distro`. It's similar to the deprecated `api` target from before except that it 
-   skips building `static` libraries.
+   skips building `static` libraries and `cio_ra.bin`.
    
  - `make` now generates `.so` shared libraries with `SONAME` set to `lib<name>.so.1` where the `.1` indicates that it
    is major version 1 of the `ABI`. All 1.x.x releases are expected to be ABI compatible with earlier releases.
@@ -170,7 +176,7 @@ available on the `main` branch.
 
  - Doxygen tag file renamed to `supernovas.tag` for consistency.
    
- - Initialize test variable for reproducibility
+ - Initialize test variables for reproducibility
    
 
 
@@ -231,7 +237,7 @@ from which SuperNOVAS is forked from.
    requested mean equinox of date coordinates.
  
  - Some remainder calculations in NOVAS C 3.1 used the result from `fmod()` unchecked, which resulted in angles outside
-   of the expected [0:&pi;] range and was also the reason why `cal_date()` did not work for negative JD values.
+   of the expected [0:2&pi;] range and was also the reason why `cal_date()` did not work for negative JD values.
  
  - Fixes NOVAS C 3.1 `aberration()` returning NaN vectors if the `ve` argument is 0. It now returns the unmodified 
    input vector appropriately instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,10 @@ severity, which affected prior SuperNOVAS releases.
    an expression of that time in any timescale of choice via `novas_get_time()`, `novas_get_split_time()` or 
    `novas_get_unix_time()`. And, you can create a new time specification by incrementing an existing one, using 
    `novas_increment_time()`, or measure time differences via `novas_diff_time()`. 
-   
+ 
+ - Added `novas_planet_bundle` structure to handle planet positions and velocities more elegantly (for gravitational
+   deflection calculations).
+ 
  - #32: Added `grav_undef()` to undo gravitational bending of the observed light to obtain geometric positions from
    observed ones.
    

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ severity, which affected prior SuperNOVAS releases.
  - #29: Fix portability to non-Intel x86 platforms. Previously, SuperNOVAS used `char` for storing integer 
    coefficients, assuming `char` was signed. However, on some platforms like ARM and PowerPC `char` is unsigned, 
    which broke many calculations badly for such platforms. As of now, we use the explicit platform independent 
-   `int8_t` storage type for these coefficients.
+   signed `int8_t` storage type for these coefficients.
 
  - #38: `gcrs_to_j2000` transformed in the wrong direction.
 
@@ -47,10 +47,10 @@ severity, which affected prior SuperNOVAS releases.
      
  - #33: New observing-frame based approach for calculations (`frames.c`). A `novas_frame` object uniquely defines both 
    the place and time of observation, with a set of pre-calculated transformations and constants. Once the frame is 
-   defined it can be used very efficiently to calculate positions for multiple celestial objects with minimal 
-   additional computational cost. The frames API is also more elegant and simpler than the low-level NOVAS C approach 
-   for performing the same kind of calculations. And, frames are inherently thread-safe since post-creation their 
-   internal state is never modified during the calculations. The following new functions were added: 
+   defined it can be used very efficiently to calculate positions for multiple celestial objects with minimum 
+   additional computational cost. The frames API is also more elegant and more versatile than the low-level NOVAS C 
+   approach for performing the same kind of calculations. And, frames are inherently thread-safe since post-creation 
+   their internal state is never modified during the calculations. The following new functions were added: 
    `novas_make_frame()`, `novas_change_observer()`, `novas_geom_posvel()`, `novas_geom_to_app()`, `novas_sky_pos()`, 
    `novas_app_to_hor()`, `novas_app_to_geom()`, `novas_hor_to_app()`, `novas_make_transform()`, 
    `novas_invert_transform()`, `novas_transform_vector()`, and `novas_transform_sky_pos()`.
@@ -60,10 +60,11 @@ severity, which affected prior SuperNOVAS releases.
    (UTC, UT1, GPS, TAI, TT, TCG, TDB, or TCB), or to a UNIX time with `novas_set_unix_time()`. Once set, you can obtain 
    an expression of that time in any timescale of choice via `novas_get_time()`, `novas_get_split_time()` or 
    `novas_get_unix_time()`. And, you can create a new time specification by incrementing an existing one, using 
-   `novas_increment_time()`, or measure time differences via `novas_diff_time()`. 
+   `novas_increment_time()`, or measure time differences via `novas_diff_time()`, `novas_diff_tcg()`, or 
+   `novas_diff_tcb()`. 
  
- - Added `novas_planet_bundle` structure to handle planet positions and velocities more elegantly (for gravitational
-   deflection calculations).
+ - Added `novas_planet_bundle` structure to handle planet positions and velocities more elegantly (e.g. for 
+   gravitational deflection calculations).
  
  - #32: Added `grav_undef()` to undo gravitational bending of the observed light to obtain geometric positions from
    observed ones.
@@ -90,18 +91,19 @@ severity, which affected prior SuperNOVAS releases.
  - Added humidity field to `on_surface` structure, e.g. for refraction calculations at radio wavelengths. The
    `make_on_surface()` function will set humidity to 0.0, but the user can set the field appropriately afterwards.
 
- - New set of built-in refraction models to use with the frame-based `novas_app_to_hor()` function. The models
-   `novas_standard_refraction()` and `novas_optical_refraction()` implement the same refraction model as `refract()` 
-   in NOVAS C 3.1, with `NOVAS_STANDARD_ATMOSPHERE` and `NOVAS_WEATHER_AT_LOCATION` respectively, including the 
-   reversed direction provided by `refract_astro()`. The user may supply their own custom refraction models to
-   `novas_app_to_hor()` or `novas_hor_to_app()` also, and may make use of the generic reversal function 
-   `novas_inv_refract()` to calculate refraction in the reverse direction (observer vs astrometric elevations) as 
-   needed.
+ - New set of built-in refraction models to use with the frame-based `novas_app_to_hor()` / `novas_hor_to_app()` 
+   functions. The models `novas_standard_refraction()` and `novas_optical_refraction()` implement the same refraction 
+   model as `refract()`  in NOVAS C 3.1, with `NOVAS_STANDARD_ATMOSPHERE` and `NOVAS_WEATHER_AT_LOCATION` 
+   respectively, including the reversed direction provided by `refract_astro()`. The user may supply their own custom 
+   refraction also, and may make use of the generic reversal function `novas_inv_refract()` to calculate refraction in 
+   the reverse direction (observer vs astrometric elevations) as needed.
 
  - Added radio refraction model `novas_radio_refraction()` based on the formulae by Berman &amp; Rockwell 1976.
  
  - Added `cirs_to_tod()` and `tod_to_cirs()` functions for efficient tranformation between True of Date (TOD) and
    Celestial Intermediate Reference System (CIRS), and vice versa.
+   
+ - Added `make_cat_object()` function to create a NOVAS celestial `object` structure from existing `cat_entry` data.
  
  - `make help` to provide a brief list and explanation of the available build targets. (Thanks to `@teuben` for 
    suggesting this.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,10 @@ severity, which affected prior SuperNOVAS releases.
  - `tt2tdb()` Now uses the same, slightly more precise series as the original NOVAS C `tdb2tt()`.
 
  - `PSI_COR` and `EPS_COR` made globally visible again, thus improving NOVAS C 3.1 compatibility.
+ 
+ - Convergent inverse calculations now use the `novas_inv_max_iter` variable declared in `novas.c` to specify the
+   maximum number of iterations before inverse functions return with an error (with errno set to `ECANCELED`). Users
+   may adjust this limit, if they prefer some other maximum value.
 
  - Adjusted regression testing to treat `nan` and `-nan` effectively the same. They both represent an equally invalid 
    result regardless of the sign.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [1.1.0] -- 2024-08-11
 
-Feature release, introducing a more efficient and elegant approach to position and velocity calculations using 
-observer frames, versatile handling of astronomical timescales, as well as support for further observer locations, 
-coordinate reference systems and atmospheric refraction models. The release also fixes a number of bugs, of varying
-severity, which affected prior SuperNOVAS releases.
+Feature release. Introducing a more efficient and elegant approach to position and velocity calculations using 
+observer frames, versatile handling of astronomical timescales, support for further observer locations, coordinate 
+reference systems and atmospheric refraction models. The release also fixes a number of bugs, of varying severity, 
+which affected prior SuperNOVAS releases.
 
 
 ### Fixed
 
- - #29: Fix portability to non-Intel x86 platforms. Previously, SuperNOVAS used `char` for storing integer 
-   coefficients, assuming `char` was signed. However, on some platforms like ARM and PowerPC `char` is unsigned, 
-   which broke many calculations badly for such platforms. As of now, we use the explicit platform independent 
-   signed `int8_t` storage type for these coefficients.
+ - #29: Fix portability to non-Intel platforms. Previously, SuperNOVAS used `char` for storing integer coefficients, 
+   assuming `char` was signed. However, on some platforms like ARM and PowerPC `char` is unsigned, which broke 
+   calculations badly on such platforms. As of now, we use the explicit platform independent signed `int8_t` storage 
+   type for these coefficients.
 
  - #38: `gcrs_to_j2000` transformed in the wrong direction.
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = SuperNOVAS
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v1.0
+PROJECT_NUMBER         = v1.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ lib/libnovas.so: lib/libsupernovas.so
 SO_LINK := $(LDFLAGS) -lm
 
 # Share librarry recipe
-lib/%.so.$(SO_VERSION) : | lib
+lib/%.so.$(SO_VERSION) : | lib Makefile
 	$(CC) -o $@ $(CPPFLAGS) $(CFLAGS) $^ -shared -fPIC -Wl,-soname,$(subst lib/,,$@) $(SO_LINK)
 
 lib/libsolsys%.so.$(SO_VERSION): SO_LINK += -Llib -lsupernovas
@@ -142,7 +142,7 @@ lib/libsolsys-ephem.so.$(SO_VERSION): $(SRC)/solsys-ephem.c | lib/libsupernovas.
 
 
 # Static library: novas.a
-lib/libnovas.a: $(OBJECTS) | lib
+lib/libnovas.a: $(OBJECTS) | lib Makefile
 	ar -rc $@ $^
 	ranlib $@
 
@@ -165,9 +165,9 @@ Doxyfile.local:
 
 # Local documentation without specialized headers. The resulting HTML documents do not have
 # Google Search or Analytics tracking info.
+.PHONY: local-dox
 local-dox: README-orig.md Doxyfile.local
 	doxygen Doxyfile.local
-
 
 .PHONY: help
 help:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ SuperNOVAS is entirely free to use without licensing restrictions.  Its source c
 standard, and hence should be suitable for old and new platforms alike. It is light-weight and easy to use, with full 
 support for the IAU 2000/2006 standards for sub-microarcsecond position calculations.
 
+This document has been updated for the `v1.1` release.
 
 
 ## Table of Contents
@@ -374,7 +375,7 @@ UT1 - UTC time difference (a.k.a. DUT1), and the current leap seconds.
  int dut1 = ...;
 ``` 
  
-Now we can set a standard UNIX time, for example, using the current time:
+Now we can set the time of observation, for example, using the current UNIX time:
 
 ```c
  novas_timescale t_obs;	        // Structure that will define astrometric time

--- a/README.md
+++ b/README.md
@@ -718,6 +718,9 @@ before that level of accuracy is reached.
    `novas_get_unix_time()`. And, you can create a new time specification by incrementing an existing one, using 
    `novas_increment_time()`, or measure time differences via `novas_diff_time()`, `novas_diff_tcg()`, or 
    `novas_diff_tcb()`.
+ 
+ - Added `novas_planet_bundle` structure to handle planet positions and velocities more elegantly (e.g. for 
+   gravitational deflection calculations).
    
  - `obs_posvel()` to calculate the observer position and velocity relative to the Solar System Barycenter (SSB).
  

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ provided by SuperNOVAS over the upstream NOVAS C 3.1 code:
    mean equinox of date coordinates.
  
  - Some remainder calculations in NOVAS C 3.1 used the result from `fmod()` unchecked, which resulted in angles outside
-   of the expected [0:&pi;] range and was also the reason why `cal_date()` did not work for negative JD values.
+   of the expected [0:2&pi;] range and was also the reason why `cal_date()` did not work for negative JD values.
  
  - Fixes `aberration()` returning NaN vectors if the `ve` argument is 0. It now returns the unmodified input vector 
    appropriately instead.
@@ -135,9 +135,6 @@ provided by SuperNOVAS over the upstream NOVAS C 3.1 code:
    position (e.g. the Sun for `solsys3.c`). The bug affects for example `grav_def()`, where it effectively results in
     the gravitational deflection due to the Sun being skipped.
    
- - [__v1.1__] Radial velocity calculation to precede aberration and gravitational bending in `place()`, since the 
-   radial velocity that is observed is in the geometric direction towards the source (unaffected by aberration), and 
-   `rad_vel()` requires geometric directions also to account for the gravitational effects of the Sun and Earth.
 
 -----------------------------------------------------------------------------
 
@@ -188,10 +185,10 @@ the necessary variables in the shell prior to invoking `make`. For example:
    one tries to use the functions from `solsys1.c`). Note, that a `readeph()` implementation is not always necessary 
    and you can provide a superior ephemeris reader implementation at runtime via the `set_ephem_provider()` call.
 
- - If you want to use the CIO locator binary file for `cio_location()`, you can specify the path to the binary file 
-   (e.g. `/usr/local/share/novas/cio_ra.bin`) on your system e.g. by setting the `CIO_LOCATOR_FILE` shell variable
-   prior to calling `make`. (The CIO locator file is not at all necessary for the functioning of the library, unless 
-   you specifically require CIO positions relative to GCRS.)
+ - If you want to use the CIO locator binary file for `cio_location()`, you can specify the path to the CIO locator
+   file (e.g. `/usr/local/share/supernovas/CIO_RA.TXT`) on your system e.g. by setting the `CIO_LOCATOR_FILE` shell 
+   variable prior to calling `make`. (The CIO locator file is not at all necessary for the functioning of the library, 
+   unless  you specifically require CIO positions relative to GCRS.)
    
  - If your compiler does not support the C11 standard and it is not GCC &gt;=3.3, but provides some non-standard
    support for declaring thread-local variables, you may want to pass the keyword to use to declare variables as
@@ -206,8 +203,8 @@ Now you are ready to build the library:
 
 will compile the shared (e.g. `lib/libsupernovas.so`) libraries, produce a CIO locator data file (e.g. 
 `tools/data/cio_ra.bin`), and compile the API documentation (into `apidoc/`) using `doxygen` (if available). 
-Alternatively, you can build select components of the above with the `make` targets `shared`, `cio_file`, and 
-`local-dox` respectively. And, if unsure, you can always call `make help` to see what build targets are available.
+Alternatively, you can build select components of the above with the `make` targets `shared`, and `local-dox` 
+respectively. And, if unsure, you can always call `make help` to see what build targets are available.
 
 After building the library you can install the above components to the desired locations on your system. For a 
 system-wide install you may place the static or shared library into `/usr/local/lib/`, copy the CIO locator file to 
@@ -600,10 +597,10 @@ before that level of accuracy is reached.
     
   4. __Refraction__: Ground based observations are also subject to atmospheric refraction. SuperNOVAS offers the 
     option to include approximate _optical_ refraction corrections either for a standard atmosphere or more precisely 
-    using the weather parameters defined in the `on_surface` data structure that specifies the observer locations. 
-    Note, that refraction at radio wavelengths is notably different from the included optical model. In any case you 
-    may want to skip the refraction corrections offered in this library, and instead implement your own as appropriate 
-    (or not at all).
+    using the weather parameters defined in the `on_surface` data structure that specifies the observer locations.
+    Note, that refraction at radio wavelengths is notably different from the included optical model, and a standard
+    radio refraction model is included as of version 1.1. In any case you may want to skip the refraction corrections 
+    offered in this library, and instead implement your own as appropriate (or not at all).
   
 
 
@@ -826,6 +823,9 @@ before that level of accuracy is reached.
  - [__v1.1__] `grav_def()` is simplified. It no longer uses the location type argument. Instead it will skip 
    deflections due to a body, if the observer is within ~1500 km of its center.
 
+ - [__v1.1__] Radial velocity calculation to precede aberration and gravitational bending in `place()`, since the 
+   radial velocity that is observed is in the geometric direction towards the source (unaffected by aberration), and 
+   `rad_vel()` requires geometric directions also to account for the gravitational effects of the Sun and Earth.
 
 -----------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -698,14 +698,15 @@ before that level of accuracy is reached.
 
  - New `make_planet()` and `make_ephem_object()` to make it simpler to configure Solar-system objects.
 
+
 #### Added in v1.1
 
  - New observing-frame based approach for calculations (`frames.c`). A `novas_frame` object uniquely defines both the 
-   place and time of observation, with a set of pre-calculated transformations and constants. Once the frame is defined 
-   it can be used very efficiently to calculate positions for multiple celestial objects with minimal 
-   additional computational cost. The frames API is also more elegant and simpler than the low-level NOVAS C approach 
-   for performing the same kind of calculations. And, frames are inherently thread-safe since post-creation their 
-   internal state is never modified during the calculations. The following new functions were added: 
+   place and time of observation, with a set of pre-calculated transformations and constants. Once the frame is 
+   defined it can be used very efficiently to calculate positions for multiple celestial objects with minimum 
+   additional computational cost. The frames API is also more elegant and more versatile than the low-level NOVAS C 
+   approach for performing the same kind of calculations. And, frames are inherently thread-safe since post-creation 
+   their internal state is never modified during the calculations. The following new functions were added: 
    `novas_make_frame()`, `novas_change_observer()`, `novas_geom_posvel()`, `novas_geom_to_app()`, `novas_sky_pos()`, 
    `novas_app_to_hor()`, `novas_app_to_geom()`, `novas_hor_to_app()`, `novas_make_transform()`, 
    `novas_invert_transform()`, `novas_transform_vector()`, and `novas_transform_sky_pos()`.
@@ -715,7 +716,8 @@ before that level of accuracy is reached.
    UT1, GPS, TAI, TT, TCG, TDB, or TCB), or to a UNIX time with `novas_set_unix_time()`. Once set, you can obtain an 
    expression of that time in any timescale of choice via `novas_get_time()`, `novas_get_split_time()` or 
    `novas_get_unix_time()`. And, you can create a new time specification by incrementing an existing one, using 
-   `novas_increment_time()`, or measure time differences via `novas_diff_time()`.
+   `novas_increment_time()`, or measure time differences via `novas_diff_time()`, `novas_diff_tcg()`, or 
+   `novas_diff_tcb()`.
    
  - `obs_posvel()` to calculate the observer position and velocity relative to the Solar System Barycenter (SSB).
  
@@ -742,15 +744,19 @@ before that level of accuracy is reached.
  - Added humidity field to `on_surface` structure, e.g. for refraction calculations at radio wavelengths. The
    `make_on_surface()` function will set humidity to 0.0, but the user can set the field appropriately afterwards.
 
- - New set of built-in refraction models to use with the frame-based `novas_app_to_hor()` function. The models
-   `novas_standard_refraction()` and `novas_optical_refraction()` implement the same refraction model as `refract()` 
-   in NOVAS C 3.1, with `NOVAS_STANDARD_ATMOSPHERE` and `NOVAS_WEATHER_AT_LOCATION` respectively, including the 
-   reversed direction provided by `refract_astro()`. The user may supply their own refraction models to
-   `novas_app_to_hor()` also, and may make used of the generic reversal function `novas_inv_refract` to calculate
-   refraction in the reverse direction (observer vs astrometric elevations) as needed.
+ - New set of built-in refraction models to use with the frame-based `novas_app_to_hor()` / `novas_hor_to_app()` 
+   functions. The models `novas_standard_refraction()` and `novas_optical_refraction()` implement the same refraction 
+   model as `refract()`  in NOVAS C 3.1, with `NOVAS_STANDARD_ATMOSPHERE` and `NOVAS_WEATHER_AT_LOCATION` 
+   respectively, including the reversed direction provided by `refract_astro()`. The user may supply their own custom 
+   refraction also, and may make use of the generic reversal function `novas_inv_refract()` to calculate refraction in 
+   the reverse direction (observer vs astrometric elevations) as needed.
 
  - Added radio refraction model `novas_radio_refraction()` based on the formulae by Berman &amp; Rockwell 1976.
+ 
+ - Added `cirs_to_tod()` and `tod_to_cirs()` functions for efficient tranformation between True of Date (TOD) and
+   Celestial Intermediate Reference System (CIRS), and vice versa.
 
+ - Added `make_cat_object()` function to create a NOVAS celestial `object` structure from existing `cat_entry` data.
 
 
 <a name="api-changes"></a>

--- a/build.mk
+++ b/build.mk
@@ -41,7 +41,7 @@ check:
 
 # Doxygen documentation (HTML and man pages) under apidocs/
 .PHONY: dox
-dox: README.md | apidoc
+dox: README.md Doxyfile | apidoc
 	@echo "   [doxygen]"
 	@$(DOXYGEN)
 

--- a/include/eph_manager.h
+++ b/include/eph_manager.h
@@ -8,6 +8,8 @@
  *  Astronomical Applications Dept.
  *  Washington, DC
  *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">http://www.usno.navy.mil/USNO/astronomical-applications</a>
+ *
+ * @sa solsys1.c
  */
 
 #ifndef _EPHMAN_

--- a/include/eph_manager.h
+++ b/include/eph_manager.h
@@ -4,10 +4,13 @@
  *
  *  SuperNOVAS header for managing 1997 version of JPL ephemerides specifically for solsys2.c.
  *
- *  Based on the NOVAS C Edition, Version 3.1,  U. S. Naval Observatory
- *  Astronomical Applications Dept.
- *  Washington, DC
- *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">http://www.usno.navy.mil/USNO/astronomical-applications</a>
+ *  Based on the NOVAS C Edition, Version 3.1:
+ *
+ *  U. S. Naval Observatory<br>
+ *  Astronomical Applications Dept.<br>
+ *  Washington, DC<br>
+ *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">
+ *  http://www.usno.navy.mil/USNO/astronomical-applications</a>
  *
  * @sa solsys1.c
  */

--- a/include/novas.h
+++ b/include/novas.h
@@ -721,15 +721,17 @@ typedef struct {
 
 
 /**
- * Position and velocity data for a set of major planets (including Sun and Moon).
+ * Position and velocity data for a set of major planets (which may include the Sun and the Moon also).
  *
  * @since 1.1
+ *
+ * @sa enum novas_planet
  */
 typedef struct {
   int mask;                      ///< Bitwise mask (1 << planet-number) specifying wich planets have pos/vel data
   double pos[NOVAS_PLANETS][3];  ///< [AU] Apparent positions of planets w.r.t. observer antedated for light-time
   double vel[NOVAS_PLANETS][3];  ///< [AU/day] Apparent velocity of planets w.r.t. barycenter antedated for light-time
-} novas_planet_set;
+} novas_planet_bundle;
 
 /**
  * A set of parameters that uniquely define the place and time of observation. The user may
@@ -775,7 +777,7 @@ typedef struct {
   novas_matrix precession;        ///< precession matrix
   novas_matrix nutation;          ///< nutation matrix (Lieske 1977 method)
   novas_matrix gcrs_to_cirs;      ///< GCRS to CIRS conversion matrix
-  novas_planet_set planets;   ///< Planet positions and velocities
+  novas_planet_bundle planets;   ///< Planet positions and velocities
 } novas_frame;
 
 /**
@@ -1147,13 +1149,13 @@ double app_to_cirs_ra(double jd_tt, enum novas_accuracy accuracy, double ra);
 int obs_posvel(double jd_tdb, double ut1_to_tt, enum novas_accuracy accuracy, const observer *obs,
         const double *geo_pos, const double *geo_vel, double *pos, double *vel);
 
-int obs_planets(double jd_tdb, enum novas_accuracy accuracy, const double *pos_obs, int pl_mask, novas_planet_set *planets);
+int obs_planets(double jd_tdb, enum novas_accuracy accuracy, const double *pos_obs, int pl_mask, novas_planet_bundle *planets);
 
 int grav_undef(double jd_tdb, enum novas_accuracy accuracy, const double *pos_app, const double *pos_obs, double *out);
 
-int grav_planets(const double *pos_src, const double *pos_obs, const novas_planet_set *planets, double *out);
+int grav_planets(const double *pos_src, const double *pos_obs, const novas_planet_bundle *planets, double *out);
 
-int grav_undo_planets(const double *pos_app, const double *pos_obs, enum novas_accuracy accuracy, const novas_planet_set *planets, double *out);
+int grav_undo_planets(const double *pos_app, const double *pos_obs, enum novas_accuracy accuracy, const novas_planet_bundle *planets, double *out);
 
 int make_airborne_observer(const on_surface *location, const double *vel, observer *obs);
 

--- a/include/novas.h
+++ b/include/novas.h
@@ -7,11 +7,13 @@
  *  SuperNOVAS astrometry software based on the Naval Observatory Vector Astrometry Software (NOVAS).
  *  It has been modified to fix outstanding issues and to make it easier to use.
  *
+ *  Based on the NOVAS C Edition, Version 3.1:
  *
- *  Based on the NOVAS C Edition, Version 3.1,  U. S. Naval Observatory
- *  Astronomical Applications Dept.
- *  Washington, DC
- *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">http://www.usno.navy.mil/USNO/astronomical-applications</a>
+ *  U. S. Naval Observatory<br>
+ *  Astronomical Applications Dept.<br>
+ *  Washington, DC<br>
+ *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">
+ *  http://www.usno.navy.mil/USNO/astronomical-applications</a>
  */
 
 #ifndef _NOVAS_
@@ -1299,7 +1301,7 @@ void novas_set_errno(int en, const char *from, const char *desc, ...);
 int novas_error(int ret, int en, const char *from, const char *desc, ...);
 
 /**
- * Propagate an error (if any) with an offset. If the error is non-zero, it returns with the offset
+ * Propagates an error (if any) with an offset. If the error is non-zero, it returns with the offset
  * error value. Otherwise it keeps going as if it weren't even there...
  *
  * @param n     {int} error code or the call that produces the error code

--- a/include/novas.h
+++ b/include/novas.h
@@ -1187,9 +1187,9 @@ time_t novas_get_unix_time(const novas_timespec *time, long *nanos);
 
 double novas_diff_time(const novas_timespec *t1, const novas_timespec *t2);
 
-double novas_tcb_diff(const novas_timespec *t1, const novas_timespec *t2);
+double novas_diff_tcb(const novas_timespec *t1, const novas_timespec *t2);
 
-double novas_tcg_diff(const novas_timespec *t1, const novas_timespec *t2);
+double novas_diff_tcg(const novas_timespec *t1, const novas_timespec *t2);
 
 int novas_offset_time(const novas_timespec *time, double seconds, novas_timespec *out);
 

--- a/include/novas.h
+++ b/include/novas.h
@@ -779,16 +779,16 @@ typedef struct {
   novas_matrix precession;        ///< precession matrix
   novas_matrix nutation;          ///< nutation matrix (Lieske 1977 method)
   novas_matrix gcrs_to_cirs;      ///< GCRS to CIRS conversion matrix
-  novas_planet_bundle planets;   ///< Planet positions and velocities
+  novas_planet_bundle planets;    ///< Planet positions and velocities
 } novas_frame;
 
 /**
  * A transformation between two astronomical coordinate systems for the same observer
  * location and time. This allows for more elegant, generic, and efficient coordinate
- * transformations than using the low-level NOVAS functions.
+ * transformations than the low-level NOVAS functions.
  *
- * The transformation can be (should be) initialized via novas_make_trasform(), or else
- * modified via novas_invert_transform() or novas_change_observer().
+ * The transformation can be (should be) initialized via novas_make_trasform(), or via
+ * novas_invert_transform().
  *
  * @since 1.1
  *
@@ -844,6 +844,7 @@ enum novas_refraction_type {
  * @sa grav_def()
  * @sa grav_planets()
  * @sa DEFAULT_GRAV_BODIES_REDUCED_ACCURACY
+ * @sa set_ephem_provider()
  *
  * @since 1.1
  */
@@ -859,6 +860,7 @@ extern int grav_bodies_reduced_accuracy;
  * @sa grav_def()
  * @sa grav_planets()
  * @sa DEFAULT_GRAV_BODIES_FULL_ACCURACY
+ * @sa set_ephem_provider_hp()
  *
  * @since 1.1
  */
@@ -869,7 +871,7 @@ extern int grav_bodies_full_accuracy;
  * A function that returns a refraction correction for a given date/time of observation at the
  * given site on earth, and for a given astrometric source elevation
  *
- * @param j_tt      [day] Terrestrial Time (TT) based Julian data of observation
+ * @param jd_tt     [day] Terrestrial Time (TT) based Julian data of observation
  * @param loc       Pointer to structure defining the observer's location on earth, and local weather
  * @param type      Whether the input elevation is observed or astrometric: REFRACT_OBSERVED (-1) or
  *                  REFRACT_ASTROMETRIC (0).
@@ -879,7 +881,7 @@ extern int grav_bodies_full_accuracy;
  *
  * @since 1.1
  */
-typedef double (*RefractionModel)(double j_tt, const on_surface *loc, enum novas_refraction_type type, double el);
+typedef double (*RefractionModel)(double jd_tt, const on_surface *loc, enum novas_refraction_type type, double el);
 
 
 short app_star(double jd_tt, const cat_entry *star, enum novas_accuracy accuracy, double *ra, double *dec);

--- a/include/novas.h
+++ b/include/novas.h
@@ -1155,7 +1155,7 @@ int grav_undef(double jd_tdb, enum novas_accuracy accuracy, const double *pos_ap
 
 int grav_planets(const double *pos_src, const double *pos_obs, const novas_planet_bundle *planets, double *out);
 
-int grav_undo_planets(const double *pos_app, const double *pos_obs, enum novas_accuracy accuracy, const novas_planet_bundle *planets, double *out);
+int grav_undo_planets(const double *pos_app, const double *pos_obs, const novas_planet_bundle *planets, double *out);
 
 int make_airborne_observer(const on_surface *location, const double *vel, observer *obs);
 

--- a/include/novas.h
+++ b/include/novas.h
@@ -4,7 +4,7 @@
  * @author G. Kaplan and A. Kovacs
  * @version 1.1.0
  *
- *  SuperNOVAS astrometry softwate based on the Naval Observatory Vector Astrometry Software (NOVAS).
+ *  SuperNOVAS astrometry software based on the Naval Observatory Vector Astrometry Software (NOVAS).
  *  It has been modified to fix outstanding issues and to make it easier to use.
  *
  *

--- a/include/novas.h
+++ b/include/novas.h
@@ -1267,7 +1267,9 @@ double novas_inv_refract(RefractionModel model, double jd_tt, const on_surface *
 #define HOURANGLE           (M_PI / 12.0)
 #define MAS                 (1e-3 * ASEC2RAD)
 
-#define INV_MAX_ITER        100
+#ifndef INV_MAX_ITER
+#  define INV_MAX_ITER      100                   ///< Maximum number of iterations for convergent inverse calculations
+#endif
 
 #  ifndef THREAD_LOCAL
 #    if __STDC_VERSION__ >= 201112L

--- a/include/novas.h
+++ b/include/novas.h
@@ -1267,9 +1267,6 @@ double novas_inv_refract(RefractionModel model, double jd_tt, const on_surface *
 #define HOURANGLE           (M_PI / 12.0)
 #define MAS                 (1e-3 * ASEC2RAD)
 
-#ifndef INV_MAX_ITER
-#  define INV_MAX_ITER      100                   ///< Maximum number of iterations for convergent inverse calculations
-#endif
 
 #  ifndef THREAD_LOCAL
 #    if __STDC_VERSION__ >= 201112L
@@ -1280,6 +1277,7 @@ double novas_inv_refract(RefractionModel model, double jd_tt, const on_surface *
 #      define THREAD_LOCAL                        ///< no thread-local variables
 #    endif
 #  endif
+
 
 int novas_trace(const char *loc, int n, int offset);
 void novas_set_errno(int en, const char *from, const char *desc, ...);
@@ -1306,6 +1304,16 @@ double novas_vdot(const double *v1, const double *v2);
 
 int polar_dxdy_to_dpsideps(double jd_tt, double dx, double dy, double *dpsi, double *deps);
 
+/**
+ * Maximum number of iterations for convergent inverse calculations. Most iterative inverse functions should
+ * normally converge in a handful of iterations. In some pathological cases more iterations may be required.
+ * This variable sets an absolute maximum for the number of iterations in order to avoid runaway (zombie)
+ * behaviour. If inverse functions faile to converge, they will return a value indicating an error, and
+ * errno should be set to ECANCELED.
+ *
+ * @since 1.1
+ */
+extern int novas_inv_max_iter;
 
 #endif /* __NOVAS_INTERNAL_API__ */
 /// \endcond

--- a/include/novas.h
+++ b/include/novas.h
@@ -1304,15 +1304,6 @@ double novas_vdot(const double *v1, const double *v2);
 
 int polar_dxdy_to_dpsideps(double jd_tt, double dx, double dy, double *dpsi, double *deps);
 
-/**
- * Maximum number of iterations for convergent inverse calculations. Most iterative inverse functions should
- * normally converge in a handful of iterations. In some pathological cases more iterations may be required.
- * This variable sets an absolute maximum for the number of iterations in order to avoid runaway (zombie)
- * behaviour. If inverse functions faile to converge, they will return a value indicating an error, and
- * errno should be set to ECANCELED.
- *
- * @since 1.1
- */
 extern int novas_inv_max_iter;
 
 #endif /* __NOVAS_INTERNAL_API__ */

--- a/include/novascon.h
+++ b/include/novascon.h
@@ -11,10 +11,13 @@
  *              conflicts with the super-simplistic naming scheme here. You are better off
  *              without this.
  *
- *  Based on the NOVAS C Edition, Version 3.1,  U. S. Naval Observatory
- *  Astronomical Applications Dept.
- *  Washington, DC
- *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">http://www.usno.navy.mil/USNO/astronomical-applications</a>
+ *  Based on the NOVAS C Edition, Version 3.1:
+ *
+ *  U. S. Naval Observatory<br>
+ *  Astronomical Applications Dept.<br>
+ *  Washington, DC<br>
+ *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">
+ *  http://www.usno.navy.mil/USNO/astronomical-applications</a>
  */
 
 #ifndef _CONSTS_

--- a/include/nutation.h
+++ b/include/nutation.h
@@ -7,10 +7,13 @@
  *  between computational cost and precision. It provides support for both the IAU 2000A and
  *  IAU 2000B series as well as a NOVAS-specific truncated low-precision version we call NU2000K.
  *
- *  Based on the NOVAS C Edition, Version 3.1,  U. S. Naval Observatory
- *  Astronomical Applications Dept.
- *  Washington, DC
- *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">http://www.usno.navy.mil/USNO/astronomical-applications</a>
+ *  Based on the NOVAS C Edition, Version 3.1:
+ *
+ *  U. S. Naval Observatory<br>
+ *  Astronomical Applications Dept.<br>
+ *  Washington, DC<br>
+ *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">
+ *  http://www.usno.navy.mil/USNO/astronomical-applications</a>
  */
 
 #ifndef _NUTATION_

--- a/include/solarsystem.h
+++ b/include/solarsystem.h
@@ -21,6 +21,11 @@
  *  Astronomical Applications Dept.
  *  Washington, DC
  *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">http://www.usno.navy.mil/USNO/astronomical-applications</a>
+ *
+ *  @sa solsys1.c
+ *  @sa solsys2.c
+ *  @sa solsys3.c
+ *  @sa solsys-ephem.c
  */
 
 #ifndef _SOLSYS_

--- a/include/solarsystem.h
+++ b/include/solarsystem.h
@@ -17,10 +17,13 @@
  *  Additionally, users may set their custom choice of major planet ephemeris handler at
  *  runtime via the set_ephem_size().
  *
- *  Based on the NOVAS C Edition, Version 3.1,  U. S. Naval Observatory
- *  Astronomical Applications Dept.
- *  Washington, DC
- *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">http://www.usno.navy.mil/USNO/astronomical-applications</a>
+ *  Based on the NOVAS C Edition, Version 3.1:
+ *
+ *  U. S. Naval Observatory<br>
+ *  Astronomical Applications Dept.<br>
+ *  Washington, DC<br>
+ *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">
+ *  http://www.usno.navy.mil/USNO/astronomical-applications</a>
  *
  *  @sa solsys1.c
  *  @sa solsys2.c

--- a/src/cio_file.c
+++ b/src/cio_file.c
@@ -1,13 +1,18 @@
-/*
- Naval Observatory Vector Astrometry Software (NOVAS)
- C Edition, Version 3.1
-
- cio_file.c: Produces binary file of RA values for CIO
-
- U. S. Naval Observatory
- Astronomical Applications Dept.
- Washington, DC
- http://www.usno.navy.mil/USNO/astronomical-applications
+/**
+ * @author G. Kaplan and A. Kovacs
+ *
+ *  SuperNOVAS tool to Produces binary data file of RA values for CIO. The resulting binary file
+ *  is platform-dependent. As of SuperNOVAS version 1.1, one may use the ASCII file, which is used
+ *  as an input to this too, directly with SuperNOVAS. As such, there is no longer the need to
+ *  produce the platform-dependent binary, and the use of the ASCII CIO locator file is now
+ *  preferred for reasons of portability.
+ *
+ *  Based on the NOVAS C Edition, Version 3.1,  U. S. Naval Observatory
+ *  Astronomical Applications Dept.
+ *  Washington, DC
+ *   <a href="http://www.usno.navy.mil/USNO/astronomical-applications">http://www.usno.navy.mil/USNO/astronomical-applications</a>
+ *
+ *  @sa set_cio_locator_file()
  */
 
 #include <stdio.h>

--- a/src/cio_file.c
+++ b/src/cio_file.c
@@ -2,15 +2,17 @@
  * @author G. Kaplan and A. Kovacs
  *
  *  SuperNOVAS tool to Produces binary data file of RA values for CIO. The resulting binary file
- *  is platform-dependent. As of SuperNOVAS version 1.1, one may use the ASCII file, which is used
- *  as an input to this too, directly with SuperNOVAS. As such, there is no longer the need to
- *  produce the platform-dependent binary, and the use of the ASCII CIO locator file is now
- *  preferred for reasons of portability.
+ *  is platform-dependent. As of SuperNOVAS version 1.1, one may use the ASCII file directly with
+ *  SuperNOVAS. As such, there is no longer the need to produce the platform-dependent binary, and
+ *  the use of the ASCII CIO locator file is now preferred for reasons of portability.
  *
- *  Based on the NOVAS C Edition, Version 3.1,  U. S. Naval Observatory
- *  Astronomical Applications Dept.
- *  Washington, DC
- *   <a href="http://www.usno.navy.mil/USNO/astronomical-applications">http://www.usno.navy.mil/USNO/astronomical-applications</a>
+ *  Based on the NOVAS C Edition, Version 3.1:
+ *
+ *  U. S. Naval Observatory<br>
+ *  Astronomical Applications Dept.<br>
+ *  Washington, DC<br>
+ *   <a href="http://www.usno.navy.mil/USNO/astronomical-applications">
+ *   http://www.usno.navy.mil/USNO/astronomical-applications</a>
  *
  *  @sa set_cio_locator_file()
  */

--- a/src/eph_manager.c
+++ b/src/eph_manager.c
@@ -8,12 +8,15 @@
  *
  *  This module exposes a lot of its own internal state variables globally. You probably should
  *  not access them from outside this module, but they are kept ad globals to ensure compatibility
- *  with existing NOVAS C applications that do tinker with those values.
+ *  with existing NOVAS C applications that might access those values.
  *
- *  Based on the NOVAS C Edition, Version 3.1,  U. S. Naval Observatory
- *  Astronomical Applications Dept.
- *  Washington, DC
- *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">http://www.usno.navy.mil/USNO/astronomical-applications</a>
+ *  Based on the NOVAS C Edition, Version 3.1:
+ *
+ *  U. S. Naval Observatory<br>
+ *  Astronomical Applications Dept.<br>
+ *  Washington, DC<br>
+ *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">
+ *  http://www.usno.navy.mil/USNO/astronomical-applications</a>
  *
  *  @sa solsys2.c
  */

--- a/src/frames.c
+++ b/src/frames.c
@@ -261,7 +261,7 @@ static int frame_aberration(const novas_frame *frame, int dir, double *pos) {
     }
   }
 
-  errno = ECANCELED;
+  novas_set_errno(ECANCELED, "frame_aberration", "failed to converge");
   return -1;
 }
 

--- a/src/frames.c
+++ b/src/frames.c
@@ -235,7 +235,7 @@ static int frame_aberration(const novas_frame *frame, int dir, double *pos) {
     return 0;
 
   // Iterate as necessary (for inverse only)
-  for(i = 0; i < INV_MAX_ITER; i++) {
+  for(i = 0; i < novas_inv_max_iter; i++) {
     const double p = frame->beta * novas_vdot(pos, frame->obs_vel) / (d * frame->v_obs);
     const double q = (1.0 + p / (1.0 + frame->gamma)) * d / C_AUDAY;
     const double r = 1.0 + p;

--- a/src/frames.c
+++ b/src/frames.c
@@ -261,8 +261,7 @@ static int frame_aberration(const novas_frame *frame, int dir, double *pos) {
     }
   }
 
-  novas_set_errno(ECANCELED, "frame_aberration", "failed to converge");
-  return -1;
+  return novas_error(-1, ECANCELED, "frame_aberration", "failed to converge");
 }
 
 

--- a/src/frames.c
+++ b/src/frames.c
@@ -923,7 +923,7 @@ int novas_app_to_geom(const novas_frame *frame, enum novas_reference_system sys,
   frame_aberration(frame, APP_TO_GEOM, app_pos);
 
   // Undo gravitational deflection and aberration.
-  prop_error(fn, grav_undo_planets(app_pos, frame->obs_pos, frame->accuracy, &frame->planets, geom_icrs), 0);
+  prop_error(fn, grav_undo_planets(app_pos, frame->obs_pos, &frame->planets, geom_icrs), 0);
 
   return 0;
 }

--- a/src/frames.c
+++ b/src/frames.c
@@ -5,10 +5,12 @@
  * @author Attila Kovacs
  * @since 1.1
  *
- *  Routines for higher-level and efficient repeat coordinate transformations using observer frames.
- *  Observer frames represent an observer location at a specific astronomical time (instant), which
- *  can be re-used again and again to calculate or transform positions of celestial sources in a
- *  a range of astronomical coordinate systems.
+ *  SuperNOVAS routines for higher-level and efficient repeat coordinate transformations using
+ *  observer frames. Observer frames represent an observer location at a specific astronomical
+ *  time (instant), which can be re-used again and again to calculate or transform positions of
+ *  celestial sources in a a range of astronomical coordinate systems.
+ *
+ *  @sa timescale.c
  */
 
 /// \cond PRIVATE

--- a/src/frames.c
+++ b/src/frames.c
@@ -6,8 +6,8 @@
  * @since 1.1
  *
  *  Routines for higher-level and efficient repeat coordinate transformations using observer frames.
- *  Observer frames represent an observer location at a specific stronomical time (instant), which
- *  can be re-used again and again to calculate or transform positions of celestial sources in
+ *  Observer frames represent an observer location at a specific astronomical time (instant), which
+ *  can be re-used again and again to calculate or transform positions of celestial sources in a
  *  a range of astronomical coordinate systems.
  */
 
@@ -497,8 +497,20 @@ int novas_geom_posvel(const object *source, const novas_frame *frame, enum novas
     bary2obs(pos1, frame->obs_pos, pos1, &t_light);
   }
   else {
-    // Get position of body wrt observer, antedated for light-time.
-    prop_error(fn, light_time2(jd_tdb, source, frame->obs_pos, 0.0, frame->accuracy, pos1, vel1, &t_light), 50);
+    int got = 0;
+
+    // If we readily have the requested planet data in the frame, use it.
+    if(source->type == NOVAS_PLANET)
+      if(frame->pl_mask & (1 << source->number)) {
+        memcpy(pos1, &frame->pl_pos[source->number][0], sizeof(pos1));
+        memcpy(vel1, &frame->pl_vel[source->number][0], sizeof(vel1));
+        got = 1;
+      }
+
+    // Otherwise, get the position of body wrt observer, antedated for light-time.
+    if(!got) {
+      prop_error(fn, light_time2(jd_tdb, source, frame->obs_pos, 0.0, frame->accuracy, pos1, vel1, &t_light), 50);
+    }
   }
 
   if(pos) {

--- a/src/novas.c
+++ b/src/novas.c
@@ -2,9 +2,9 @@
  * @file
  *
  * @author G. Kaplan and A. Kovacs
- * @version 1.0.1
+ * @version 1.1.0
  *
- *  SuperNOVAS astrometry softwate based on the Naval Observatory Vector Astrometry Software (NOVAS).
+ *  SuperNOVAS astrometry software based on the Naval Observatory Vector Astrometry Software (NOVAS).
  *  It has been modified to fix outstanding issues and to make it easier to use.
  *
  *  Based on the NOVAS C Edition, Version 3.1,  U. S. Naval Observatory

--- a/src/novas.c
+++ b/src/novas.c
@@ -7,11 +7,13 @@
  *  SuperNOVAS astrometry software based on the Naval Observatory Vector Astrometry Software (NOVAS).
  *  It has been modified to fix outstanding issues and to make it easier to use.
  *
- *  Based on the NOVAS C Edition, Version 3.1,  U. S. Naval Observatory
- *  Astronomical Applications Dept.
- *  Washington, DC
- *   <a href="http://www.usno.navy.mil/USNO/astronomical-applications">http://www.usno.navy.mil/USNO/astronomical-applications</a>
+ *  Based on the NOVAS C Edition, Version 3.1:
  *
+ *  U. S. Naval Observatory<br>
+ *  Astronomical Applications Dept.<br>
+ *  Washington, DC<br>
+ *   <a href="http://www.usno.navy.mil/USNO/astronomical-applications">
+ *   http://www.usno.navy.mil/USNO/astronomical-applications</a>
  */
 
 #include <string.h>
@@ -27,7 +29,7 @@
 #endif
 
 /// \cond PRIVATE
-#define __NOVAS_INTERNAL_API__      ///< Use definitions meant for internal use by SuperNOVAS only
+#define __NOVAS_INTERNAL_API__    ///< Use definitions meant for internal use by SuperNOVAS only
 #include "novas.h"
 
 #define CIO_INTERP_POINTS   6     ///< Number of points to load from CIO interpolation table at once.

--- a/src/novas.c
+++ b/src/novas.c
@@ -4388,8 +4388,6 @@ int grav_planets(const double *pos_src, const double *pos_obs, const novas_plane
  * @param pos_obs     [AU] Position 3-vector of observer (or the geocenter), with respect to
  *                    origin at solar system barycenter, referred to ICRS axes,
  *                    components in AU.
- * @param accuracy    NOVAS_FULL_ACCURACY (0) for sub-&mu;as accuracy or NOVAS_REDUCED_ACCURACY (1)
- *                    for sub-mas accuracy.
  * @param planets     Apparent planet data containing positions and velocities for the major
  *                    gravitating bodies in the solar-system.
  * @param[out] out    [AU] Nominal position vector of observed object, with respect to origin at
@@ -4405,12 +4403,12 @@ int grav_planets(const double *pos_src, const double *pos_obs, const novas_plane
  * @since 1.1
  * @author Attila Kovacs
  */
-int grav_undo_planets(const double *pos_app, const double *pos_obs, enum novas_accuracy accuracy, const novas_planet_bundle *planets, double *out) {
+int grav_undo_planets(const double *pos_app, const double *pos_obs, const novas_planet_bundle *planets, double *out) {
   static const char *fn = "grav_undo_planets";
 
+  const double tol = 1e-13;
   double pos_def[3] = { }, pos0[3] = { };
   double l;
-  double tol = accuracy == NOVAS_FULL_ACCURACY ? 1e-13 : 1e-10;
   int i;
 
   if(!pos_app || !pos_obs)
@@ -4498,7 +4496,6 @@ int obs_planets(double jd_tdb, enum novas_accuracy accuracy, const double *pos_o
 
   if(!pos_obs)
     return novas_error(-1, EINVAL, fn, "NULL observer position parameter");
-
 
   // Set up the structures of type 'object' containing the body information.
   if(!initialized) {
@@ -4666,7 +4663,7 @@ int grav_undef(double jd_tdb, enum novas_accuracy accuracy, const double *pos_ap
     return novas_error(-1, EINVAL, fn, "NULL source position 3-vector: pos_app=%p, out=%p", pos_app, out);
 
   prop_error(fn, obs_planets(jd_tdb, accuracy, pos_obs, pl_mask, &planets), 0);
-  prop_error(fn, grav_undo_planets(pos_app, pos_obs, accuracy, &planets, out), 0);
+  prop_error(fn, grav_undo_planets(pos_app, pos_obs, &planets, out), 0);
   return 0;
 }
 

--- a/src/novas.c
+++ b/src/novas.c
@@ -358,6 +358,9 @@ int j2000_to_tod(double jd_tdb, enum novas_accuracy accuracy, const double *in, 
  *
  * @sa j2000_to_tod()
  * @sa j2000_to_gcrs()
+ * @sa tod_to_gcrs()
+ * @sa tod_to_cirs()
+ * @sa tod_to_itrs()
  *
  * @since 1.0
  * @author Attila Kovacs
@@ -384,6 +387,7 @@ int tod_to_j2000(double jd_tdb, enum novas_accuracy accuracy, const double *in, 
  * @param[out] out  GCRS output 3-vector
  * @return          0 if successful, or else an error from frame_tie()
  *
+ * @sa j2000_to_tod()
  * @sa gcrs_to_j2000()
  *
  * @since 1.0
@@ -402,6 +406,7 @@ int j2000_to_gcrs(const double *in, double *out) {
  * @return          0 if successful, or else an error from frame_tie()
  *
  * @sa j2000_to_gcrs()
+ * @sa tod_to_j2000()
  *
  * @since 1.0
  * @author Attila Kovacs
@@ -453,7 +458,9 @@ static int gcrs_to_tod(double jd_tdb, enum novas_accuracy accuracy, const double
  * @return          0 if successful, or -1 if either of the vector arguments is NULL.
  *
  * @sa j2000_to_tod()
- * @sa tod_to_gcrs()
+ * @sa tod_to_cirs()
+ * @sa tod_to_j2000()
+ * @sa tod_to_itrs()
  *
  * @since 1.0
  * @author Attila Kovacs
@@ -529,6 +536,8 @@ int gcrs_to_cirs(double jd_tdb, enum novas_accuracy accuracy, const double *in, 
  *
  * @sa tod_to_gcrs()
  * @sa gcrs_to_cirs()
+ * @sa cirs_to_itrs()
+ * @sa cirs_to_tod()
  *
  *
  * @since 1.0
@@ -579,6 +588,8 @@ int cirs_to_gcrs(double jd_tdb, enum novas_accuracy accuracy, const double *in, 
  *
  * @sa tod_to_cirs()
  * @sa cirs_to_app_ra()
+ * @sa cirs_to_gcrs()
+ * @sa cirs_to_itrs()
  *
  *
  * @since 1.1
@@ -612,6 +623,9 @@ int cirs_to_tod(double jd_tt, enum novas_accuracy accuracy, const double *in, do
  *
  * @sa cirs_to_tod()
  * @sa app_to_cirs_ra()
+ * @sa tod_to_gcrs()
+ * @sa tod_to_j2000()
+ * @sa tod_to_itrs()
  *
  *
  * @since 1.1
@@ -3161,6 +3175,8 @@ short cel2ter(double jd_ut1_high, double jd_ut1_low, double ut1_to_tt, enum nova
  * @sa tod_to_itrs()
  * @sa itrs_to_cirs()
  * @sa gcrs_to_cirs()
+ * @sa cirs_to_gcrs()
+ * @sa cirs_to_tod()
  *
  * @since 1.0
  * @author Attila Kovacs
@@ -3209,6 +3225,9 @@ int cirs_to_itrs(double jd_tt_high, double jd_tt_low, double ut1_to_tt, enum nov
  * @sa cirs_to_itrs()
  * @sa itrs_to_tod()
  * @sa j2000_to_tod()
+ * @sa tod_to_gcrs()
+ * @sa tod_to_j2000()
+ * @sa tod_to_cirs()
  *
  * @since 1.0
  * @author Attila Kovacs

--- a/src/novas.c
+++ b/src/novas.c
@@ -4306,12 +4306,11 @@ double d_light(const double *pos_src, const double *pos_body) {
  * @sa novas_geom_to_app()
  * @sa grav_bodies_full_accuracy
  * @sa grav_bodies_reduced_accuracy
- * @sa enum novas_planet
  *
  * @since 1.1
  * @author Attila Kovacs
  */
-int grav_planets(const double *pos_src, const double *pos_obs, const novas_planet_set *planets, double *out) {
+int grav_planets(const double *pos_src, const double *pos_obs, const novas_planet_bundle *planets, double *out) {
   static const char *fn = "grav_planets";
   static const double rmass[] = NOVAS_RMASS_INIT;
 
@@ -4402,12 +4401,11 @@ int grav_planets(const double *pos_src, const double *pos_obs, const novas_plane
  * @sa obs_planets()
  * @sa grav_planets()
  * @sa novas_app_to_geom()
- * @sa enum novas_planet
  *
  * @since 1.1
  * @author Attila Kovacs
  */
-int grav_undo_planets(const double *pos_app, const double *pos_obs, enum novas_accuracy accuracy, const novas_planet_set *planets, double *out) {
+int grav_undo_planets(const double *pos_app, const double *pos_obs, enum novas_accuracy accuracy, const novas_planet_bundle *planets, double *out) {
   static const char *fn = "grav_undo_planets";
 
   double pos_def[3] = { }, pos0[3] = { };
@@ -4484,7 +4482,7 @@ int grav_undo_planets(const double *pos_app, const double *pos_obs, enum novas_a
  * @since 1.1
  * @author Attila Kovacs
  */
-int obs_planets(double jd_tdb, enum novas_accuracy accuracy, const double *pos_obs, int pl_mask, novas_planet_set *planets) {
+int obs_planets(double jd_tdb, enum novas_accuracy accuracy, const double *pos_obs, int pl_mask, novas_planet_bundle *planets) {
   static const char *fn = "obs_planets";
 
   static object body[NOVAS_PLANETS];
@@ -4603,7 +4601,7 @@ short grav_def(double jd_tdb, enum novas_observer_place unused, enum novas_accur
         double *out) {
   static const char *fn = "grav_def";
 
-  novas_planet_set planets = {};
+  novas_planet_bundle planets = {};
   int pl_mask = (accuracy == NOVAS_FULL_ACCURACY) ? grav_bodies_full_accuracy : grav_bodies_reduced_accuracy;
 
   if(!pos_src || !out)
@@ -4661,7 +4659,7 @@ short grav_def(double jd_tdb, enum novas_observer_place unused, enum novas_accur
 int grav_undef(double jd_tdb, enum novas_accuracy accuracy, const double *pos_app, const double *pos_obs, double *out) {
   static const char *fn = "grav_undef";
 
-  novas_planet_set planets = {};
+  novas_planet_bundle planets = {};
   int pl_mask = (accuracy == NOVAS_FULL_ACCURACY) ? grav_bodies_full_accuracy : grav_bodies_reduced_accuracy;
 
   if(!pos_app || !out)

--- a/src/novas.c
+++ b/src/novas.c
@@ -4291,13 +4291,8 @@ double d_light(const double *pos_src, const double *pos_body) {
  * @param pos_obs     [AU] Position 3-vector of observer (or the geocenter), with respect to
  *                    origin at solar system barycenter, referred to ICRS axes,
  *                    components in AU.
- * @param pl_mask     Bitwise `(1 << planet-number)` mask indicating which planets to use,
- *                    and have apparent positions and velocities defined. See enum novas_planet
- *                    for the planet numbers.
- * @param pl_pos      [AU] Apparent geometric position of planets rel. to observer, antedated
- *                    for light travel time to observer.
- * @param pl_vel      [AU/day] Apparent velocities of planets rel. to observer, antedated
- *                    for light travel time to observer.
+ * @param planets     Apparent planet data containing positions and velocities for the major
+ *                    gravitating bodies in the solar-system.
  * @param[out] out    [AU] Position vector of observed object, with respect to origin at
  *                    observer (or the geocenter), referred to ICRS axes, corrected
  *                    for gravitational deflection, components in AU. It can be the same
@@ -4396,13 +4391,8 @@ int grav_planets(const double *pos_src, const double *pos_obs, const novas_plane
  *                    components in AU.
  * @param accuracy    NOVAS_FULL_ACCURACY (0) for sub-&mu;as accuracy or NOVAS_REDUCED_ACCURACY (1)
  *                    for sub-mas accuracy.
- * @param pl_mask     Bitwise `(1 << planet-number)` mask indicating which planets to use,
- *                    and have apparent positions and velocities defined. See enum novas_planet for
- *                    the planet numbers.
- * @param pl_pos      [AU] Apparent geometric position of planets rel. to observer, antedated
- *                    for light travel time to observer.
- * @param pl_vel      [AU/day] Apparent velocities of planets rel. to observer, antedated
- *                    for light travel time to observer.
+ * @param planets     Apparent planet data containing positions and velocities for the major
+ *                    gravitating bodies in the solar-system.
  * @param[out] out    [AU] Nominal position vector of observed object, with respect to origin at
  *                    observer (or the geocenter), referred to ICRS axes, without gravitational
  *                    deflection, components in AU. It can be the same vector as the input, but not

--- a/src/novas.c
+++ b/src/novas.c
@@ -4458,8 +4458,7 @@ int grav_undo_planets(const double *pos_app, const double *pos_obs, enum novas_a
       pos0[j] -= pos_def[j] - pos_app[j];
   }
 
-  novas_set_errno(ECANCELED, fn, "failed to converge");
-  return -1;
+  return novas_error(-1, ECANCELED, fn, "failed to converge");
 }
 
 /**

--- a/src/novas.c
+++ b/src/novas.c
@@ -69,6 +69,15 @@ double PSI_COR = 0.0;
  */
 double EPS_COR = 0.0;
 
+/**
+ * Maximum number of iterations for convergent inverse calculations. Most iterative inverse functions should
+ * normally converge in a handful of iterations. In some pathological cases more iterations may be required.
+ * This variable sets an absolute maximum for the number of iterations in order to avoid runaway (zombie)
+ * behaviour. If inverse functions faile to converge, they will return a value indicating an error, and
+ * errno should be set to ECANCELED.
+ *
+ * @since 1.1
+ */
 int novas_inv_max_iter = 100;
 
 // Defined in novas.h

--- a/src/novas.c
+++ b/src/novas.c
@@ -6425,6 +6425,8 @@ short ephemeris(const double *jd_tdb, const object *body, enum novas_origin orig
       enum novas_origin eph_origin = NOVAS_HELIOCENTER;
 
       error = -1;
+      errno = ENOSYS;
+
       if(readeph2_call) {
         // If there is a newstyle epehemeris access routine set, we will prefer it.
         error = readeph2_call(body->name, body->number, jd_tdb[0], jd_tdb[1], &eph_origin, posvel, &posvel[3]);

--- a/src/novas.c
+++ b/src/novas.c
@@ -69,6 +69,8 @@ double PSI_COR = 0.0;
  */
 double EPS_COR = 0.0;
 
+int novas_inv_max_iter = 100;
+
 // Defined in novas.h
 int grav_bodies_reduced_accuracy = DEFAULT_GRAV_BODIES_REDUCED_ACCURACY;
 
@@ -1479,7 +1481,7 @@ short mean_star(double jd_tt, double tra, double tdec, enum novas_accuracy accur
 
   // Iteratively find ICRS coordinates that produce input apparent place
   // of star at date 'jd_tt'.
-  for(iter = INV_MAX_ITER; --iter >= 0;) {
+  for(iter = novas_inv_max_iter; --iter >= 0;) {
     double ra1, dec1;
 
     prop_error(fn, app_star(jd_tt, &star, accuracy, &ra1, &dec1), 20);
@@ -4444,7 +4446,7 @@ int grav_undo_planets(const double *pos_app, const double *pos_obs, enum novas_a
 
   memcpy(pos0, pos_app, sizeof(pos0));
 
-  for(i = 0; i < INV_MAX_ITER; i++) {
+  for(i = 0; i < novas_inv_max_iter; i++) {
     int j;
 
     prop_error(fn, grav_planets(pos0, pos_obs, pl_mask, pl_pos, pl_vel, pos_def), 0);
@@ -6820,7 +6822,7 @@ double refract_astro(const on_surface *location, enum novas_refraction_model opt
   double refr = 0.0;
   int i;
 
-  for(i = 0; i < INV_MAX_ITER; i++) {
+  for(i = 0; i < novas_inv_max_iter; i++) {
     double zd_obs = zd_astro - refr;
     refr = refract(location, option, zd_obs);
     if(fabs(refr - (zd_astro - zd_obs)) < 3.0e-5)

--- a/src/novas.c
+++ b/src/novas.c
@@ -4332,7 +4332,7 @@ int grav_planets(const double *pos_src, const double *pos_obs, const novas_plane
 
   tsrc = novas_vlen(pos_src) / C_AUDAY;
 
-  for(i = 0; i < NOVAS_PLANETS; i++) {
+  for(i = 1; i < NOVAS_PLANETS; i++) {
     double lt, dlt, dpl, p1[3];
     int k;
 

--- a/src/novascon.c
+++ b/src/novascon.c
@@ -3,12 +3,15 @@
  *
  * @author G. Kaplan and A. Kovacs
  *
- *  SuperNOVAS implementation for numerical constants that were used internally in novas.c. In SuperNOVAS it is no longer needed
- *  by novas.c, and you probably don't want to use it either with your application code.
+ *  SuperNOVAS implementation for numerical constants that were used internally in novas.c. In
+ *  SuperNOVAS it is no longer needed by novas.c, and you probably don't want to use it either
+ *  with your application code.
  *
- *  @deprecated Use your own version for the selection of the constant you need, expressed in whatever units your application
- *              desires. We should not force you to adopt the internally used convention of NOVAS, not to mention the high
- *              chance of namespace conflicts with the super-simplistic naming scheme here. You are better off without this.
+ *  @deprecated Use your own version for the selection of the constant you need, expressed in
+ *              whatever units your application desires. We should not force you to adopt the
+ *              internally used convention of NOVAS, not to mention the high chance of namespace
+ *              conflicts with the super-simplistic naming scheme here. You are better off
+ *              without this.
  *
  *  Based on the NOVAS C Edition, Version 3.1,  U. S. Naval Observatory
  *  Astronomical Applications Dept.

--- a/src/novascon.c
+++ b/src/novascon.c
@@ -13,10 +13,13 @@
  *              conflicts with the super-simplistic naming scheme here. You are better off
  *              without this.
  *
- *  Based on the NOVAS C Edition, Version 3.1,  U. S. Naval Observatory
- *  Astronomical Applications Dept.
- *  Washington, DC
- *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">http://www.usno.navy.mil/USNO/astronomical-applications</a>
+ *  Based on the NOVAS C Edition, Version 3.1:
+ *
+ *  U. S. Naval Observatory<br>
+ *  Astronomical Applications Dept.<br>
+ *  Washington, DC<br>
+ *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">
+ *  http://www.usno.navy.mil/USNO/astronomical-applications</a>
  */
 
 // We shall never use these in the internal API. We define precompiler constants instead...

--- a/src/nutation.c
+++ b/src/nutation.c
@@ -8,10 +8,13 @@
  *  IAU 2000A and IAU2000B series as well as a NOVAS-specific truncated low-precision
  *  version we call NU2000K.
  *
- *  Based on the NOVAS C Edition, Version 3.1,  U. S. Naval Observatory
- *  Astronomical Applications Dept.
- *  Washington, DC
- *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">http://www.usno.navy.mil/USNO/astronomical-applications</a>
+ *  Based on the NOVAS C Edition, Version 3.1:
+ *
+ *  U. S. Naval Observatory<br>
+ *  Astronomical Applications Dept.<br>
+ *  Washington, DC<br>
+ *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">
+ *  http://www.usno.navy.mil/USNO/astronomical-applications</a>
  */
 
 #include <stdint.h>

--- a/src/readeph0.c
+++ b/src/readeph0.c
@@ -1,15 +1,15 @@
-/*
- Naval Observatory Vector Astrometry Software (NOVAS)
- C Edition, Version 3.1
-
- readeph0.c: Dummy readeph for use when minor planet ephermeris is unavailable
-
- U. S. Naval Observatory
- Astronomical Applications Dept.
- Washington, DC
- http://www.usno.navy.mil/USNO/astronomical-applications
+/**
+ * @author G. Kaplan and A. Kovacs
+ *
+ *  Dummy readeph() implementation for SuperNOVAS for use when minor planet ephermeris is
+ *  unavailable.
+ *
+ *  Based on the NOVAS C Edition, Version 3.1,  U. S. Naval Observatory
+ *  Astronomical Applications Dept.
+ *  Washington, DC
+ *   <a href="http://www.usno.navy.mil/USNO/astronomical-applications">http://www.usno.navy.mil/USNO/astronomical-applications</a>
+ *
  */
-
 #include <stdlib.h>
 #include <errno.h>
 

--- a/src/readeph0.c
+++ b/src/readeph0.c
@@ -4,10 +4,13 @@
  *  Dummy readeph() implementation for SuperNOVAS for use when minor planet ephermeris is
  *  unavailable.
  *
- *  Based on the NOVAS C Edition, Version 3.1,  U. S. Naval Observatory
- *  Astronomical Applications Dept.
- *  Washington, DC
- *   <a href="http://www.usno.navy.mil/USNO/astronomical-applications">http://www.usno.navy.mil/USNO/astronomical-applications</a>
+ *  Based on the NOVAS C Edition, Version 3.1:
+ *
+ *  U. S. Naval Observatory<br>
+ *  Astronomical Applications Dept.<br>
+ *  Washington, DC<br>
+ *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">
+ *  http://www.usno.navy.mil/USNO/astronomical-applications</a>
  *
  */
 #include <stdlib.h>

--- a/src/readeph0.c
+++ b/src/readeph0.c
@@ -30,6 +30,7 @@ double * readeph_dummy(int mp, const char *name, double jd_tdb, int *error) {
 
   if(isnanf(jd_tdb)) {
     set_error(-1, EINVAL, fn, "NaN jd_tdb");
+    *error = -1;
     return NULL;
   }
 

--- a/src/refract.c
+++ b/src/refract.c
@@ -23,7 +23,6 @@
 #include <math.h>
 #include "novas.h"
 
-
 static double novas_refraction(enum novas_refraction_model model, const on_surface *loc, enum novas_refraction_type type, double el) {
   if(!loc) {
     novas_error(-1, EINVAL, "novas_refraction", "NULL on surface observer location");

--- a/src/refract.c
+++ b/src/refract.c
@@ -64,7 +64,7 @@ double novas_inv_refract(RefractionModel model, double jd_tt, const on_surface *
   const int dir = (type == NOVAS_REFRACT_OBSERVED ? 1 : -1);
   int i;
 
-  for(i = 0; i < INV_MAX_ITER; i++) {
+  for(i = 0; i < novas_inv_max_iter; i++) {
     double el1 = el0 + dir * refr;
     refr = model(jd_tt, loc, type, el1);
 

--- a/src/refract.c
+++ b/src/refract.c
@@ -138,7 +138,9 @@ double novas_optical_refraction(double jd_tt, const on_surface *loc, enum novas_
  * </ol>
  *
  * @param jd_tt     [day] Terrestrial Time (TT) based Julian data of observation
- * @param loc       Pointer to structure defining the observer's location on earth, and local weather
+ * @param loc       Pointer to structure defining the observer's location on earth, and local weather.
+ *                  Make sure all weather values, including humidity (added in v1.1), are fully
+ *                  populated.
  * @param type      Whether the input elevation is observed or astrometric: REFRACT_OBSERVED (-1) or
  *                  REFRACT_ASTROMETRIC (0).
  * @param el        [deg] source elevation of the specified type.

--- a/src/refract.c
+++ b/src/refract.c
@@ -4,7 +4,7 @@
  * @date Created  on Jun 27, 2024
  * @author Attila Kovacs
  *
- *  A collection of refraction models to used with novas_app_to_hor()
+ *  A collection of refraction models and utilities to use with novas_app_to_hor() or novas_hor_to_app().
  */
 
 /// \cond PRIVATE

--- a/src/refract.c
+++ b/src/refract.c
@@ -4,7 +4,11 @@
  * @date Created  on Jun 27, 2024
  * @author Attila Kovacs
  *
- *  A collection of refraction models and utilities to use with novas_app_to_hor() or novas_hor_to_app().
+ *  A collection of refraction models and utilities to use with novas_app_to_hor() or
+ *  novas_hor_to_app().
+ *
+ * @sa novas_app_to_hor()
+ * @sa novas_hor_to_app().
  */
 
 /// \cond PRIVATE

--- a/src/solsys-ephem.c
+++ b/src/solsys-ephem.c
@@ -1,8 +1,8 @@
 /**
  * @file
  *
- * SuperNOVAS major planet ephemeris handler via the same generic ephemeris reader that is configured by set_ephem_provider() prior
- * to calling this routine.
+ * SuperNOVAS major planet ephemeris handler via the same generic ephemeris reader that is
+ * configured by set_ephem_provider() prior to calling this routine.
  *
  * @date Created  on Jan 29, 2024
  * @author Attila Kovacs

--- a/src/solsys1.c
+++ b/src/solsys1.c
@@ -3,10 +3,11 @@
  *
  * @author G. Kaplan and A. Kovacs
  *
- *  SuperNOVAS major planet ephemeris lookup implementation using JPL 1997 ephemeris data, to be used together
- *  with eph_manager.c. A more generic solution is to implement a novas_ephem_provider (e.g. relying on the current
- *  version of the CSPICE library) and set it as the default ephemeris handler via set_ephem_provider(), and then
- *  use solsys-ephem.c instead to use the same implementation for major planets.
+ *  SuperNOVAS major planet ephemeris lookup implementation using JPL 1997 ephemeris data, to be
+ *  used together with eph_manager.c. A more generic solution is to implement a
+ *  novas_ephem_provider (e.g. relying on the current version of the CSPICE library) and set it as
+ *  the default ephemeris handler via set_ephem_provider(), and then use solsys-ephem.c instead to
+ *  use the same implementation for major planets.
  *
  *  Based on the NOVAS C Edition, Version 3.1,  U. S. Naval Observatory
  *  Astronomical Applications Dept.

--- a/src/solsys1.c
+++ b/src/solsys1.c
@@ -9,10 +9,13 @@
  *  the default ephemeris handler via set_ephem_provider(), and then use solsys-ephem.c instead to
  *  use the same implementation for major planets.
  *
- *  Based on the NOVAS C Edition, Version 3.1,  U. S. Naval Observatory
- *  Astronomical Applications Dept.
- *  Washington, DC
- *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">http://www.usno.navy.mil/USNO/astronomical-applications</a>
+ *  Based on the NOVAS C Edition, Version 3.1:
+ *
+ *  U. S. Naval Observatory<br>
+ *  Astronomical Applications Dept.<br>
+ *  Washington, DC<br>
+ *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">
+ *  http://www.usno.navy.mil/USNO/astronomical-applications</a>
  *
  * @sa solsys-ephem.c
  * @sa solsys1.c

--- a/src/solsys1.c
+++ b/src/solsys1.c
@@ -180,10 +180,9 @@ short solarsystem(double jd_tdb, short body, short origin, double *position, dou
 }
 
 short solarsystem_hp(const double jd_tdb[2], short body, short origin, double *position, double *velocity) {
-  if(!jd_tdb) {
-    errno = EINVAL;
-    return -1;
-  }
+  if(!jd_tdb)
+    return novas_error(-1, EINVAL, "solarsystem_hp", "NULL jd_tdb 2-component input array");
+
   prop_error("solarsystem_hp", planet_eph_manager_hp(jd_tdb, body, origin, position, velocity), 0);
   return 0;
 }

--- a/src/solsys2.c
+++ b/src/solsys2.c
@@ -13,10 +13,13 @@
  *  e.g. to the SPICE library, via novas_ephem_provider instead, which you can then activate
  *  at runtime with set_planet_provider().
  *
- *  Based on the NOVAS C Edition, Version 3.1,  U. S. Naval Observatory
- *  Astronomical Applications Dept.
- *  Washington, DC
- *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">http://www.usno.navy.mil/USNO/astronomical-applications</a>
+ *  Based on the NOVAS C Edition, Version 3.1:
+ *
+ *  U. S. Naval Observatory<br>
+ *  Astronomical Applications Dept.<br>
+ *  Washington, DC<br>
+ *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">
+ *  http://www.usno.navy.mil/USNO/astronomical-applications</a>
  *
  * @sa solsys-ephem.c
  * @sa solsys1.c

--- a/src/solsys3.c
+++ b/src/solsys3.c
@@ -6,10 +6,13 @@
  *  SuperNOVAS plane calculator functions for the Earth and Sun only, with an orbital model
  *  based on the DE405 ephemerides by JPL.
  *
- *  Based on the NOVAS C Edition, Version 3.1,  U. S. Naval Observatory
- *  Astronomical Applications Dept.
- *  Washington, DC
- *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">http://www.usno.navy.mil/USNO/astronomical-applications</a>
+ *  Based on the NOVAS C Edition, Version 3.1:
+ *
+ *  U. S. Naval Observatory<br>
+ *  Astronomical Applications Dept.<br>
+ *  Washington, DC<br>
+ *  <a href="http://www.usno.navy.mil/USNO/astronomical-applications">
+ *  http://www.usno.navy.mil/USNO/astronomical-applications</a>
  *
  *  @sa solsys-ephem.c
  */

--- a/src/timescale.c
+++ b/src/timescale.c
@@ -326,8 +326,8 @@ double novas_get_split_time(const novas_timespec *time, enum novas_timescale tim
  *
  * @sa novas_set_time()
  * @sa novas_offset_time()
- * @sa novas_tcb_diff()
- * @sa novas_tcg_diff()
+ * @sa novas_diff_tcb()
+ * @sa novas_diff_tcg()
  *
  * @since 1.1
  * @author Attila Kovacs
@@ -352,13 +352,13 @@ double novas_diff_time(const novas_timespec *t1, const novas_timespec *t2) {
  * @return      [day] Precise TCB time difference (t1-t2), or NAN if one of the inputs was
  *              NULL (errno will be set to EINVAL)
  *
- * @sa novas_tgc_diff()
+ * @sa novas_diff_tcg()
  * @sa novas_diff_time()
  *
  * @since 1.1
  * @author Attila Kovacs
  */
-double novas_tcb_diff(const novas_timespec *t1, const novas_timespec *t2) {
+double novas_diff_tcb(const novas_timespec *t1, const novas_timespec *t2) {
   return novas_diff_time(t1, t2) * (1.0 + TC_LB);
 }
 
@@ -374,13 +374,13 @@ double novas_tcb_diff(const novas_timespec *t1, const novas_timespec *t2) {
  * @return      [day] Precise TCG time difference (t1-t2), or NAN if one of the inputs was
  *              NULL (errno will be set to EINVAL)
  *
- * @sa novas_tcb_diff()
+ * @sa novas_diff_tcb()
  * @sa novas_diff_time()
  *
  * @since 1.1
  * @author Attila Kovacs
  */
-double novas_tcg_diff(const novas_timespec *t1, const novas_timespec *t2) {
+double novas_diff_tcg(const novas_timespec *t1, const novas_timespec *t2) {
   return novas_diff_time(t1, t2) * (1.0 + TC_LG);
 }
 

--- a/src/timescale.c
+++ b/src/timescale.c
@@ -5,7 +5,7 @@
  * @author Attila Kovacs
  * @since 1.1
  *
- *   A set of routines to make handling of astronomical timescale and conversions between them
+ *   A set of routines to make handling of astronomical timescales and conversions between them
  *   easier.
  */
 

--- a/src/timescale.c
+++ b/src/timescale.c
@@ -46,9 +46,9 @@
 
 /**
  * Sets an astronomical time to the fractional Julian Date value, defined in the specified
- * timescale. The time set this way is accurate to a few &mu;s (microsecond) due to the inherent
+ * timescale. The time set this way is accurate to a few &mu;s (microseconds) due to the inherent
  * precision of the double-precision argument. For higher precision applications you may use
- * `novas_set_split_time()` instead, which has an inherent accuracy at the picoseconds level.
+ * `novas_set_split_time()` instead, which has an inherent accuracy at the picosecond level.
  *
  * @param timescale     The astronomical time scale in which the Julian Date is given
  * @param jd            [day] Julian day value in the specified timescale
@@ -73,8 +73,8 @@ int novas_set_time(enum novas_timescale timescale, double jd, int leap, double d
 /**
  * Sets an astronomical time to the split Julian Date value, defined in the specified timescale.
  * The split into the integer and fractional parts can be done in any convenient way. The highest
- * precision is reached if the fractional part is on the order of &le;= 1 day. In that case, the
- * time may be specified to picosecond accuracy, if needed.
+ * precision is reached if the fractional part is &le; 1 day. In that case, the time may be
+ * specified to picosecond accuracy, if needed.
  *
  * The accuracy of Barycentric Time measures (TDB and TCB) relative to other time measures is
  * limited by the precision of `tbd2tt()` implementation, to around 10 &mu;s.
@@ -205,7 +205,7 @@ int novas_offset_time(const novas_timespec *time, double seconds, novas_timespec
  * double-precision result. For higher precision applications you may use `novas_get_split_time()`
  * instead, which has an inherent accuracy at the picosecond level.
  *
- * @param time        Pointer to the astronimical time specification data structure.
+ * @param time        Pointer to the astronomical time specification data structure.
  * @param timescale   The astronomical time scale in which the returned Julian Date is to be
  *                    provided
  * @return            [day] The Julian date in the requested timescale.
@@ -224,9 +224,9 @@ double novas_get_time(const novas_timespec *time, enum novas_timescale timescale
 
 /**
  * Returns the fractional Julian date of an astronomical time in the specified timescale, as an
- * integer and fractional part. The two-component split of the time allows for abolute precisions
+ * integer and fractional part. The two-component split of the time allows for absolute precisions
  * at the picosecond level, as opposed to `novas_set_time()`, whose precision is limited to a
- * ew microseconds. Ultimately, the accutacy of the time will depend on how it was set.
+ * few microseconds typically.
  *
  * The accuracy of Barycentric Time measures (TDB and TCB) relative to other time measures is
  * limited by the precision of the `tbd2tt()` implemenation, to around 10 &mu;s.
@@ -244,7 +244,7 @@ double novas_get_time(const novas_timespec *time, enum novas_timescale timescale
  * https://gssc.esa.int/navipedia/index.php/Transformations_between_Time_Systems</a></li>
  * </ol>
  *
- * @param time        Pointer to the astronimical time specification data structure.
+ * @param time        Pointer to the astronomical time specification data structure.
  * @param timescale   The astronomical time scale in which the returned Julian Date is to be
  *                    provided
  * @param[out] ijd    [day] The integer part of the Julian date in the requested timescale. It may
@@ -430,9 +430,9 @@ int novas_set_unix_time(time_t unix_time, long nanos, int leap, double dut1, nov
 /**
  * Returns the UNIX time for an astronomical time instant.
  *
- * @param time      The astronomical time scale in which the returned Julian Date is to be provided
- * @param nanos     [ns] UTC sub-second component. It may be NULL if not required.
- * @return          [s] The integer UNIX time
+ * @param time        Pointer to the astronomical time specification data structure.
+ * @param[out] nanos  [ns] UTC sub-second component. It may be NULL if not required.
+ * @return            [s] The integer UNIX time
  *
  * @sa novas_set_unix_time()
  * @sa novas_get_time()

--- a/src/timescale.c
+++ b/src/timescale.c
@@ -342,10 +342,10 @@ double novas_diff_time(const novas_timespec *t1, const novas_timespec *t2) {
 }
 
 /**
- * Returns the Geocentric Coordinate Time (TCG) based time difference (t1 - t2) in days between
- * two astronomical time specifications. TCG progresses slightly faster, by a relative rate about
- * 1.6&times10<sup>-8</sup> higher, than time on Earth due to the lack of gravitational time
- * dilation by the Earth or Sun.
+ * Returns the Barycentric Coordinate Time (TCB) based time difference (t1 - t2) in days between
+ * two astronomical time specifications. TCB progresses slightly faster than time on Earth, at a
+ * rate about 1.6&times10<sup>-8</sup> higher, due to the lack of gravitational time dilation by
+ * the Earth or Sun.
  *
  * @param t1    First time
  * @param t2    Second time
@@ -364,10 +364,12 @@ double novas_diff_tcb(const novas_timespec *t1, const novas_timespec *t2) {
 
 
 /**
- * Returns the Geocentric Coordinate Time (TCG) based time difference (t1 - t2) in days between two
- * astronomical time specifications. TCG progresses slightly faster, by a relative rate about
- * 7&times10<sup>-10</sup> higher, than time on Earth due to the lack of gravitational time
- * dilation by Earth.
+ * Returns the Geocentric Coordinate Time (TCG) based time difference (t1 - t2) in days between
+ * two astronomical time specifications. TCG progresses slightly faster than time on Earth, at a
+ * rate about 7&times10<sup>-10</sup> higher, due to the lack of gravitational time dilation by
+ * Earth. TCG is an appropriate time measure for a spacecraft that is in the proximity of the
+ * orbit of Earth, but far enough from Earth such that the relativistic effects of Earth's gravity
+ * can be ignored.
  *
  * @param t1    First time
  * @param t2    Second time

--- a/src/timescale.c
+++ b/src/timescale.c
@@ -448,7 +448,7 @@ time_t novas_get_unix_time(const novas_timespec *time, long *nanos) {
   seconds = UNIX_J2000 + (ijd - IJD_J2000) * IDAY + isod;
 
   if(nanos) {
-    *nanos = round(1e9 * (sod - isod));
+    *nanos = floor(1e9 * (sod - isod) + 0.5);
     if(*nanos == E9) {
       seconds++;
       *nanos = 0;

--- a/src/timescale.c
+++ b/src/timescale.c
@@ -5,8 +5,10 @@
  * @author Attila Kovacs
  * @since 1.1
  *
- *   A set of routines to make handling of astronomical timescales and conversions between them
- *   easier.
+ *   A set of SuperNOVAS routines to make handling of astronomical timescales and conversions
+ *   among them easier.
+ *
+ * @sa frames.c
  */
 
 /// \cond PRIVATE

--- a/test/Makefile
+++ b/test/Makefile
@@ -39,6 +39,7 @@ coverage: novas.c.gcov nutation.c.gcov solsys3.c.gcov timescale.c.gcov refract.c
 data:
 	mkdir data
 
+.PHONY: bad-data
 bad-data: ../cio_ra.bin bad-cio-data
 	touch bad-cio-data/empty
 	dd if=../cio_ra.bin of=bad-cio-data/bad-1.bin bs=27 count=1
@@ -88,6 +89,21 @@ clean-data:
 .PHONY: clean
 clean: clean-test clean-cov clean-data
 	rm -f *.o
+
+
+.PHONY: help
+help:
+	@echo
+	@echo "Syntax: make [target]"
+	@echo
+	@echo "The following targets are available:"
+	@echo
+	@echo "  run           (default) Compiles and runs regression tests."
+	@echo "  coverage      Extracts test coverage data."
+	@echo "  clean         Removes intermediate products."
+	@echo "  distclean     Deletes all generated files."
+	@echo
+
 
 vpath %.c ../src
 vpath %.c src

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,6 +13,7 @@ include ../config.mk
 
 #OBJECTS := $(subst obj/,,$(OBJECTS))
 OBJECTS := novas.o nutation.o solsys3.o frames.o timescale.o refract.o
+SOURCES := $(subst .o,.c,$(OBJECTS))
 
 .PHONY: run
 run: clean-cov clean-data test-compat test-cio_file test-super test-errors data ../cio_ra.bin bad-data
@@ -65,6 +66,10 @@ bad-cio-data:
 ../cio_ra.bin:
 	make -C .. cio_ra.bin
 
+test-errors: CPPFLAGS += -DINV_MAX_ITER=0
+test-errors: test-errors.o $(SOURCES) | Makefile data
+	$(CC) -o $@ $^ $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
+
 test-%: test-%.o $(OBJECTS) | Makefile data
 	$(CC) -o $@ $^ $(LDFLAGS)
 
@@ -86,9 +91,12 @@ clean-cov:
 clean-data:
 	rm -rf data cio_ra.bin bad-cio-data
 
-.PHONY: clean
-clean: clean-test clean-cov clean-data
+.PHONY: clean-obj
+clean-obj:
 	rm -f *.o
+
+.PHONY: clean
+clean: clean-obj clean-test clean-cov clean-data
 
 
 .PHONY: help

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,7 +13,6 @@ include ../config.mk
 
 #OBJECTS := $(subst obj/,,$(OBJECTS))
 OBJECTS := novas.o nutation.o solsys3.o frames.o timescale.o refract.o
-SOURCES := $(subst .o,.c,$(OBJECTS))
 
 .PHONY: run
 run: clean-cov clean-data test-compat test-cio_file test-super test-errors data ../cio_ra.bin bad-data
@@ -66,10 +65,6 @@ bad-cio-data:
 ../cio_ra.bin:
 	make -C .. cio_ra.bin
 
-test-errors: CPPFLAGS += -DINV_MAX_ITER=0
-test-errors: test-errors.o $(SOURCES) | Makefile data
-	$(CC) -o $@ $^ $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
-
 test-%: test-%.o $(OBJECTS) | Makefile data
 	$(CC) -o $@ $^ $(LDFLAGS)
 
@@ -91,12 +86,9 @@ clean-cov:
 clean-data:
 	rm -rf data cio_ra.bin bad-cio-data
 
-.PHONY: clean-obj
-clean-obj:
-	rm -f *.o
-
 .PHONY: clean
-clean: clean-obj clean-test clean-cov clean-data
+clean: clean-test clean-cov clean-data
+	rm -f *.o
 
 
 .PHONY: help

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -273,6 +273,20 @@ static int test_cirs_to_gcrs() {
   return n;
 }
 
+static int test_cirs_to_app_ra() {
+  int n = 0;
+  if(check_nan("cirs_to_app_ra:accuracy:-1", cirs_to_app_ra(NOVAS_JD_J2000, -1, 0.0))) n++;
+  if(check_nan("cirs_to_app_ra:accuracy:2", cirs_to_app_ra(NOVAS_JD_J2000, 2, 0.0))) n++;
+  return n;
+}
+
+static int test_app_to_cirs_ra() {
+  int n = 0;
+  if(check_nan("app_to_cirs_ra:accuracy:-1", app_to_cirs_ra(NOVAS_JD_J2000, -1, 0.0))) n++;
+  if(check_nan("app_to_cirs_ra:accuracy:2", app_to_cirs_ra(NOVAS_JD_J2000, 2, 0.0))) n++;
+  return n;
+}
+
 static int test_set_planet_provider() {
   if(check("set_planet_provider", -1, set_planet_provider(NULL))) return 1;
   return 0;
@@ -852,12 +866,12 @@ static int test_grav_init_planets() {
   double p[3] = {2.0}, pb[NOVAS_PLANETS][3] = {{}}, vb[NOVAS_PLANETS][3] = {{}};
   int pl_mask, n = 0;
 
-  if(check("grav_init_planets:pos_obs", -1, obs_planets(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, NULL, &pl_mask, pb, vb))) n++;
-  if(check("grav_init_planets:pl_pos", -1, obs_planets(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, p, &pl_mask, NULL, vb))) n++;
-  if(check("grav_init_planets:pl_vel", -1, obs_planets(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, p, &pl_mask, pb, NULL))) n++;
-  if(check("grav_init_planets:pl_pos+pl_vel", -1, obs_planets(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, p, &pl_mask, NULL, NULL))) n++;
-  if(check("grav_init_planets:pl_pos=pl_vel", -1, obs_planets(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, p, &pl_mask, pb, pb))) n++;
-  if(check("grav_init_planets:pl_mask", -1, obs_planets(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, p, NULL, pb, vb))) n++;
+  if(check("grav_init_planets:pos_obs", -1, obs_planets(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, NULL, 0, pb, vb, &pl_mask))) n++;
+  if(check("grav_init_planets:pl_pos", -1, obs_planets(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, p, 0, NULL, vb, &pl_mask))) n++;
+  if(check("grav_init_planets:pl_vel", -1, obs_planets(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, p, 0, pb, NULL, &pl_mask))) n++;
+  if(check("grav_init_planets:pl_pos+pl_vel", -1, obs_planets(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, p, 0, NULL, NULL, &pl_mask))) n++;
+  if(check("grav_init_planets:pl_pos=pl_vel", -1, obs_planets(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, p, 0, pb, pb, &pl_mask))) n++;
+  if(check("grav_init_planets:pl_mask", -1, obs_planets(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, p, 0, pb, vb, NULL))) n++;
 
   return n;
 }
@@ -1326,6 +1340,8 @@ int main() {
   if(test_tod_to_j2000()) n++;
   if(test_gcrs_to_cirs()) n++;
   if(test_cirs_to_gcrs()) n++;
+  if(test_cirs_to_app_ra()) n++;
+  if(test_app_to_cirs_ra()) n++;
 
   if(test_set_planet_provider()) n++;
   if(test_set_planet_provider_hp()) n++;

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -889,48 +889,41 @@ static int test_grav_undef() {
 }
 
 static int test_grav_init_planets() {
-  double p[3] = {2.0}, pb[NOVAS_PLANETS][3] = {{}}, vb[NOVAS_PLANETS][3] = {{}};
-  int pl_mask, n = 0;
+  novas_planet_set planets = {};
+  double p[3] = {2.0};
+  int n = 0;
 
-  if(check("grav_init_planets:pos_obs", -1, obs_planets(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, NULL, 0, pb, vb, &pl_mask))) n++;
-  if(check("grav_init_planets:pl_pos", -1, obs_planets(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, p, 0, NULL, vb, &pl_mask))) n++;
-  if(check("grav_init_planets:pl_vel", -1, obs_planets(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, p, 0, pb, NULL, &pl_mask))) n++;
-  if(check("grav_init_planets:pl_pos+pl_vel", -1, obs_planets(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, p, 0, NULL, NULL, &pl_mask))) n++;
-  if(check("grav_init_planets:pl_pos=pl_vel", -1, obs_planets(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, p, 0, pb, pb, &pl_mask))) n++;
-  if(check("grav_init_planets:pl_mask", -1, obs_planets(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, p, 0, pb, vb, NULL))) n++;
+  if(check("grav_init_planets:pos_obs", -1, obs_planets(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, NULL, 0, &planets))) n++;
+  if(check("grav_init_planets:planets", -1, obs_planets(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, p, 0, NULL))) n++;
 
   return n;
 }
 
 static int test_grav_planets() {
-  double p[3] = {2.0}, po[3] = {0.0, 1.0}, pb[NOVAS_PLANETS][3] = {{}}, vb[NOVAS_PLANETS][3] = {{}}, out[3] = {};
-  int pl_mask = 0, n = 0;
+  novas_planet_set planets = {};
+  double p[3] = {2.0}, po[3] = {0.0, 1.0}, out[3] = {};
+  int n = 0;
 
-  if(check("grav_planets:pos_src", -1, grav_planets(NULL, po, pl_mask, pb, vb, out))) n++;
-  if(check("grav_planets:pos_obs", -1, grav_planets(p, NULL, pl_mask, pb, vb, out))) n++;
-  if(check("grav_planets:pl_pos", -1, grav_planets(p, po, pl_mask, NULL, vb, out))) n++;
-  if(check("grav_planets:pl_vel", -1, grav_planets(p, po, pl_mask, pb, NULL, out))) n++;
-  if(check("grav_planets:pl_pos+pl_vel", -1, grav_planets(p, po, pl_mask, NULL, NULL, out))) n++;
-  if(check("grav_planets:pl_pos=pl_vel", -1, grav_planets(p, po, pl_mask, pb, pb, out))) n++;
-  if(check("grav_planets:pos_src", -1, grav_planets(p, po, pl_mask, pb, vb, NULL))) n++;
+  if(check("grav_planets:pos_src", -1, grav_planets(NULL, po, &planets, out))) n++;
+  if(check("grav_planets:pos_obs", -1, grav_planets(p, NULL, &planets, out))) n++;
+  if(check("grav_planets:planets", -1, grav_planets(p, po, NULL, out))) n++;
+  if(check("grav_planets:pos_src", -1, grav_planets(p, po, &planets, NULL))) n++;
 
   return n;
 }
 
 static int test_grav_undo_planets() {
-  double p[3] = {2.0}, po[3] = {0.0, 1.0}, pb[NOVAS_PLANETS][3] = {{}}, vb[NOVAS_PLANETS][3] = {{}}, out[3] = {};
-  int pl_mask = 0, n = 0;
+  novas_planet_set planets = {};
+  double p[3] = {2.0}, po[3] = {0.0, 1.0}, out[3] = {};
+  int n = 0;
 
-  if(check("grav_undo_planets:pos_app", -1, grav_undo_planets(NULL, po, NOVAS_REDUCED_ACCURACY, pl_mask, pb, vb, out))) n++;
-  if(check("grav_undo_planets:pos_obs", -1, grav_undo_planets(p, NULL, NOVAS_REDUCED_ACCURACY, pl_mask, pb, vb, out))) n++;
-  if(check("grav_undo_planets:pl_pos", -1, grav_undo_planets(p, po, NOVAS_REDUCED_ACCURACY, pl_mask, NULL, vb, out))) n++;
-  if(check("grav_undo_planets:pl_vel", -1, grav_undo_planets(p, po, NOVAS_REDUCED_ACCURACY, pl_mask, pb, NULL, out))) n++;
-  if(check("grav_undo_planets:pl_pos+pl_vel", -1, grav_undo_planets(p, po, NOVAS_REDUCED_ACCURACY, pl_mask, NULL, NULL, out))) n++;
-  if(check("grav_undo_planets:pl_pos=pl_vel", -1, grav_undo_planets(p, po, NOVAS_REDUCED_ACCURACY, pl_mask, pb, pb, out))) n++;
-  if(check("grav_undo_planets:pos_src", -1, grav_undo_planets(p, po, NOVAS_REDUCED_ACCURACY, pl_mask, pb, vb, NULL))) n++;
+  if(check("grav_undo_planets:pos_app", -1, grav_undo_planets(NULL, po, NOVAS_REDUCED_ACCURACY, &planets, out))) n++;
+  if(check("grav_undo_planets:pos_obs", -1, grav_undo_planets(p, NULL, NOVAS_REDUCED_ACCURACY, &planets, out))) n++;
+  if(check("grav_undo_planets:planets", -1, grav_undo_planets(p, po, NOVAS_REDUCED_ACCURACY, NULL, out))) n++;
+    if(check("grav_undo_planets:pos_src", -1, grav_undo_planets(p, po, NOVAS_REDUCED_ACCURACY, &planets, NULL))) n++;
 
-  pl_mask = 1 << NOVAS_SUN;
-  if(check("grav_undo_planets:converge", -1, grav_undo_planets(p, po, NOVAS_REDUCED_ACCURACY, pl_mask, pb, vb, out))) {
+  planets.mask = 1 << NOVAS_SUN;
+  if(check("grav_undo_planets:converge", -1, grav_undo_planets(p, po, NOVAS_REDUCED_ACCURACY, &planets, out))) {
     if(check("grav_undo_planets:converge:errno", ECANCELED, errno)) n++;
   }
 

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -1116,6 +1116,10 @@ static int test_geom_posvel() {
   frame.accuracy = 2;
   if(check("geom_posvel:frame:accuracy:2", -1, novas_geom_posvel(&o, &frame, NOVAS_ICRS, pos, vel))) n++;
 
+  frame.accuracy = NOVAS_REDUCED_ACCURACY;
+  make_ephem_object("blah", 111111, &o);
+  if(check("geom_posvel:ephem_object", -1, novas_geom_posvel(&o, &frame, NOVAS_ICRS, pos, vel))) n++;
+
   return n;
 }
 

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -917,13 +917,13 @@ static int test_grav_undo_planets() {
   double p[3] = {2.0}, po[3] = {0.0, 1.0}, out[3] = {};
   int n = 0;
 
-  if(check("grav_undo_planets:pos_app", -1, grav_undo_planets(NULL, po, NOVAS_REDUCED_ACCURACY, &planets, out))) n++;
-  if(check("grav_undo_planets:pos_obs", -1, grav_undo_planets(p, NULL, NOVAS_REDUCED_ACCURACY, &planets, out))) n++;
-  if(check("grav_undo_planets:planets", -1, grav_undo_planets(p, po, NOVAS_REDUCED_ACCURACY, NULL, out))) n++;
-    if(check("grav_undo_planets:pos_src", -1, grav_undo_planets(p, po, NOVAS_REDUCED_ACCURACY, &planets, NULL))) n++;
+  if(check("grav_undo_planets:pos_app", -1, grav_undo_planets(NULL, po, &planets, out))) n++;
+  if(check("grav_undo_planets:pos_obs", -1, grav_undo_planets(p, NULL, &planets, out))) n++;
+  if(check("grav_undo_planets:planets", -1, grav_undo_planets(p, po, NULL, out))) n++;
+    if(check("grav_undo_planets:pos_src", -1, grav_undo_planets(p, po, &planets, NULL))) n++;
 
   planets.mask = 1 << NOVAS_SUN;
-  if(check("grav_undo_planets:converge", -1, grav_undo_planets(p, po, NOVAS_REDUCED_ACCURACY, &planets, out))) {
+  if(check("grav_undo_planets:converge", -1, grav_undo_planets(p, po, &planets, out))) {
     if(check("grav_undo_planets:converge:errno", ECANCELED, errno)) n++;
   }
 

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -1353,7 +1353,11 @@ static int test_inv_transform() {
 }
 
 int main() {
+  extern int novas_inv_max_iter;
   int n = 0;
+
+  // For testing convergence errors.
+  novas_inv_max_iter = 0;
 
   if(test_make_on_surface()) n++;
   if(test_make_in_space()) n++;

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -889,7 +889,7 @@ static int test_grav_undef() {
 }
 
 static int test_grav_init_planets() {
-  novas_planet_set planets = {};
+  novas_planet_bundle planets = {};
   double p[3] = {2.0};
   int n = 0;
 
@@ -900,7 +900,7 @@ static int test_grav_init_planets() {
 }
 
 static int test_grav_planets() {
-  novas_planet_set planets = {};
+  novas_planet_bundle planets = {};
   double p[3] = {2.0}, po[3] = {0.0, 1.0}, out[3] = {};
   int n = 0;
 
@@ -913,7 +913,7 @@ static int test_grav_planets() {
 }
 
 static int test_grav_undo_planets() {
-  novas_planet_set planets = {};
+  novas_planet_bundle planets = {};
   double p[3] = {2.0}, po[3] = {0.0, 1.0}, out[3] = {};
   int n = 0;
 

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -1711,13 +1711,13 @@ static int test_diff_time() {
   if(!is_equal("diff_time:check", novas_diff_time(&t1, &t), 0.5, 1e-9)) return 1;
   if(!is_equal("diff_time:check:rev", novas_diff_time(&t, &t1), -0.5, 1e-9)) return 1;
 
-  dt = novas_tcb_diff(&t, &t1) - (1.0 + LB) * novas_diff_time(&t, &t1);
+  dt = novas_diff_tcb(&t, &t1) - (1.0 + LB) * novas_diff_time(&t, &t1);
   if(!is_ok("diff_time:check:tcb", fabs(dt) >= 1e-9)) {
     printf("!!! missed TCB by %.9f\n", dt);
     return 1;
   }
 
-  dt = novas_tcg_diff(&t, &t1) - (1.0 + LG) * novas_diff_time(&t, &t1);
+  dt = novas_diff_tcg(&t, &t1) - (1.0 + LG) * novas_diff_time(&t, &t1);
   if(!is_ok("diff_time:check:tcg", fabs(dt) >= 1e-9)) {
     printf("!!! missed TCG by %.9f\n", dt);
     return 1;

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -782,6 +782,23 @@ static int test_radec_planet() {
 }
 
 
+static int test_cirs_tod() {
+  double pos1[3] = {}, pos2[3] = {};
+  double ra0, dec0, ra1, dec1;
+
+  if(vector2radec(pos0, &ra0, &dec0) != 0) return 0;
+
+  if(!is_ok("cirs_tod:cirs_to_tod", cirs_to_tod(tdb, NOVAS_FULL_ACCURACY, pos0, pos1))) return 1;
+
+  vector2radec(pos1, &ra1, &dec1);
+  if(!is_equal("cirs_tod:cirs_to_tod:check", cirs_to_app_ra(tdb, NOVAS_FULL_ACCURACY, ra0), ra1, 1e-10)) return 1;
+
+  if(!is_ok("cirs_tod:tod_to_cirs", tod_to_cirs(tdb, NOVAS_FULL_ACCURACY, pos1, pos2))) return 1;
+  if(!is_ok("cirs_tod:tod_to_cirs:check", check_equal_pos(pos2, pos0, 1e-13 * vlen(pos0)))) return 1;
+
+  return 0;
+}
+
 static int test_observers() {
   double ps[3] = { 100.0, 30.0, 10.0 }, vs[3] = { 10.0 };
   int n = 0;
@@ -791,6 +808,8 @@ static int test_observers() {
 
   if(test_equ_ecl()) n++;
   if(test_equ_gal()) n++;
+
+  if(test_cirs_tod()) n++;
 
   make_observer_at_geocenter(&obs);
   n += test_source();
@@ -911,6 +930,8 @@ static int test_cirs_app_ra() {
   }
   return 0;
 }
+
+
 
 static int test_set_time() {
   novas_timespec tt, tt1, tai, gps, TDB, tcb, tcg, utc, ut1;


### PR DESCRIPTION
- Added `novas_planet_bundle` to handle planet data (e.g. for gravitational deflection) more elegantly.
- Added `cirs_to_tod()` and `tod_to_cirs()`
- `novas_geom_posvel()` to use frame-internal planet data if possible.
- `frame_aberration` to calculate inverse iteratively
- Remove `accuracy` argument from new `grav_undo_planets()` to simplify. 
- Refactor `novas_tcb_diff()` / `novas_tcg_diff()` to `novas_diff_tcb()` / `novas_diff_tcg()`.
- A few error traces that were missed before
- doxygen edits
- Updates to `README.md` and `CHANGELOG.md`
- Makefile edits and tweaks 
- Test for convergence failures