### PR TITLE
Redshifted motion handling

### DIFF
--- a/.settings/language.settings.xml
+++ b/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="([^/\\\\]*)((g?cc)|([gc]\+\+)|(clang))" prefer-non-shared="true"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="533288513625084254" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="533368308517884254" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ Outside contributions are very welcome. See
 
 Here are some links to other SuperNOVAS related content online:
 
- - [SuperNOVAS](https://smithsonian.github.io/SuperNOVAS) page on github.io.
+ - [SuperNOVAS](https://smithsonian.github.io/SuperNOVAS) page on github.io, including 
+   [API documentation](https://smithsonian.github.io/SuperNOVAS/apidoc/html/files.html).
  - [NOVAS](https://aa.usno.navy.mil/software/novas_info) home page at the US Naval Observatory.
  - [SPICE toolkit](https://naif.jpl.nasa.gov/naif/toolkit.html) for integrating Solar-system ephemeris
    via JPL HORIZONS.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ provided by SuperNOVAS over the upstream NOVAS C 3.1 code:
  - Fixes the [ephem_close bug](https://aa.usno.navy.mil/software/novas_faq), whereby `ephem_close()` in 
    `eph_manager.c` did not reset the `EPHFILE` pointer to NULL. This was a documented issue of NOVAS C 3.1.
    
- - [__v1.0.2__] Fixes division by zero bug in `d_light()` if the first position argument is the ephemeris reference
+ - [__v1.1__] Fixes division by zero bug in `d_light()` if the first position argument is the ephemeris reference
    position (e.g. the Sun for `solsys3.c`). The bug affects for example `grav_def()`, where it effectively results in
    the gravitational deflection due to the Sun being skipped.
     

--- a/README.md
+++ b/README.md
@@ -983,7 +983,7 @@ A predictable release schedule and process can help manage expectations and redu
 alike.
 
 Releases of the library shall follow a quarterly release schedule. You may expect upcoming releases 
-to be published around __March 1__, __June 1__, __September 1__, and/or __December 1__ each year, on an as-needed
+to be published around __February 1__, __May 1__, __August 1__, and/or __November 1__ each year, on an as-needed
 basis. That means that if there are outstanding bugs, or new pull requests (PRs), you may expect a release that 
 addresses these in the upcoming quarter. The dates are placeholders only, with no guarantee that a new release will 
 actually be available every quarter. If nothing of note comes up, a potential release date may pass without a release 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ provided by SuperNOVAS over the upstream NOVAS C 3.1 code:
  - Fixes the [sidereal_time bug](https://aa.usno.navy.mil/software/novas_faq), whereby the `sidereal_time()` function 
    had an incorrect unit cast. This was a documented issue of NOVAS C 3.1.
    
+ - Fixes the [ephem_close bug](https://aa.usno.navy.mil/software/novas_faq), whereby `ephem_close()` in 
+   `eph_manager.c` did not reset the `EPHFILE` pointer to NULL. This was a documented issue of NOVAS C 3.1.
+     
  - Fixes antedating velocities and distances for light travel time in `ephemeris()`. When getting positions and 
    velocities for Solar-system sources, it is important to use the values from the time light originated from the 
    observed body rather than at the time that light arrives to the observer. This correction was done properly for 
@@ -130,9 +133,6 @@ provided by SuperNOVAS over the upstream NOVAS C 3.1 code:
    
  - Fixes potential string overflows and eliminates associated compiler warnings.
  
- - Fixes the [ephem_close bug](https://aa.usno.navy.mil/software/novas_faq), whereby `ephem_close()` in 
-   `eph_manager.c` did not reset the `EPHFILE` pointer to NULL. This was a documented issue of NOVAS C 3.1.
-   
  - [__v1.1__] Fixes division by zero bug in `d_light()` if the first position argument is the ephemeris reference
    position (e.g. the Sun for `solsys3.c`). The bug affects for example `grav_def()`, where it effectively results in
    the gravitational deflection due to the Sun being skipped.
@@ -146,7 +146,8 @@ provided by SuperNOVAS over the upstream NOVAS C 3.1 code:
 <a name="compatibility"></a>
 ## Compatibility with NOVAS C 3.1
 
-SuperNOVAS strives to maintain API compatibility with the upstream NOVAS C 3.1 library, but not binary compatibility. 
+SuperNOVAS strives to maintain API compatibility with the upstream NOVAS C 3.1 library, but not binary (ABI) 
+compatibility. 
 
 If you have code that was written for NOVAS C 3.1, it should work with SuperNOVAS as is, without modifications. Simply 
 (re)build your application against SuperNOVAS, and you are good to go. 

--- a/include/novas.h
+++ b/include/novas.h
@@ -593,7 +593,7 @@ typedef struct {
   double promora;                   ///< [mas/yr] ICRS proper motion in right ascension
   double promodec;                  ///< [mas/yr] ICRS proper motion in declination
   double parallax;                  ///< [mas] parallax
-  double radialvelocity;            ///< [km/s] radial velocity
+  double radialvelocity;            ///< [km/s] catalog radial velocity
 } cat_entry;
 
 /**
@@ -1248,10 +1248,21 @@ double novas_radio_refraction(double jd_tt, const on_surface *loc, enum novas_re
 double novas_inv_refract(RefractionModel model, double jd_tt, const on_surface *loc, enum novas_refraction_type type, double el0);
 
 
+// ---------------------- Added in 1.2.0 -------------------------
+int make_redshifted_object(const char *name, double ra, double dec, double z, object *source);
+
+double novas_v2z(double vel);
+
+double novas_z2v(double z);
+
+
 
 // <================= END of SuperNOVAS API =====================>
 
 #include "solarsystem.h"
+
+
+
 
 
 // <================= SuperNOVAS internals ======================>

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -144,6 +144,29 @@ static int test_make_cat_object() {
   return n;
 }
 
+static int test_make_redshifted_object() {
+  object source;
+  int n = 0;
+
+  if(check("make_redshifted_object", -1, make_redshifted_object("TEST", 0.0, 0.0, 0.0, NULL))) n++;
+  if(check("make_redshifted_object:z:lo", -1, make_redshifted_object("TEST", 0.0, 0.0, -1.0, &source))) n++;
+
+  return n;
+}
+
+static int test_v2z() {
+  int n = 0;
+
+  if(check_nan("v2z:hi", novas_v2z(NOVAS_C / 1000.0 + 0.01))) n++;
+  return n;
+}
+
+static int test_z2v() {
+  int n = 0;
+
+  if(check_nan("z2v:-1", novas_z2v(-1.0))) n++;
+  return n;
+}
 
 static int test_refract() {
   on_surface o = {};
@@ -1374,6 +1397,9 @@ static int test_inv_transform() {
 int main() {
   int n = 0;
 
+  if(test_v2z()) n++;
+  if(test_z2v()) n++;
+
   if(test_make_on_surface()) n++;
   if(test_make_in_space()) n++;
   if(test_make_observer()) n++;
@@ -1381,6 +1407,7 @@ int main() {
 
   if(test_make_object()) n++;
   if(test_make_cat_object()) n++;
+  if(test_make_redshifted_object()) n++;
   if(test_make_ephem_object()) n++;
   if(test_make_planet()) n++;
   if(test_make_cat_entry()) n++;
@@ -1485,7 +1512,6 @@ int main() {
   if(test_transform_vector()) n++;
   if(test_transform_sky_pos()) n++;
   if(test_inv_transform()) n++;
-
 
   if(n) fprintf(stderr, " -- FAILED %d tests\n", n);
   else fprintf(stderr, " -- OK\n");

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -782,7 +782,7 @@ static int test_source() {
 static int test_make_planet() {
   object mars;
 
-  make_planet(NOVAS_MARS, &mars);
+  if(!is_ok("make_panet", make_planet(NOVAS_MARS, &mars))) return 1;
 
   if(!is_ok("make_planet:type", mars.type != NOVAS_PLANET)) return 1;
   if(!is_ok("make_planet:number", mars.number != NOVAS_MARS)) return 1;
@@ -1258,6 +1258,23 @@ static int test_refract_astro() {
   return 0;
 }
 
+static int test_v2z() {
+  int v;
+
+  for(v = 0.0; v < NOVAS_C; v += 10000000) {
+    char label[40];
+    double zexp = sqrt((1.0 + v / NOVAS_C) / (1.0 - v / NOVAS_C)) - 1.0;
+
+    sprintf(label, "v2z:v:%d", v);
+    if(!is_equal(label, novas_v2z(v / 1000.0), zexp, 1e-6)) return 1;
+
+    sprintf(label, "v2z:z2v:v:%d", v);
+    if(!is_equal(label, novas_z2v(zexp), v / 1000.0, 1e-6)) return 1;
+  }
+
+  return 0;
+}
+
 static int test_case() {
   object o;
 
@@ -1301,6 +1318,22 @@ static int test_make_object() {
   cat_entry c = {};
 
   if(!is_ok("make_object:name:null", make_object(NOVAS_CATALOG_OBJECT, 1, NULL, &c, &o))) return 1;
+
+  return 0;
+}
+
+static int test_make_redshifted_object() {
+  object gal;
+
+  if(!is_ok("make_redshifted_object", make_redshifted_object("test", 1.0, 2.0, 3.0, &gal))) return 1;
+
+  if(!is_ok("make_redshifted_object:type", gal.type != NOVAS_CATALOG_OBJECT)) return 1;
+  if(!is_equal("make_redshifted_object:ra", gal.star.ra, 1.0, 1e-12)) return 1;
+  if(!is_equal("make_redshifted_object:dec", gal.star.dec, 2.0, 1e-12)) return 1;
+  if(!is_equal("make_redshifted_object:rv", novas_v2z(gal.star.radialvelocity), 3.0, 1e-12)) return 1;
+  if(!is_ok("make_redshifted_object:ra", gal.star.promora != 0.0)) return 1;
+  if(!is_ok("make_redshifted_object:ra", gal.star.promodec != 0.0)) return 1;
+  if(!is_ok("make_redshifted_object:ra", gal.star.parallax != 0.0)) return 1;
 
   return 0;
 }
@@ -2036,6 +2069,10 @@ int main(int argc, char *argv[]) {
   if(test_change_observer()) n++;
   if(test_transform()) n++;
   if(test_app_hor2()) n++;
+
+  // v1.2
+  if(test_v2z()) n++;
+  if(test_make_redshifted_object()) n++;
 
   n += test_dates();
 


### PR DESCRIPTION
So far, sidereal (i.e. catalog) sources were defined with parameters typical for stars in our Galaxy. As such, motion was parametrized by radial velocity (in line of sight) , as well as proper motion. And, as a result, NOVAS did not offer proper support for handling distant quasars or galaxies, where line-of-sight motion is more typically parameterized with a redshift (z) instead.

Thus we now add:

- `novas_z2v()` to convert redshift values (z) to an equivalent radial velocity (in km/s).
- `novas_v2z()` to convert radial velocity values(in km/s) to an equivalent redshift (z).
- `make_redshifted_object()` to simplify the initialization of distant sources parameterized by redshift. It will set proper motion and parallax to zero, and initialized the source catalog to `EXT` to indicate an extragalactic source. (The user may then override the initial values, if necessary).