### PR TITLE
Separate error tracing for NAN returns

### DIFF
--- a/include/novas.h
+++ b/include/novas.h
@@ -1319,6 +1319,7 @@ double novas_inv_refract(RefractionModel model, double jd_tt, const on_surface *
 
 
 int novas_trace(const char *loc, int n, int offset);
+double novas_trace_nan(const char *loc);
 void novas_set_errno(int en, const char *from, const char *desc, ...);
 int novas_error(int ret, int en, const char *from, const char *desc, ...);
 

--- a/src/novas.c
+++ b/src/novas.c
@@ -130,6 +130,8 @@ int novas_trace(const char *loc, int n, int offset) {
  *
  * @param loc     Function [:location] where error was produced.
  * @return       NAN
+ *
+ * @since 1.1.1
  */
 double novas_trace_nan(const char *loc) {
   if(novas_get_debug_mode() != NOVAS_DEBUG_OFF) {

--- a/src/novas.c
+++ b/src/novas.c
@@ -126,6 +126,20 @@ int novas_trace(const char *loc, int n, int offset) {
 }
 
 /**
+ * (<i>for internal use</i>) Traces an error before returning NAN.
+ *
+ * @param loc     Function [:location] where error was produced.
+ * @return       NAN
+ */
+double novas_trace_nan(const char *loc) {
+  if(novas_get_debug_mode() != NOVAS_DEBUG_OFF) {
+    fprintf(stderr, "       @ %s [=> NAN]\n", loc);
+  }
+  return NAN;
+}
+
+
+/**
  * (<i>for internal use</i>) Sets an errno and report errors to the standard error, depending
  * on the current debug mode.
  *

--- a/src/refract.c
+++ b/src/refract.c
@@ -95,7 +95,7 @@ double novas_inv_refract(RefractionModel model, double jd_tt, const on_surface *
 double novas_standard_refraction(double jd_tt, const on_surface *loc, enum novas_refraction_type type, double el) {
   double dz = novas_refraction(NOVAS_STANDARD_ATMOSPHERE, loc, type, el);
   if(isnan(dz))
-    novas_trace("novas_optical_refraction", -1, 0);
+    return novas_trace_nan("novas_optical_refraction");
   return dz;
 }
 
@@ -119,7 +119,7 @@ double novas_standard_refraction(double jd_tt, const on_surface *loc, enum novas
 double novas_optical_refraction(double jd_tt, const on_surface *loc, enum novas_refraction_type type, double el) {
   double dz = novas_refraction(NOVAS_WEATHER_AT_LOCATION, loc, type, el);
   if(isnan(dz))
-    novas_trace("novas_optical_refraction", -1, 0);
+    return novas_trace_nan("novas_optical_refraction");
   return dz;
 }
 

--- a/src/super.c
+++ b/src/super.c
@@ -593,10 +593,8 @@ double cirs_to_app_ra(double jd_tt, enum novas_accuracy accuracy, double ra) {
 
   // Obtain the R.A. [h] of the CIO at the given date
   int stat = cio_ra(jd_tt, accuracy, &ra_cio);
-  if(stat) {
-    novas_trace("cirs_to_app_ra", stat, 0);
-    return NAN;
-  }
+  if(stat)
+    return novas_trace_nan("cirs_to_app_ra");
 
   // Convert CIRS R.A. to true apparent R.A., keeping the result in the [0:24] h range
   ra = remainder(ra + ra_cio, 24.0);
@@ -627,10 +625,8 @@ double app_to_cirs_ra(double jd_tt, enum novas_accuracy accuracy, double ra) {
 
   // Obtain the R.A. [h] of the CIO at the given date
   int stat = cio_ra(jd_tt, accuracy, &ra_cio);
-  if(stat) {
-    novas_trace("app_to_cirs_ra", stat, 0);
-    return NAN;
-  }
+  if(stat)
+    return novas_trace_nan("app_to_cirs_ra");
 
   // Convert CIRS R.A. to true apparent R.A., keeping the result in the [0:24] h range
   ra = remainder(ra - ra_cio, 24.0);

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -1065,6 +1065,11 @@ static int test_refraction() {
   if(check_nan("inv_refract:conv", novas_inv_refract(switching_refraction, NOVAS_JD_J2000, NULL, NOVAS_REFRACT_OBSERVED, 10.0))) n++;
   else if(check("inv_refract:conv:errno", ECANCELED, errno)) n++;
 
+  fprintf(stderr, ">>> Expecting an eror and trace...\n");
+  novas_debug(1);
+  novas_optical_refraction(NOVAS_JD_J2000, NULL, NOVAS_REFRACT_OBSERVED, 10.0);
+  novas_debug(0);
+
   return n;
 }
 


### PR DESCRIPTION
Enhance debug mode to properly report when NAN values are returned by a function in case of an error. (Previously the traces showed a 'fictional' integer value for these).