### PR TITLE
Debug error tracing fixes and tweaks

### DIFF
--- a/src/novas.c
+++ b/src/novas.c
@@ -4245,17 +4245,17 @@ double rad_vel2(const object *source, const double *pos_emit, const double *vel_
   int i;
 
   if(!source) {
-    novas_error(-1, EINVAL, fn, "NULL input source");
+    novas_set_errno(EINVAL, fn, "NULL input source");
     return NAN;
   }
 
   if(!pos_emit || !vel_src || !pos_det) {
-    novas_error(-1, EINVAL, fn, "NULL input source pos/vel: pos_emit=%p, vel_src=%p, pos_det=%p", pos_emit, vel_src, pos_det);
+    novas_set_errno(EINVAL, fn, "NULL input source pos/vel: pos_emit=%p, vel_src=%p, pos_det=%p", pos_emit, vel_src, pos_det);
     return NAN;
   }
 
   if(!vel_obs) {
-    novas_error(-1, EINVAL, fn, "NULL input observer velocity");
+    novas_set_errno(EINVAL, fn, "NULL input observer velocity");
     return NAN;
   }
 
@@ -4331,7 +4331,7 @@ double rad_vel2(const object *source, const double *pos_emit, const double *vel_
       break;
 
     default:
-      novas_error(-1, EINVAL, fn, "invalid source type: %d", source->type);
+      novas_set_errno(EINVAL, fn, "invalid source type: %d", source->type);
       return NAN;
   }
 
@@ -5113,7 +5113,7 @@ int set_cio_locator_file(const char *filename) {
   if(old)
     fclose(old);
 
-  return cio_file ? 0 : -1;
+  return cio_file ? 0 : novas_error(-1, errno, "set_cio_locator_file", "File could not be opened");
 }
 
 /**

--- a/src/novas.c
+++ b/src/novas.c
@@ -5806,7 +5806,6 @@ short transform_cat(enum novas_transform_type option, double jd_tt_in, const cat
 
   double paralx, dist, r, d, cra, sra, cdc, sdc, k;
   double pos[3], vel[3], term1, pmr, pmd, rvl, xyproj;
-  int error = 0;
 
   if(!in || !out)
     return novas_error(-1, EINVAL, fn, "NULL parameter: in=%p, out=%p", in, out);
@@ -5955,7 +5954,7 @@ short transform_cat(enum novas_transform_type option, double jd_tt_in, const cat
     out->starnumber = in->starnumber;
   }
 
-  return error;
+  return 0;
 }
 
 /**

--- a/src/novas.c
+++ b/src/novas.c
@@ -235,7 +235,7 @@ enum novas_debug_mode novas_get_debug_mode() {
 /// \cond PRIVATE
 
 /**
- * Calculates the length of a 3-vector
+ * (<i>for internal use only</i>) Calculates the length of a 3-vector
  *
  * @param v     Pointer to a 3-component (x, y, z) vector. The argument cannot be NULL
  * @return      the length of the vector
@@ -261,7 +261,7 @@ static double vdist2(const double *v1, const double *v2) {
 }
 
 /**
- * Calculates the distance between two 3-vectors.
+ * (<i>for internal use only</i>) Calculates the distance between two 3-vectors.
  *
  * @param v1    Pointer to a 3-component (x, y, z) vector. The argument cannot be NULL
  * @param v2    Pointer to another 3-component (x, y, z) vector. The argument cannot
@@ -279,7 +279,7 @@ double novas_vdist(const double *v1, const double *v2) {
 }
 
 /**
- * Calculates the dot product between two 3-vectors.
+ * (<i>for internal use only</i>) Calculates the dot product between two 3-vectors.
  *
  * @param v1    Pointer to a 3-component (x, y, z) vector. The argument cannot be NULL
  * @param v2    Pointer to another 3-component (x, y, z) vector. The argument cannot
@@ -395,14 +395,11 @@ static int time_equals(double jd1, double jd2) {
 int j2000_to_tod(double jd_tdb, enum novas_accuracy accuracy, const double *in, double *out) {
   static const char *fn = "j2000_to_tod";
 
-  if(!in || !out)
-    return novas_error(-1, EINVAL, fn, "NULL input or output 3-vector: in=%p, out=%p", in, out);
-
   if(accuracy != NOVAS_FULL_ACCURACY && accuracy != NOVAS_REDUCED_ACCURACY)
     return novas_error(-1, EINVAL, fn, "invalid accuracy: %d", accuracy);
 
-  precession(JD_J2000, in, jd_tdb, out);
-  nutation(jd_tdb, NUTATE_MEAN_TO_TRUE, accuracy, out, out);
+  prop_error(fn, precession(JD_J2000, in, jd_tdb, out), 0);
+  prop_error(fn, nutation(jd_tdb, NUTATE_MEAN_TO_TRUE, accuracy, out, out), 0);
 
   return 0;
 }
@@ -434,14 +431,11 @@ int j2000_to_tod(double jd_tdb, enum novas_accuracy accuracy, const double *in, 
 int tod_to_j2000(double jd_tdb, enum novas_accuracy accuracy, const double *in, double *out) {
   static const char *fn = "tod_to_j2000";
 
-  if(!in || !out)
-    return novas_error(-1, EINVAL, fn, "NULL input or output 3-vector: in=%p, out=%p", in, out);
-
   if(accuracy != NOVAS_FULL_ACCURACY && accuracy != NOVAS_REDUCED_ACCURACY)
     return novas_error(-1, EINVAL, fn, "invalid accuracy: %d", accuracy);
 
-  nutation(jd_tdb, NUTATE_TRUE_TO_MEAN, accuracy, in, out);
-  precession(jd_tdb, out, JD_J2000, out);
+  prop_error(fn, nutation(jd_tdb, NUTATE_TRUE_TO_MEAN, accuracy, in, out), 0);
+  prop_error(fn, precession(jd_tdb, out, JD_J2000, out), 0);
 
   return 0;
 }
@@ -3292,9 +3286,8 @@ int proper_motion(double jd_tdb_in, const double *pos, const double *vel, double
   if(!pos || !vel || !out)
     return novas_error(-1, EINVAL, "proper_motion", "NULL input or output 3-vector: pos=%p, vel=%p, out=%p", pos, vel, out);
 
-  for(j = 3; --j >= 0;) {
+  for(j = 3; --j >= 0;)
     out[j] = pos[j] + vel[j] * dt;
-  }
 
   return 0;
 }

--- a/src/readeph0.c
+++ b/src/readeph0.c
@@ -27,12 +27,12 @@ double * readeph_dummy(int mp, const char *name, double jd_tdb, int *error) {
   double *pv;
 
   if(!name || !error) {
-    set_error(-1, EINVAL, fn, "NULL parameter: name=%p, error=%p", name, error);
+    novas_set_errno(EINVAL, fn, "NULL parameter: name=%p, error=%p", name, error);
     return NULL;
   }
 
   if(isnanf(jd_tdb)) {
-    set_error(-1, EINVAL, fn, "NaN jd_tdb");
+    novas_set_errno(-1, EINVAL, fn, "NaN jd_tdb");
     *error = -1;
     return NULL;
   }

--- a/src/refract.c
+++ b/src/refract.c
@@ -24,8 +24,10 @@
 #include "novas.h"
 
 static double novas_refraction(enum novas_refraction_model model, const on_surface *loc, enum novas_refraction_type type, double el) {
+  static const char *fn = "novas_refraction";
+
   if(!loc) {
-    novas_error(-1, EINVAL, "novas_refraction", "NULL on surface observer location");
+    novas_set_errno(EINVAL, fn, "NULL on surface observer location");
     return NAN;
   }
 
@@ -35,6 +37,7 @@ static double novas_refraction(enum novas_refraction_model model, const on_surfa
   if(type == NOVAS_REFRACT_ASTROMETRIC)
     return refract_astro(loc, model, 90.0 - el);
 
+  novas_set_errno(EINVAL, fn, "NULL on surface observer location");
   return NAN;
 }
 
@@ -163,7 +166,7 @@ double novas_radio_refraction(double jd_tt, const on_surface *loc, enum novas_re
   int j;
 
   if(!loc) {
-    novas_error(-1, EINVAL, fn, "NULL on surface observer location");
+    novas_set_errno(EINVAL, fn, "NULL on surface observer location");
     return NAN;
   }
 
@@ -171,7 +174,7 @@ double novas_radio_refraction(double jd_tt, const on_surface *loc, enum novas_re
     return novas_inv_refract(novas_radio_refraction, jd_tt, loc, NOVAS_REFRACT_ASTROMETRIC, el);
 
   if(type != NOVAS_REFRACT_ASTROMETRIC) {
-    novas_error(-1, EINVAL, fn, "invalid refraction type: %d", type);
+    novas_set_errno(EINVAL, fn, "invalid refraction type: %d", type);
     return NAN;
   }
 

--- a/src/super.c
+++ b/src/super.c
@@ -379,12 +379,15 @@ int j2000_to_gcrs(const double *in, double *out) {
  * @author Attila Kovacs
  */
 int cirs_to_tod(double jd_tt, enum novas_accuracy accuracy, const double *in, double *out) {
+  static const char *fn = "cirs_to_tod";
+
   double ra_cio;  // [h] R.A. of the CIO (from the true equinox) we'll calculate
 
   // Obtain the R.A. [h] of the CIO at the given date
-  prop_error("cirs_to_tod", cio_ra(jd_tt, NOVAS_FULL_ACCURACY, &ra_cio), 0);
+  prop_error(fn, cio_ra(jd_tt, NOVAS_FULL_ACCURACY, &ra_cio), 0);
+  prop_error(fn, spin(-15.0 * ra_cio, in, out), 0);
 
-  return spin(-15.0 * ra_cio, in, out);
+  return 0;
 }
 
 /**
@@ -414,12 +417,15 @@ int cirs_to_tod(double jd_tt, enum novas_accuracy accuracy, const double *in, do
  * @author Attila Kovacs
  */
 int tod_to_cirs(double jd_tt, enum novas_accuracy accuracy, const double *in, double *out) {
+  static const char *fn = "tod_to_cirs";
+
   double ra_cio;  // [h] R.A. of the CIO (from the true equinox) we'll calculate
 
   // Obtain the R.A. [h] of the CIO at the given date
-  prop_error("tod_to_cirs", cio_ra(jd_tt, accuracy, &ra_cio), 0);
+  prop_error(fn, cio_ra(jd_tt, accuracy, &ra_cio), 0);
+  prop_error(fn, spin(15.0 * ra_cio, in, out), 0);
 
-  return spin(15.0 * ra_cio, in, out);
+  return 0;
 }
 
 

--- a/src/timescale.c
+++ b/src/timescale.c
@@ -268,7 +268,7 @@ double novas_get_split_time(const novas_timespec *time, enum novas_timescale tim
   if(ijd) *ijd = -1;
 
   if(!time) {
-    novas_error(-1, EINVAL, fn, "NULL input time specification");
+    novas_set_errno(EINVAL, fn, "NULL input time specification");
     return NAN;
   }
 
@@ -303,7 +303,7 @@ double novas_get_split_time(const novas_timespec *time, enum novas_timescale tim
       f -= time->ut1_to_tt / DAY;
       break;
     default:
-      novas_error(-1, EINVAL, fn, "Invalid timescale: %d", timescale);
+      novas_set_errno(EINVAL, fn, "Invalid timescale: %d", timescale);
       return NAN;
   }
 
@@ -340,7 +340,7 @@ double novas_get_split_time(const novas_timespec *time, enum novas_timescale tim
  */
 double novas_diff_time(const novas_timespec *t1, const novas_timespec *t2) {
   if(!t1 || !t2) {
-    novas_error(-1, EINVAL, "novas_diff_time", "NULL parameter: t1=%p, t2=%p", t1, t2);
+    novas_set_errno(EINVAL, "novas_diff_time", "NULL parameter: t1=%p, t2=%p", t1, t2);
     return NAN;
   }
 

--- a/src/timescale.c
+++ b/src/timescale.c
@@ -67,7 +67,8 @@
  * @author Attila Kovacs
  */
 int novas_set_time(enum novas_timescale timescale, double jd, int leap, double dut1, novas_timespec *time) {
-  return novas_set_split_time(timescale, 0, jd, leap, dut1, time);
+  prop_error("novas_set_time", novas_set_split_time(timescale, 0, jd, leap, dut1, time), 0);
+  return 0;
 }
 
 /**
@@ -219,6 +220,8 @@ int novas_offset_time(const novas_timespec *time, double seconds, novas_timespec
 double novas_get_time(const novas_timespec *time, enum novas_timescale timescale) {
   long ijd;
   double fjd = novas_get_split_time(time, timescale, &ijd);
+  if(isnan(fjd))
+    return novas_trace_nan("novas_get_time");
   return ijd + fjd;
 }
 
@@ -249,7 +252,8 @@ double novas_get_time(const novas_timespec *time, enum novas_timescale timescale
  *                    provided
  * @param[out] ijd    [day] The integer part of the Julian date in the requested timescale. It may
  *                    be NULL if not required.
- * @return            [day] The fractional part of the Julian date in the requested timescale.
+ * @return            [day] The fractional part of the Julian date in the requested timescale or
+ *                    NAN is the time argument is NULL.
  *
  * @sa novas_set_split_time()
  * @sa novas_get_time()
@@ -258,7 +262,7 @@ double novas_get_time(const novas_timespec *time, enum novas_timescale timescale
  * @author Attila Kovacs
  */
 double novas_get_split_time(const novas_timespec *time, enum novas_timescale timescale, long *ijd) {
-  static const char *fn = "novas_get_time";
+  static const char *fn = "novas_get_split_time";
   double f;
 
   if(!time) {
@@ -359,7 +363,10 @@ double novas_diff_time(const novas_timespec *t1, const novas_timespec *t2) {
  * @author Attila Kovacs
  */
 double novas_diff_tcb(const novas_timespec *t1, const novas_timespec *t2) {
-  return novas_diff_time(t1, t2) * (1.0 + TC_LB);
+  double dt = novas_diff_time(t1, t2) * (1.0 + TC_LB);
+  if(isnan(dt))
+    return novas_trace_nan("novas_diff_tcb");
+  return dt;
 }
 
 
@@ -383,7 +390,10 @@ double novas_diff_tcb(const novas_timespec *t1, const novas_timespec *t2) {
  * @author Attila Kovacs
  */
 double novas_diff_tcg(const novas_timespec *t1, const novas_timespec *t2) {
-  return novas_diff_time(t1, t2) * (1.0 + TC_LG);
+  double dt = novas_diff_time(t1, t2) * (1.0 + TC_LG);
+  if(isnan(dt))
+    return novas_trace_nan("novas_diff_tcg");
+  return dt;
 }
 
 /**
@@ -424,7 +434,8 @@ int novas_set_unix_time(time_t unix_time, long nanos, int leap, double dut1, nov
     jd--;
   }
 
-  return novas_set_split_time(NOVAS_UTC, jd, (sojd + 1e-9 * nanos) / DAY, leap, dut1, time);
+  prop_error("novas_set_unix_time", novas_set_split_time(NOVAS_UTC, jd, (sojd + 1e-9 * nanos) / DAY, leap, dut1, time), 0);
+  return 0;
 }
 
 /**
@@ -446,6 +457,9 @@ time_t novas_get_unix_time(const novas_timespec *time, long *nanos) {
   time_t seconds;
 
   sod = novas_get_split_time(time, NOVAS_UTC, &ijd) * DAY;
+  if(isnan(sod))
+    return novas_trace_nan("novas_get_unix_time");
+
   isod = (long) floor(sod);
   seconds = UNIX_J2000 + (ijd - IJD_J2000) * IDAY + isod;
 

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -1016,6 +1016,7 @@ static int test_obs_posvel() {
 static int test_time() {
   novas_timespec time = {};
   int n = 0;
+  long ijd = 0;
 
   if(check("time:set:time", -1, novas_set_time(NOVAS_TT, NOVAS_JD_J2000, 37, 0.11, NULL))) n++;
   if(check("time:set:scale:-1", -1, novas_set_time(-1, NOVAS_JD_J2000, 37, 0.11, &time))) n++;
@@ -1025,6 +1026,9 @@ static int test_time() {
   if(check_nan("time:get:scale:-1", novas_get_time(&time, -1))) n++;
   if(check_nan("time:get:scale:hi", novas_get_time(&time, NOVAS_TIMESCALES))) n++;
 
+  if(check("time:get_unix_time:time", -1, novas_get_unix_time(NULL, &ijd))) n++;
+  if(check("time:get_unix_time:time+ijd", -1, novas_get_unix_time(NULL, NULL))) n++;
+
   if(check("time:offset:time", -1, novas_offset_time(NULL, 0.1, &time))) n++;
   if(check("time:offset:out", -1, novas_offset_time(&time, 0.1, NULL))) n++;
   if(check("time:offset:both", -1, novas_offset_time(NULL, 0.1, NULL))) n++;
@@ -1032,6 +1036,15 @@ static int test_time() {
   if(check_nan("time:diff:t1", novas_diff_time(NULL, &time))) n++;
   if(check_nan("time:diff:t2", novas_diff_time(&time, NULL))) n++;
   if(check_nan("time:diff:both", novas_diff_time(NULL, NULL))) n++;
+
+  if(check_nan("time:diff_tcg:t1", novas_diff_tcg(NULL, &time))) n++;
+  if(check_nan("time:diff_tcg:t2", novas_diff_tcg(&time, NULL))) n++;
+  if(check_nan("time:diff_tcg:both", novas_diff_tcg(NULL, NULL))) n++;
+
+  if(check_nan("time:diff_tcb:t1", novas_diff_tcb(NULL, &time))) n++;
+  if(check_nan("time:diff_tcb:t2", novas_diff_tcb(&time, NULL))) n++;
+  if(check_nan("time:diff_tcb:both", novas_diff_tcb(NULL, NULL))) n++;
+
 
   return n;
 }
@@ -1065,7 +1078,7 @@ static int test_refraction() {
   if(check_nan("inv_refract:conv", novas_inv_refract(switching_refraction, NOVAS_JD_J2000, NULL, NOVAS_REFRACT_OBSERVED, 10.0))) n++;
   else if(check("inv_refract:conv:errno", ECANCELED, errno)) n++;
 
-  fprintf(stderr, ">>> Expecting an eror and trace...\n");
+  fprintf(stderr, ">>> Expecting an error and trace...\n");
   novas_debug(1);
   novas_optical_refraction(NOVAS_JD_J2000, NULL, NOVAS_REFRACT_OBSERVED, 10.0);
   novas_debug(0);


### PR DESCRIPTION
Incomplete error traces in:

- `tod_to_cirs()`
- `cirs_to_tod()`
- `novas_set_time()`
- `novas_get_time()`
- `novas_diff_tcb()`
- `novas_diff_tcg()`
- `novas_set_unix_time()`
- `novas_get_unix_time()`
- `novas_refraction()`

superfluous error checking (propagate instead) in:

- `j2000_to_tod()`
- `tod_to_j2000()`

Unnecessary error variable in:

- `transform_cat()`

Wrong error trace name for

- `novas_get_split_time()`

Non-existing function called in 

- `readeph_dummy()`