### PR TITLE
Initializer macros, and old-style declarations.

### DIFF
--- a/build.mk
+++ b/build.mk
@@ -15,12 +15,14 @@ $(LIB)/%.so.$(SO_VERSION) : | $(LIB) Makefile
 	$(CC) -o $@ $(CPPFLAGS) $(CFLAGS) $^ -shared -fPIC -Wl,-soname,$(subst $(LIB)/,,$@) $(LDFLAGS)
 
 # Unversioned shared libs (for linking against)
-$(LIB)/lib%.so:  | $(LIB)
+$(LIB)/lib%.so:
+	@if [ ! -e $(LIB) ] ; then mkdir $(LIB); fi
 	@rm -f $@
 	ln -sr $< $@
 
 # Static library recipe
-$(LIB)/%.a: | $(LIB) Makefile
+$(LIB)/%.a:
+	@if [ ! -e $(LIB) ] ; then mkdir $(LIB); fi
 	ar -rc $@ $^
 	ranlib $@
 

--- a/include/novas.h
+++ b/include/novas.h
@@ -611,6 +611,12 @@ typedef struct {
 } cat_entry;
 
 /**
+ * Initializer for a NOVAS cat_entry structure.
+ * @since 1.1.1
+ */
+#define CAT_ENTRY_INIT { {'\0'}, {'\0'}, 0L, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }
+
+/**
  * Celestial object of interest.
  *
  * Note, the memory footprint is different from NOVAS C due to the use of the enum vs short 'type'
@@ -652,6 +658,12 @@ typedef struct {
 } in_space;
 
 /**
+ * Initializer for a NOVAS in_space structure.
+ * @since 1.1.1
+ */
+#define IN_SPACE_INIT   {{0.0}, {0.0}}
+
+/**
  * Observer location (somewhere around Earth).
  *
  */
@@ -680,6 +692,12 @@ typedef struct {
   double dis;       ///< [AU] true (geometric, Euclidian) distance to solar system body or 0.0 for star (AU)
   double rv;        ///< [km/s] radial velocity (km/s)
 } sky_pos;
+
+/**
+ * Initializer for a NOVAS sky_pos structure.
+ * @since 1.1.1
+ */
+#define SKY_POS_INIT { {0.0}, 0.0, 0.0, 0.0, 0.0 }
 
 /**
  * Right ascension of the Celestial Intermediate Origin (CIO) with respect to the GCRS

--- a/src/frames.c
+++ b/src/frames.c
@@ -315,9 +315,8 @@ static int is_frame_initialized(const novas_frame *frame) {
 int novas_make_frame(enum novas_accuracy accuracy, const observer *obs, const novas_timespec *time, double dx, double dy,
         novas_frame *frame) {
   static const char *fn = "novas_make_frame";
-  static const cat_entry zero_star = {0};
-  static const object earth = { NOVAS_PLANET, NOVAS_EARTH, "Earth", zero_star };
-  static const object sun = { NOVAS_PLANET, NOVAS_SUN, "Sun", zero_star };
+  static const object earth = { NOVAS_PLANET, NOVAS_EARTH, "Earth", CAT_ENTRY_INIT };
+  static const object sun = { NOVAS_PLANET, NOVAS_SUN, "Sun", CAT_ENTRY_INIT };
 
   double tdb2[2];
   double mobl, tobl, ee, dpsi, deps;

--- a/src/novas.c
+++ b/src/novas.c
@@ -741,7 +741,7 @@ int place_star(double jd_tt, const cat_entry *star, const observer *obs, double 
  */
 int radec_star(double jd_tt, const cat_entry *star, const observer *obs, double ut1_to_tt, enum novas_reference_system sys,
         enum novas_accuracy accuracy, double *ra, double *dec, double *rv) {
-  sky_pos output = {0};
+  sky_pos output = SKY_POS_INIT;
 
   // Default return values in case of error.
   if(ra)
@@ -804,7 +804,7 @@ int radec_star(double jd_tt, const cat_entry *star, const observer *obs, double 
 int radec_planet(double jd_tt, const object *ss_body, const observer *obs, double ut1_to_tt, enum novas_reference_system sys,
         enum novas_accuracy accuracy, double *ra, double *dec, double *dis, double *rv) {
   static const char *fn = "radec_planet";
-  sky_pos output = {0};
+  sky_pos output = SKY_POS_INIT;
 
   // Default return values in case of error.
   if(ra)
@@ -1272,7 +1272,7 @@ short local_planet(double jd_tt, const object *ss_body, double ut1_to_tt, const 
  */
 short mean_star(double jd_tt, double tra, double tdec, enum novas_accuracy accuracy, double *ira, double *idec) {
   static const char *fn = "mean_star";
-  cat_entry star = {0};
+  cat_entry star = CAT_ENTRY_INIT;
   double pos[3];
   int iter;
 
@@ -1347,7 +1347,7 @@ short mean_star(double jd_tt, double tra, double tdec, enum novas_accuracy accur
 int obs_posvel(double jd_tdb, double ut1_to_tt, enum novas_accuracy accuracy, const observer *obs, const double *geo_pos,
         const double *geo_vel, double *pos, double *vel) {
   static const char *fn = "get_obs_posvel";
-  static const cat_entry zero_star = {0};
+  static const cat_entry zero_star = CAT_ENTRY_INIT;
 
   if(!obs)
     return novas_error(-1, EINVAL, fn, "NULL observer parameter");
@@ -3366,7 +3366,7 @@ short geo_posvel(double jd_tt, double ut1_to_tt, enum novas_accuracy accuracy, c
   static THREAD_LOCAL double t_last = 0;
   static THREAD_LOCAL enum novas_accuracy acc_last = -1;
   static THREAD_LOCAL double gast;
-  static const cat_entry zero_star = {0};
+  static const cat_entry zero_star = CAT_ENTRY_INIT;
 
   double gmst, eqeq, pos1[3], vel1[3], jd_tdb, jd_ut1;
 
@@ -3897,11 +3897,12 @@ int obs_planets(double jd_tdb, enum novas_accuracy accuracy, const double *pos_o
  */
 short grav_def(double jd_tdb, enum novas_observer_place unused, enum novas_accuracy accuracy, const double *pos_src, const double *pos_obs,
         double *out) {
-  (void) unused;
   static const char *fn = "grav_def";
 
   novas_planet_bundle planets = {0};
   int pl_mask = (accuracy == NOVAS_FULL_ACCURACY) ? grav_bodies_full_accuracy : grav_bodies_reduced_accuracy;
+
+  (void) unused;
 
   if(!pos_src || !out)
     return novas_error(-1, EINVAL, fn, "NULL source position 3-vector: pos_src=%p, out=%p", pos_src, out);

--- a/src/refract.c
+++ b/src/refract.c
@@ -96,8 +96,9 @@ double novas_inv_refract(RefractionModel model, double jd_tt, const on_surface *
  * @sa refract_astro()
  */
 double novas_standard_refraction(double jd_tt, const on_surface *loc, enum novas_refraction_type type, double el) {
-  (void) jd_tt;
   double dz = novas_refraction(NOVAS_STANDARD_ATMOSPHERE, loc, type, el);
+  (void) jd_tt;
+
   if(isnan(dz))
     return novas_trace_nan("novas_optical_refraction");
   return dz;
@@ -121,8 +122,9 @@ double novas_standard_refraction(double jd_tt, const on_surface *loc, enum novas
  * @sa refract_astro()
  */
 double novas_optical_refraction(double jd_tt, const on_surface *loc, enum novas_refraction_type type, double el) {
-  (void) jd_tt;
   double dz = novas_refraction(NOVAS_WEATHER_AT_LOCATION, loc, type, el);
+  (void) jd_tt;
+
   if(isnan(dz))
     return novas_trace_nan("novas_optical_refraction");
   return dz;
@@ -156,7 +158,6 @@ double novas_optical_refraction(double jd_tt, const on_surface *loc, enum novas_
  * @sa on_surface
  */
 double novas_radio_refraction(double jd_tt, const on_surface *loc, enum novas_refraction_type type, double el) {
-  (void) jd_tt;
   static const char *fn = "novas_radio_refraction";
   // Various coefficients...
   static const double E[] = { 0.0, 46.625, 45.375, 4.1572, 1.4468, 0.25391, 2.2716, -1.3465, -4.3877, 3.1484, 4.520, -1.8982, 0.8900 };
@@ -167,6 +168,8 @@ double novas_radio_refraction(double jd_tt, const on_surface *loc, enum novas_re
   double fptem;
   double refraction;
   int j;
+
+  (void) jd_tt;
 
   if(!loc) {
     novas_set_errno(EINVAL, fn, "NULL on surface observer location");

--- a/src/super.c
+++ b/src/super.c
@@ -1042,7 +1042,7 @@ int make_ephem_object(const char *name, long num, object *body) {
  * @author Attila Kovacs
  */
 int make_airborne_observer(const on_surface *location, const double *vel, observer *obs) {
-  in_space motion = {0};
+  in_space motion = IN_SPACE_INIT;
 
   if(!vel)
     return novas_error(-1, EINVAL, "make_airborne_observer", "NULL velocity");


### PR DESCRIPTION
Mode code style fixes:

- initializer macros (exposed with `-Wextra`)
- 'Using' unused variables after declarations (old style).
- Makefile without order-only dependencies (for older `make`).