### PR TITLE
Redshift utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,22 @@ file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
 
+Changes expected for the next bug-fix release, expected around 1 December 2024.
+
+## Added
+
+ - #57: New `novas_make_redshifted_object()` to simplify the creation of distant catalog sources that are characterized
+   with a redshift measure rather than a radial velocity value.
+
+ - #57: New generic redshift-handling functions `novas_v2z()`, `novas_z2v()`, 
+ 
+ - #58: New functions to calculate and apply additional gravitational redshift corrections for light that originates
+   near massive gravitating bodies (other than major planets, or Sun or Moon), or for observers located near massive
+   gravitating bodies (other than the Sun and Earth). The added functions are `grav_redshift()`, `redhift_vrad()`,
+   `unredshift_vrad()`, `novas_z_add()`, and `novas_z_inv()`.
+   
 
 ## [1.1.1] - 2024-10-28
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = SuperNOVAS
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v1.1
+PROJECT_NUMBER         = v1.2
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ SuperNOVAS is entirely free to use without licensing restrictions.  Its source c
 standard, and hence should be suitable for old and new platforms alike. It is light-weight and easy to use, with full 
 support for the IAU 2000/2006 standards for sub-microarcsecond position calculations.
 
-This document has been updated for the `v1.1` release.
+This document has been updated for the `v1.2` and later releases.
 
 
 ## Table of Contents

--- a/include/novas.h
+++ b/include/novas.h
@@ -607,7 +607,7 @@ typedef struct {
   double promora;                   ///< [mas/yr] ICRS proper motion in right ascension
   double promodec;                  ///< [mas/yr] ICRS proper motion in declination
   double parallax;                  ///< [mas] parallax
-  double radialvelocity;            ///< [km/s] radial velocity
+  double radialvelocity;            ///< [km/s] catalog radial velocity
 } cat_entry;
 
 /**
@@ -1280,10 +1280,21 @@ double novas_radio_refraction(double jd_tt, const on_surface *loc, enum novas_re
 double novas_inv_refract(RefractionModel model, double jd_tt, const on_surface *loc, enum novas_refraction_type type, double el0);
 
 
+// ---------------------- Added in 1.2.0 -------------------------
+int make_redshifted_object(const char *name, double ra, double dec, double z, object *source);
+
+double novas_v2z(double vel);
+
+double novas_z2v(double z);
+
+
 
 // <================= END of SuperNOVAS API =====================>
 
 #include "solarsystem.h"
+
+
+
 
 
 // <================= SuperNOVAS internals ======================>

--- a/include/novas.h
+++ b/include/novas.h
@@ -1283,18 +1283,28 @@ double novas_inv_refract(RefractionModel model, double jd_tt, const on_surface *
 // ---------------------- Added in 1.2.0 -------------------------
 int make_redshifted_object(const char *name, double ra, double dec, double z, object *source);
 
-double novas_v2z(double vel);
-
 double novas_z2v(double z);
 
+
+// in util.c
+double novas_v2z(double vel);
+
+double grav_redshift(double M_kg, double r_m);
+
+double redshift_vrad(double vrad, double z);
+
+double unredshift_vrad(double vrad, double z);
+
+double novas_z_add(double z1, double z2);
+
+double novas_z_inv(double z);
 
 
 // <================= END of SuperNOVAS API =====================>
 
+
+
 #include "solarsystem.h"
-
-
-
 
 
 // <================= SuperNOVAS internals ======================>

--- a/include/novas.h
+++ b/include/novas.h
@@ -69,7 +69,7 @@
 #define SUPERNOVAS_PATCHLEVEL     2
 
 /// Additional release information in version, e.g. "-1", or "-rc1".
-#define SUPERNOVAS_RELEASE_STRING "-devel"
+#define SUPERNOVAS_RELEASE_STRING ""
 
 /// \cond PRIVATE
 

--- a/include/novas.h
+++ b/include/novas.h
@@ -2,7 +2,7 @@
  * @file
  *
  * @author G. Kaplan and A. Kovacs
- * @version 1.1.0
+ * @version 1.2.0
  *
  *  SuperNOVAS astrometry software based on the Naval Observatory Vector Astrometry Software (NOVAS).
  *  It has been modified to fix outstanding issues and to make it easier to use.
@@ -63,13 +63,13 @@
 #define SUPERNOVAS_MAJOR_VERSION  1
 
 /// API minor version
-#define SUPERNOVAS_MINOR_VERSION  1
+#define SUPERNOVAS_MINOR_VERSION  2
 
 /// Integer sub version of the release
-#define SUPERNOVAS_PATCHLEVEL     2
+#define SUPERNOVAS_PATCHLEVEL     0
 
 /// Additional release information in version, e.g. "-1", or "-rc1".
-#define SUPERNOVAS_RELEASE_STRING ""
+#define SUPERNOVAS_RELEASE_STRING "-devel"
 
 /// \cond PRIVATE
 

--- a/src/novas.c
+++ b/src/novas.c
@@ -310,6 +310,32 @@ static double novas_add_beta(double beta1, double beta2) {
 static double novas_add_vel(double v1, double v2) {
   return novas_add_beta(v1 / C_AUDAY, v2 / C_AUDAY) * C_AUDAY;
 }
+/// \endcond
+
+
+/**
+ * Converts a radial recession velocity to a redshift value (z = &delta;f / f<sub>rest</sub>).
+ * It is based on the relativistic formula:
+ * <pre>
+ *  1 + z = sqrt((1 + &beta;) / (1 - &beta;))
+ * </pre>
+ * where &beta; = v / c.
+ *
+ * @param vel   [km/s] velocity (i.e. rate) of recession.
+ * @return      the corresponding redshift value (&delta;&lambda; / &lambda;<sub>rest</sub>), or NAN if
+ *              the input velocity is invalid (i.e., it exceeds the speed of light).
+ *
+ * @sa novas_z2v()
+ *
+ * @author Attila Kovacs
+ * @since 1.2
+ */
+double novas_v2z(double vel) {
+  vel *= 1e3 / C;   // [km/s] -> beta
+  if(fabs(vel) > 1.0)
+    return NAN;
+  return sqrt((1.0 + vel) / (1.0 - vel)) - 1.0;
+}
 
 /**
  * Converts a redshift value (z = &delta;f / f<sub>rest</sub>) to a radial velocity (i.e. rate) of recession.
@@ -323,16 +349,17 @@ static double novas_add_vel(double v1, double v2) {
  * @return    [km/s] Corresponding velocity of recession, or NAN if the input redshift is invalid, i.e. z &lt;= -1).
  *
  * @sa novas_v2z()
+ *
+ * @author Attila Kovacs
+ * @since 1.2
  */
-static double novas_z2v(double z) {
-//  if(z <= -1.0)
-//    return NAN;
+double novas_z2v(double z) {
+  if(z <= -1.0)
+    return NAN;
   z += 1.0;
   z *= z;
   return 1e-3 * (z - 1.0) / (z + 1.0) * C;
 }
-
-/// \endcond
 
 /**
  * Computationally efficient implementation of 3D rotation with small angles.
@@ -4238,6 +4265,7 @@ int rad_vel(const object *source, const double *pos_src, const double *vel_src, 
  * @sa rad_vel()
  * @sa place()
  * @sa novas_sky_pos()
+ * @sa novas_v2z()
  *
  * @since 1.1
  * @author Attila Kovacs
@@ -6350,7 +6378,7 @@ void novas_case_sensitive(int value) {
 }
 
 /**
- * Populates and object data structure using the parameters provided. By default (for
+ * Populates an object data structure using the parameters provided. By default (for
  * compatibility with NOVAS C) source names are converted to upper-case internally. You can
  * however enable case-sensitive processing by calling novas_case_sensitive() before.
  *
@@ -6371,6 +6399,7 @@ void novas_case_sensitive(int value) {
  *
  * @sa novas_case_sensitive()
  * @sa make_cat_object()
+ * @sa make_redshifted_object()
  * @sa make_planet()
  * @sa make_ephem_object()
  * @sa place()

--- a/src/novas.c
+++ b/src/novas.c
@@ -2,7 +2,7 @@
  * @file
  *
  * @author G. Kaplan and A. Kovacs
- * @version 1.1.1
+ * @version 1.2.0
  *
  *  SuperNOVAS astrometry software based on the Naval Observatory Vector Astrometry Software (NOVAS).
  *  It has been modified to fix outstanding issues and to make it easier to use.

--- a/src/super.c
+++ b/src/super.c
@@ -1118,4 +1118,158 @@ int make_solar_system_observer(const double *sc_pos, const double *sc_vel, obser
   return 0;
 }
 
+/**
+ * Converts a radial recession velocity to a redshift value (z = &delta;f / f<sub>rest</sub>).
+ * It is based on the relativistic formula:
+ * <pre>
+ *  1 + z = sqrt((1 + &beta;) / (1 - &beta;))
+ * </pre>
+ * where &beta; = v / c.
+ *
+ * @param vel   [km/s] velocity (i.e. rate) of recession.
+ * @return      the corresponding redshift value (&delta;&lambda; / &lambda;<sub>rest</sub>), or NAN if
+ *              the input velocity is invalid (i.e., it exceeds the speed of light).
+ *
+ * @sa novas_z2v()
+ * @sa novas_z_add()
+ *
+ * @author Attila Kovacs
+ * @since 1.2
+ */
+double novas_v2z(double vel) {
+  vel *= 1e3 / C;   // [km/s] -> beta
+  if(fabs(vel) > 1.0) {
+    novas_error(-1, EINVAL, "novas_v2z", "velocity exceeds speed of light v=%g km/s", 1e-3 * vel * C);
+    return NAN;
+  }
+  return sqrt((1.0 + vel) / (1.0 - vel)) - 1.0;
+}
+
+/**
+ * Returns the gravitational redshift (_z_) for light emitted near a massive spherical body
+ * at some distance from its center, and observed at some very large (infinite) distance away.
+ *
+ * @param M_kg    [kg] Mass of gravitating body that is contained inside the emitting radius.
+ * @param r_m     [m] Radius at which light is emitted.
+ * @return        The gravitational redshift (_z_) for an observer at very large  (infinite)
+ *                distance from the gravitating body.
+ *
+ * @sa redshift_vrad()
+ * @sa unredshift_vrad()
+ * @sa novas_z_add()
+ *
+ * @since 1.2
+ * @author Attila Kovacs
+ */
+double grav_redshift(double M_kg, double r_m) {
+  static const double G = 6.6743e-11; // G in SI units.
+  static const double c2 = C * C;
+
+  const double rs = 2 * G * M_kg / c2;
+
+  return 1.0 / sqrt(1.0 - rs / r_m) - 1.0;
+}
+
+/**
+ * Applies an incremental redshift correction to a radial velocity. For example, you may
+ * use this function to correct a radial velocity calculated by `rad_vel()` or `rad_vel2()`
+ * for a Solar-system body to account for the gravitational redshift for light originating
+ * at a specific distance away from the body. For the Sun, you may want to undo the redshift
+ * correction applied for the photosphere using `unredshift_vrad()` first.
+ *
+ * @param vrad    [km/s] Radial velocity
+ * @param z       Redshift correction to apply
+ * @return        [km/s] The redshift corrected radial velocity or NAN if the redshift value
+ *                is invalid (errno will be set to EINVAL).
+ *
+ * @sa unredshift_vrad()
+ * @sa grav_redshift()
+ * @sa novas_z_add()
+ *
+ * @since 1.2
+ * @author Attila Kovacs
+ */
+double redshift_vrad(double vrad, double z) {
+  static const char *fn = "redshift_vrad";
+  double z0;
+  if(z <= -1.0) {
+    novas_error(-1, EINVAL, fn, "invalid redshift value: z=%g", z);
+    return NAN;
+  }
+  z0 = novas_v2z(vrad);
+  if(isnan(z0)) novas_trace(fn, -1, 0);
+  return novas_z2v((1.0 + z0) * (1.0 + z) - 1.0);
+}
+
+/**
+ * Undoes an incremental redshift correction that was applied to radial velocity.
+ *
+ * @param vrad    [km/s] Radial velocity
+ * @param z       Redshift correction to apply
+ * @return        [km/s] The radial velocity without the redshift correction or NAN if the
+ *                redshift value is invalid. (errno will be set to EINVAL)
+ *
+ * @sa redshift_vrad()
+ * @sa grav_redshift()
+ *
+ * @since 1.2
+ * @author Attila Kovacs
+ */
+double unredshift_vrad(double vrad, double z) {
+  static const char *fn = "unredshift_vrad";
+  double z0;
+  if(z <= -1.0) {
+    novas_error(-1, EINVAL, fn, "invalid redshift value: z=%g", z);
+    return NAN;
+  }
+  z0 = novas_v2z(vrad);
+  if(isnan(z0)) novas_trace(fn, -1, 0);
+  return novas_z2v((1.0 + z0) / (1.0 + z) - 1.0);
+}
+
+/**
+ * Compounds two redshift corrections, e.g. to apply (or undo) a series gravitational redshift
+ * corrections and/or corrections for a moving observer. It's effectively using
+ * (1 + z) = (1 + z1) * (1 + z2).
+ *
+ * @param z1    One of the redshift values
+ * @param z2    The other redshift value
+ * @return      The compound redshift value, ot NAN if either input redshift is invalid (errno
+ *              will be set to EINVAL).
+ *
+ * @sa grav_redshift()
+ * @sa redshift_vrad()
+ * @sa unredshift_vrad()
+ *
+ * @since 1.2
+ * @author Attila Kovacs
+ */
+double novas_z_add(double z1, double z2) {
+  if(z1 <= -1.0 || z2 <= -1.0) {
+    novas_error(-1, EINVAL, "novas_z_add", "invalid redshift value: z1=%g, z2=%g", z1, z2);
+    return NAN;
+  }
+  return z1 + z2 + z1 * z2;
+}
+
+/**
+ * Returns the inverse of a redshift value, that is the redshift for a body moving with the same
+ * velocity as the original but in the opposite direction.
+ *
+ * @param z     A redhift value
+ * @return      The redshift value for a body moving in the opposite direction with the
+ *              same speed, or NAN if the input redshift is invalid.
+ *
+ * @sa novas_z_add()
+ *
+ * @since 1.2
+ * @author Attila Kovacs
+ */
+double novas_z_inv(double z) {
+  if(z <= -1.0) {
+    novas_error(-1, EINVAL, "novas_z_inv", "invalid redshift value: z=%g", z);
+    return NAN;
+  }
+  return 1.0 / (1.0 + z) - 1.0;
+}
 

--- a/src/super.c
+++ b/src/super.c
@@ -1021,6 +1021,42 @@ int make_ephem_object(const char *name, long num, object *body) {
 }
 
 /**
+ * Populates a celestial object data structure with the parameters for a redhifted catalog
+ * source, such as a distant quasar or galaxy. It is similar to `make_cat_object()` except
+ * that it takes a Doppler-shift (z) instead of radial velocity and it assumes no parallax
+ * and no proper motion (appropriately for a distant redshifted source). The catalog name
+ * is set to `EXT` to indicate an extragalactic source, and the catalog number defaults to 0.
+ * The user may change these default field values as appropriate afterwards, if necessary.
+ *
+ * @param name        Object name (less than SIZE_OF_OBJ_NAME in length). It may be NULL.
+ * @param ra          [h] Right ascension of the object (hours).
+ * @param dec         [deg] Declination of the object (degrees).
+ * @param z           Redhift value (&lambda;<sub>obs</sub> / &lambda;<sub>rest</sub> - 1 =
+ *                    f<sub>rest</sub> / f<sub>obs</sub> - 1).
+ * @param[out] source Pointer to structure to populate.
+ * @return            0 if successful, or 5 if 'name' is too long, else -1 if the 'source'
+ *                    pointer is NULL.
+ *
+ * @sa make_cat_object()
+ * @sa novas_v2z()
+ *
+ * @since 1.2
+ * @author Attila Kovacs
+ */
+int make_redshifted_object(const char *name, double ra, double dec, double z, object *source) {
+  static const char *fn = "make_redshifted_source";
+
+  cat_entry c;
+  double v = novas_z2v(z);
+
+  if(isnan(v))
+    return novas_error(-1, EINVAL, fn, "invalid redshift value: %f\n", z);
+
+  prop_error(fn, make_cat_entry(name, "EXT", 0, ra, dec, 0.0, 0.0, 0.0, v, &c), 0);
+  return make_cat_object(&c, source);
+}
+
+/**
  * Populates an 'observer' data structure for an observer moving relative to the surface of Earth,
  * such as an airborne observer. Airborne observers have an earth fixed momentary location,
  * defined by longitude, latitude, and altitude, the same was as for a stationary observer on

--- a/test/Makefile
+++ b/test/Makefile
@@ -32,6 +32,7 @@ cov.info:
 	geninfo . -b . -o $@
 
 .PHONY: coverage
+
 coverage: novas.c.gcov nutation.c.gcov solsys3.c.gcov super.c.gcov timescale.c.gcov refract.c.gcov frames.c.gcov
 	make clean-test
 	make cov

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -144,6 +144,29 @@ static int test_make_cat_object() {
   return n;
 }
 
+static int test_make_redshifted_object() {
+  object source;
+  int n = 0;
+
+  if(check("make_redshifted_object", -1, make_redshifted_object("TEST", 0.0, 0.0, 0.0, NULL))) n++;
+  if(check("make_redshifted_object:z:lo", -1, make_redshifted_object("TEST", 0.0, 0.0, -1.0, &source))) n++;
+
+  return n;
+}
+
+static int test_v2z() {
+  int n = 0;
+
+  if(check_nan("v2z:hi", novas_v2z(NOVAS_C / 1000.0 + 0.01))) n++;
+  return n;
+}
+
+static int test_z2v() {
+  int n = 0;
+
+  if(check_nan("z2v:-1", novas_z2v(-1.0))) n++;
+  return n;
+}
 
 static int test_refract() {
   on_surface o = {};
@@ -1392,6 +1415,9 @@ static int test_inv_transform() {
 int main() {
   int n = 0;
 
+  if(test_v2z()) n++;
+  if(test_z2v()) n++;
+
   if(test_make_on_surface()) n++;
   if(test_make_in_space()) n++;
   if(test_make_observer()) n++;
@@ -1399,6 +1425,7 @@ int main() {
 
   if(test_make_object()) n++;
   if(test_make_cat_object()) n++;
+  if(test_make_redshifted_object()) n++;
   if(test_make_ephem_object()) n++;
   if(test_make_planet()) n++;
   if(test_make_cat_entry()) n++;
@@ -1503,7 +1530,6 @@ int main() {
   if(test_transform_vector()) n++;
   if(test_transform_sky_pos()) n++;
   if(test_inv_transform()) n++;
-
 
   if(n) fprintf(stderr, " -- FAILED %d tests\n", n);
   else fprintf(stderr, " -- OK\n");

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -1412,6 +1412,36 @@ static int test_inv_transform() {
   return n;
 }
 
+static int test_redshift_vrad() {
+  int n = 0;
+
+  if(check_nan("redshift_vrad", redshift_vrad(0.0, -1.0))) n++;
+  return n;
+}
+
+static int test_unredshift_vrad() {
+  int n = 0;
+
+  if(check_nan("unredshift_vrad", unredshift_vrad(0.0, -1.0))) n++;
+  return n;
+}
+
+static int test_z_add() {
+  int n = 0;
+
+  if(check_nan("z_add:z1", novas_z_add(-1.0, 0.0))) n++;
+  if(check_nan("z_add:z2", novas_z_add(0.0, -1.0))) n++;
+  if(check_nan("z_add:z1+z2", novas_z_add(-1.0, -1.0))) n++;
+  return n;
+}
+
+static int test_z_inv() {
+  int n = 0;
+
+  if(check_nan("z_inv", novas_z_inv(-1.0))) n++;
+  return n;
+}
+
 int main() {
   int n = 0;
 
@@ -1530,6 +1560,11 @@ int main() {
   if(test_transform_vector()) n++;
   if(test_transform_sky_pos()) n++;
   if(test_inv_transform()) n++;
+
+  if(test_redshift_vrad()) n++;
+  if(test_unredshift_vrad()) n++;
+  if(test_z_add()) n++;
+  if(test_z_inv()) n++;
 
   if(n) fprintf(stderr, " -- FAILED %d tests\n", n);
   else fprintf(stderr, " -- OK\n");

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -784,7 +784,7 @@ static int test_source() {
 static int test_make_planet() {
   object mars;
 
-  make_planet(NOVAS_MARS, &mars);
+  if(!is_ok("make_panet", make_planet(NOVAS_MARS, &mars))) return 1;
 
   if(!is_ok("make_planet:type", mars.type != NOVAS_PLANET)) return 1;
   if(!is_ok("make_planet:number", mars.number != NOVAS_MARS)) return 1;
@@ -1260,6 +1260,23 @@ static int test_refract_astro() {
   return 0;
 }
 
+static int test_v2z() {
+  int v;
+
+  for(v = 0.0; v < NOVAS_C; v += 10000000) {
+    char label[40];
+    double zexp = sqrt((1.0 + v / NOVAS_C) / (1.0 - v / NOVAS_C)) - 1.0;
+
+    sprintf(label, "v2z:v:%d", v);
+    if(!is_equal(label, novas_v2z(v / 1000.0), zexp, 1e-6)) return 1;
+
+    sprintf(label, "v2z:z2v:v:%d", v);
+    if(!is_equal(label, novas_z2v(zexp), v / 1000.0, 1e-6)) return 1;
+  }
+
+  return 0;
+}
+
 static int test_case() {
   object o;
 
@@ -1303,6 +1320,22 @@ static int test_make_object() {
   cat_entry c = {};
 
   if(!is_ok("make_object:name:null", make_object(NOVAS_CATALOG_OBJECT, 1, NULL, &c, &o))) return 1;
+
+  return 0;
+}
+
+static int test_make_redshifted_object() {
+  object gal;
+
+  if(!is_ok("make_redshifted_object", make_redshifted_object("test", 1.0, 2.0, 3.0, &gal))) return 1;
+
+  if(!is_ok("make_redshifted_object:type", gal.type != NOVAS_CATALOG_OBJECT)) return 1;
+  if(!is_equal("make_redshifted_object:ra", gal.star.ra, 1.0, 1e-12)) return 1;
+  if(!is_equal("make_redshifted_object:dec", gal.star.dec, 2.0, 1e-12)) return 1;
+  if(!is_equal("make_redshifted_object:rv", novas_v2z(gal.star.radialvelocity), 3.0, 1e-12)) return 1;
+  if(!is_ok("make_redshifted_object:ra", gal.star.promora != 0.0)) return 1;
+  if(!is_ok("make_redshifted_object:ra", gal.star.promodec != 0.0)) return 1;
+  if(!is_ok("make_redshifted_object:ra", gal.star.parallax != 0.0)) return 1;
 
   return 0;
 }
@@ -2065,6 +2098,10 @@ int main(int argc, char *argv[]) {
   if(test_transform()) n++;
   if(test_app_hor2()) n++;
   if(test_rad_vel2()) n++;
+
+  // v1.2
+  if(test_v2z()) n++;
+  if(test_make_redshifted_object()) n++;
 
   n += test_dates();
 

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -2048,6 +2048,77 @@ static int test_rad_vel2() {
   return n;
 }
 
+
+static int test_grav_redshift() {
+  static const double G = 6.6743e-11; // G in SI units.
+  static const double c2 = C * C;
+
+  double M = 2e30;  // [kg]
+  double r = NOVAS_SOLAR_RADIUS;
+
+  double rs = 2 * G * M / c2;
+  double zp1 = 1.0 / sqrt(1.0 - rs / r);
+
+  int n = 0;
+
+  if(!is_equal("grav_redshift", 1.0 + grav_redshift(M, r), zp1, 1e-12)) n++;
+
+  return n;
+}
+
+static int test_redshift_vrad() {
+  double v0 = 100.0;
+  double z;
+
+  int n = 0;
+
+  for(z = -0.5; z < 3.0; z += 0.1) {
+    char label[80];
+    double v = redshift_vrad(v0, z);
+
+    sprintf(label, "redshift_vrad:z=%.1f:inv", z);
+    if(!is_equal(label, unredshift_vrad(v, z), v0, 1e-6)) n++;
+
+    sprintf(label, "redshift_vrad:z=%.1f:check", z);
+    if(!is_equal(label, 1.0 + novas_v2z(v), (1.0 + novas_v2z(v0)) * (1.0 + z), 1e-6)) n++;
+  }
+
+  return n;
+}
+
+static int test_z_add() {
+  int n = 0;
+  double z1;
+
+  for(z1 = -0.5; z1 < 5.0; z1 += 0.5) {
+    double z2;
+    for(z2 = -0.1; z2 < 1.0; z2 += 0.1) {
+      double zexp;
+
+      zexp = (1.0 + z1) * (1.0 + z2) - 1.0;
+      if(!is_equal("z_add", novas_z_add(z1, z2), zexp, 1e-12)) n++;
+    }
+  }
+  return n;
+}
+
+static int test_z_inv() {
+  int n = 0;
+  double z;
+
+  for(z = -0.5; z < 5.0; z += 0.5) {
+    char label[80];
+    double zi = novas_z_inv(z);
+
+    sprintf(label, "z_inv:z=%.1f", z);
+    if(!is_equal(label, 1.0, (1.0 + z) * (1.0 + zi), 1e-6)) n++;
+  }
+
+  return n;
+}
+
+
+
 int main(int argc, char *argv[]) {
   int n = 0;
 
@@ -2102,6 +2173,11 @@ int main(int argc, char *argv[]) {
   // v1.2
   if(test_v2z()) n++;
   if(test_make_redshifted_object()) n++;
+  if(test_z_add()) n++;
+  if(test_z_inv()) n++;
+  if(test_redshift_vrad()) n++;
+  if(test_grav_redshift()) n++;
+
 
   n += test_dates();
 


### PR DESCRIPTION
## Added

 - #57: New `novas_make_redshifted_object()` to simplify the creation of distant catalog sources that are characterized with a redshift measure rather than a radial velocity value.

 - #57: New generic redshift-handling functions `novas_v2z()`, `novas_z2v()`, 
 
 - #58: New functions to calculate and apply additional gravitational redshift corrections for light that originates near massive gravitating bodies (other than major planets, or Sun or Moon), or for observers located near massive gravitating bodies (other than the Sun and Earth). The added functions are `grav_redshift()`, `redhift_vrad()`, `unredshift_vrad()`, `novas_z_add()`, and `novas_z_inv()`.
   