### PR TITLE
Further CSPICE support, improved error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 Changes expected for the next feature release, expected around 1 February 2025.
 
-## Added
+### Added
 
  - #57: New `novas_make_redshifted_object()` to simplify the creation of distant catalog sources that are characterized
    with a redshift measure rather than a radial velocity value.
@@ -34,11 +34,12 @@ Changes expected for the next feature release, expected around 1 February 2025.
    
  - #86: NAIF CSPICE integration: `novas_use_cspice()`, `novas_use_cspice_planets()`, `novas_use_cspice_ephem()`
    to use the NAIF CSPICE library for all Solar-system sources, major planets only, or for other bodies only. 
-   `NOVAS_EPHEM_OBJECTS` should use NAIF IDs with CSPICE (or else -1 for name-based lookup). These functions are 
-   provided by the `libsolsys-cspice.so[.1]` and/or `.a` plugin libraries, which are built contingent on the 
-   `CSPICE_SUPPORT` variable being set to 1 prior to the build. The build of the plugin module requires an accessible 
-   installation of the CSPICE development files (C headers and unversioned static or shared libraries depending on the 
-   needs of the build).
+   `NOVAS_EPHEM_OBJECTS` should use NAIF IDs with CSPICE (or else -1 for name-based lookup). 
+   Also provides `novas_cspice_add_kernel()` and `novas_cspice_remove_kernel()` for convenience to manage the set of
+   active kernels (#89). These functions are provided by the `libsolsys-cspice.so[.1]` and/or `.a` plugin libraries, 
+   which are built contingent on the `CSPICE_SUPPORT` variable being set to 1 prior to the build. The build of the 
+   plugin module requires an accessible installation of the CSPICE development files (C headers and unversioned static 
+   or shared libraries depending on the needs of the build).
    
  - #87: Added `novas_planet_for_name()` function to return the NOVAS planet ID for a given (case insensitive) name.
    

--- a/README.md
+++ b/README.md
@@ -825,7 +825,8 @@ before that level of accuracy is reached.
    
  - NAIF CSPICE integration: `novas_use_cspice()`, `novas_use_cspice_planets()`, `novas_use_cspice_ephem()` to use the 
    NAIF CSPICE library for all Solar-system sources, major planets only, or for other bodies only. 
-   `NOVAS_EPHEM_OBJECTS` should use NAIF IDs with CSPICE (or else -1 for name-based lookup).
+   `NOVAS_EPHEM_OBJECTS` should use NAIF IDs with CSPICE (or else -1 for name-based lookup). Also provides
+   `novas_cspice_add_kernel()` and `novas_cspice_remove_kernel()`.
    
  - NAIF/NOVAS ID conversions for major planets (and Sun, Moon, SSB): `novas_to_naif_planet()`, 
    `novas_to_dexxx_planet()`, and `naif_to_novas_planet()`.
@@ -1000,17 +1001,20 @@ repository to help you build CSPICE with shared libraries and dynamically linked
 Here is an example on how you might use CSPICE with SuperNOVAS in your application code:
 
 ```c
-  // You can load the desired kernels for CSPICE, using the CSPICE API.
+  // You can load the desired kernels for CSPICE
   // E.g. load DE440s and the Mars satellites from /data/ephem:
-  furnsh_c("/data/ephem/de440s.bsp");
-  furnsh_c("/data/ephem/mar097.bsp");
-  ...
+  int status;
   
-  // check for CSPICE errors
-  if(return_c()) {
-    // oops, one of the kernels must not have loaded...
+  status = novas_cspice_add_kernel("/data/ephem/de440s.bsp");
+  if(status < 0) {
+    // oops, the kernels must not have loaded...
     ...
   }
+  
+  // Load additional kernels as needed...
+  status = novas_cspice_add_kernel("/data/ephem/mar097.bsp");
+  ...
+ 
   
   // Then use CSPICE as your SuperNOVAS ephemeris provider
   novas_use_cspice();

--- a/include/solarsystem.h
+++ b/include/solarsystem.h
@@ -350,7 +350,11 @@ int novas_use_cspice_ephem();
 
 int novas_use_cspice_planets();
 
-#endif /* USE_CALCEPH */
+int novas_cspice_add_kernel(const char *filename);
+
+int novas_cspice_remove_kernel(const char *filename);
+
+#endif /* USE_CSPICE */
 
 
 /// \cond PRIVATE

--- a/src/solsys-calceph.c
+++ b/src/solsys-calceph.c
@@ -202,8 +202,10 @@ static short planet_calceph_hp(const double jd_tdb[2], enum novas_planet body, e
     return novas_error(3, EAGAIN, fn, "calceph_compute() failure (NOVAS ID=%d)", body);
 
   for(i = 3; --i >= 0;) {
-    if(position) position[i] = pv[i] * NORM_POS;
-    if(velocity) velocity[i] = pv[3 + i] * NORM_VEL;
+    if(position)
+      position[i] = pv[i] * NORM_POS;
+    if(velocity)
+      velocity[i] = pv[3 + i] * NORM_VEL;
   }
 
   return 0;
@@ -334,8 +336,10 @@ static int novas_calceph(const char *name, long id, double jd_tdb_high, double j
     return novas_error(3, EAGAIN, fn, "calceph_compute() failure (name='%s', NAIF=%ld)", name ? name : "<null>", id);
 
   for(i = 3; --i >= 0;) {
-    if(pos) pos[i] = pv[i] * NORM_POS;
-    if(vel) vel[i] = pv[3 + i] * NORM_VEL;
+    if(pos)
+      pos[i] = pv[i] * NORM_POS;
+    if(vel)
+      vel[i] = pv[3 + i] * NORM_VEL;
   }
 
   return 0;


### PR DESCRIPTION
- Improved error handling, printing CSPICE short error messages when debug mode is enabled.
- Added convenience functions to manage active kernels:
  * `novas_cspice_add_kernel()`  -- wraps the CSPICE `furnsh_c()` with graceful error handling.
  * `novas_cspice_remove_kernel()`  -- wraps the CSPICE `unload_c()` with graceful error handling.