### PR TITLE
Add install target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,6 @@ on:
 jobs:
 
   build:
-    name: Build library
-
     runs-on: ubuntu-latest
     env:
       CC: gcc

--- a/.github/workflows/dox.yml
+++ b/.github/workflows/dox.yml
@@ -1,4 +1,4 @@
-name: API documentation
+name: Documentation
 
 on:
   release:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -23,9 +23,7 @@ on:
 
 jobs:
 
-  build:
-    name: Build library
-
+  install:
     runs-on: ubuntu-latest
     env:
       CC: gcc

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Test install
 
 on: 
   push:
@@ -10,7 +10,7 @@ on:
       - 'tools/src/**'
       - 'Makefile'
       - '*.mk'
-      - '.github/workflows/build.yml'
+      - '.github/workflows/install.yml'
 
   pull_request:
     paths:
@@ -19,7 +19,7 @@ on:
       - 'tools/src/**'
       - 'Makefile'
       - '*.mk'
-      - '.github/workflows/build.yml'
+      - '.github/workflows/install.yml'
 
 jobs:
 
@@ -29,18 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CC: gcc
-      CFLAGS: -Os -Wall -Wextra -Werror -std=c99
     steps:
+    - name: install doxygen
+      run: sudo apt-get install doxygen
+    
     - uses: actions/checkout@v4
 
-    - name: Build static library
-      run: make static
+    - name: Install to default location
+      run: sudo make install
 
-    - name: Build shared library
-      run: make shared
-
-    - name: Compile solsys variants
-      run: make solsys
-
-    - name: Generate CIO locator data
-      run: make cio_file

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       
       
   test-platforms:
-    name: Test on ${{ matrix.arch }}
+    name: ${{ matrix.arch }}
     # The host should always be linux
     runs-on: ubuntu-latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ Changes expected for the next feature release, expected around 1 February 2025.
    / `solarsystem_hp()` type custom planet ephemeris provider functions currently configured, so they may be used
    directly, outside of `ephemeris()` calls.
    
+ - #93: Now supporting `make install` with prefix support (e.g. `make prefix=/opt install` to install under `/opt`).
+   You can also set other standard directory variables, as prescribed in the 
+   [GNU standard](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html) to further customize the
+   install locations.
+   
    
 ## [1.1.1] - 2024-10-28
 

--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,7 @@ install-apidoc: local-dox
 	install -d $(htmldir)/search
 	install -m 644 -D apidoc/html/search/* $(htmldir)/search/
 	install -m 644 -D apidoc/html/*.* $(htmldir)/
+	@echo "installing Doxygen tag file to $(docdir)"
 	install -d $(docdir)
 	install -m 644 apidoc/supernovas.tag $(docdir)/supernovas.tag
 

--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,55 @@ Doxyfile.local: Doxyfile Makefile
 local-dox: README-orig.md Doxyfile.local
 	doxygen Doxyfile.local
 
+# Default values for install locations
+# See https://www.gnu.org/prep/standards/html_node/Directory-Variables.html 
+prefix ?= /usr
+exec_prefix ?= $(prefix)
+libdir ?= $(exec_prefix)/lib
+includedir ?= $(prefix)/include
+datarootdir ?= $(prefix)/share
+datadir ?= $(datarootdir)
+mydatadir ?= $(datadir)/supernovas
+docdir ?= $(datarootdir)/doc/supernovas
+htmldir ?= $(docdir)/html
+
+.PHONY: install
+install: install-libs install-cio-data install-headers install-apidoc install-examples
+
+.PHONY: install-libs
+install-libs: shared
+	@echo "installing libraries to $(libdir)"
+	install -d $(libdir)
+	install -m 755 -D $(LIB)/lib*.so* $(libdir)/
+
+.PHONY: install-cio-data
+install-cio-data:
+	@echo "installing CIO locator data to $(mydatadir)"
+	install -d $(mydatadir)
+	install -m 644 data/CIO_RA.TXT $(mydatadir)/CIO_RA.TXT
+
+.PHONY: install-headers
+install-headers:
+	@echo "installing headers to $(includedir)"
+	install -d $(includedir)
+	install -m 644 -D include/* $(includedir)/
+
+.PHONY: install-apidoc
+install-apidoc: local-dox
+	@echo "installing API documentation to $(htmldir)"
+	install -d $(htmldir)/search
+	install -m 644 -D apidoc/html/search/* $(htmldir)/search/
+	install -m 644 -D apidoc/html/*.* $(htmldir)/
+	install -d $(docdir)
+	install -m 644 apidoc/supernovas.tag $(docdir)/supernovas.tag
+
+.PHONY: install-examples
+install-examples:
+	@echo "installing examples to $(docdir)"
+	install -d $(docdir)
+	install -m 644 -D examples/* $(docdir)
+
+
 # Built-in help screen for `make help`
 .PHONY: help
 help:
@@ -207,6 +256,7 @@ help:
 	@echo "  test          Runs regression tests."
 	@echo "  coverage      Runs 'gcov' to analyze regression test coverage."
 	@echo "  all           All of the above."
+	@echo "  install       Install components (e.g. 'make prefix=<path> install')"
 	@echo "  clean         Removes intermediate products."
 	@echo "  distclean     Deletes all generated files."
 	@echo

--- a/README.md
+++ b/README.md
@@ -235,9 +235,17 @@ Alternatively, you can build select components of the above with the `make` targ
 respectively. And, if unsure, you can always call `make help` to see what build targets are available.
 
 After building the library you can install the above components to the desired locations on your system. For a 
-system-wide install you may place the static or shared library into `/usr/local/lib/`, copy the CIO locator file to 
-the place you specified in `config.mk` etc. You may also want to copy the header files in `include/` to e.g. 
-`/usr/local/include` so you can compile your application against SuperNOVAS easily on your system.
+system-wide install you may simply run:
+
+```bash
+  $ sudo make install
+```
+
+Or, to install in some other locations, you may set an prefix. For example to install under `/opt` instead, you can:
+
+```bash
+  $ sudo make prefix=/opt install
+```
 
 
 ### Building your application with SuperNOVAS


### PR DESCRIPTION
Adds a `install` target to the `Makefile`, using the [standard directory variables](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html), with the recommended default values. As such it can take a `prefix` argument, e.g.:

```bash
  sudo make prefix=/opt install
``` 
To install under `/opt` rather than the default `/usr` prefix.