### PR TITLE
Orbital elements based calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,14 +56,24 @@ Changes expected for the next feature release, expected around 1 February 2025.
    You can also set other standard directory variables, as prescribed in the 
    [GNU standard](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html) to further customize the
    install locations.
-   
- - SuperNOVAS headers now include each other as system-headers, not local headers. This is unlikely to affect anything
-   really but it is more proper for an installation of the library, and works with our own `Makefile` too.
+ 
+ - #95: Added support for using orbital elements. `object.type` can now be set to `NOVAS_ORBITAL_OBJECT`, whose orbit
+   can be defined by the set of `novas_orbital_elements`, within a `novas_orbital_system`. You can initialize an 
+   `object` with a set of orbital elements using `make_orbital_object()`. For such objects, `ephemeris()` will now 
+   call on the new `novas_orbit_posvel()` to calculate positions. While orbital elements do not always yield precise 
+   positions, they can for shorter periods, provided that the orbital elements are up-to-date. For example, the Minor 
+   Planer Center (MPC) publishes orbital elements for all known asteroids and comets regularly. For newly discovered 
+   objects, this may be the only and/or most accurate information available anywhere.
    
  - #97: Added `NOVAS_EMB` (Earth-Moon Barycenter) and `NOVAS_PLUTO_BARYCENTER` to `enum novas_planets` to distinguish
    from the planet center in calculations.
    
+ - SuperNOVAS headers now include each other as system-headers, not local headers. This is unlikely to affect anything
+   really but it is more proper for an installation of the library, and works with our own `Makefile` too.
+   
 ### Changed
+
+ - #96: Changed `object` structure to include `novas_orbital_elements` for `NOVAS_ORBITAL_OBJECT` types.
 
  - #97: Updated `NOVAS_PLANETS`, `NOVAS_PLANET_NAMES_INIT` and `NOVAS_RMASS_INIT` macros to include the added planet 
    constants.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,12 +58,13 @@ Changes expected for the next feature release, expected around 1 February 2025.
    install locations.
  
  - #95: Added support for using orbital elements. `object.type` can now be set to `NOVAS_ORBITAL_OBJECT`, whose orbit
-   can be defined by the set of `novas_orbital_elements`, within a `novas_orbital_system`. You can initialize an 
-   `object` with a set of orbital elements using `make_orbital_object()`. For such objects, `ephemeris()` will now 
-   call on the new `novas_orbit_posvel()` to calculate positions. While orbital elements do not always yield precise 
-   positions, they can for shorter periods, provided that the orbital elements are up-to-date. For example, the Minor 
-   Planer Center (MPC) publishes orbital elements for all known asteroids and comets regularly. For newly discovered 
-   objects, this may be the only and/or most accurate information available anywhere.
+   can be defined by the set of `novas_orbital_elements`, relative to a `novas_orbital_system`. You can initialize an 
+   `object` with a set of orbital elements using `make_orbital_object()`, and for planetary satellite orbits you might
+   use `novas_set_orbital_pole()`. For orbital objects, `ephemeris()` will call on the new `novas_orbit_posvel()` to 
+   calculate positions. While orbital elements do not always yield precise positions, they can for shorter periods, 
+   provided that the orbital elements are up-to-date. For example, the Minor Planer Center (MPC) publishes accurate 
+   orbital elements for all known asteroids and comets regularly. For newly discovered objects, this may be the only 
+   and/or most accurate information available anywhere.
    
  - #97: Added `NOVAS_EMB` (Earth-Moon Barycenter) and `NOVAS_PLUTO_BARYCENTER` to `enum novas_planets` to distinguish
    from the planet center in calculations.

--- a/README.md
+++ b/README.md
@@ -596,6 +596,24 @@ more generic ephemeris handling via a user-provided `novas_ephem_provider`. E.g.
  make_ephem_object("Ceres", 2000001, &ceres);
 ```
 
+As of version 1.2 you can also define solar system sources with orbital elements (such as the most up-to-date ones 
+provided by the [Minor Planet Center](https://minorplanetcenter.net/data) for asteroids, comets, etc.):
+
+```c
+  object NEA;		// e.g. a Near-Earth Asteroid
+  
+  // Fill in the orbital parameters (pay attention to units!)
+  novas_orbital_elements orbit = NOVAS_ORBIT_INIT;
+  orbit.a = ...;
+  ...
+  
+  // Create an object for that orbit
+  make_orbital_object("NEAxxx", -1, &orbit, object);
+```
+
+Note, that even with orbital elements, you will, in general, require a planet calculator, to provide precise
+positions for the Sun or planet, around which the orbit is defined.
+
 Other than that, it's the same spiel as before, e.g.:
 
 ```c
@@ -893,6 +911,14 @@ before that level of accuracy is reached.
  - Access to custom ephemeris provider functions: `get_planet_provider()` and `get_planet_provider_hp()`.
 
  - Added `novas_planet_for_name()` function to return the NOVAS planet ID for a given (case insensitive) name.
+
+ - Added support for using orbital elements. `object.type` can now be set to `NOVAS_ORBITAL_OBJECT`, whose orbit
+   can be defined by the set of `novas_orbital_elements`, within a `novas_orbital_system`. You can initialize an 
+   `object` with a set of orbital elements using `make_orbital_object()`. For such objects, `ephemeris()` will now 
+   call on the new `novas_orbit_posvel()` to calculate positions. While orbital elements do not always yield precise 
+   positions, they can for shorter periods, provided that the orbital elements are up-to-date. For example, the Minor 
+   Planer Center (MPC) publishes orbital elements for all known asteroids and comets regularly. For newly discovered 
+   objects, this may be the only and/or most accurate information available anywhere.
 
  - Added `NOVAS_EMB` (Earth-Moon Barycenter) and `NOVAS_PLUTO_BARYCENTER` to `enum novas_planets` to distinguish
    from the corresponding planet centers in calculations.

--- a/README.md
+++ b/README.md
@@ -913,12 +913,13 @@ before that level of accuracy is reached.
  - Added `novas_planet_for_name()` function to return the NOVAS planet ID for a given (case insensitive) name.
 
  - Added support for using orbital elements. `object.type` can now be set to `NOVAS_ORBITAL_OBJECT`, whose orbit
-   can be defined by the set of `novas_orbital_elements`, within a `novas_orbital_system`. You can initialize an 
-   `object` with a set of orbital elements using `make_orbital_object()`. For such objects, `ephemeris()` will now 
-   call on the new `novas_orbit_posvel()` to calculate positions. While orbital elements do not always yield precise 
-   positions, they can for shorter periods, provided that the orbital elements are up-to-date. For example, the Minor 
-   Planer Center (MPC) publishes orbital elements for all known asteroids and comets regularly. For newly discovered 
-   objects, this may be the only and/or most accurate information available anywhere.
+   can be defined by the set of `novas_orbital_elements`, relative to a `novas_orbital_system`. You can initialize an 
+   `object` with a set of orbital elements using `make_orbital_object()`, and for planetary satellite orbits you might
+   use `novas_set_orbital_pole()`. For orbital objects, `ephemeris()` will call on the new `novas_orbit_posvel()` to 
+   calculate positions. While orbital elements do not always yield precise positions, they can for shorter periods, 
+   provided that the orbital elements are up-to-date. For example, the Minor Planer Center (MPC) publishes accurate 
+   orbital elements for all known asteroids and comets regularly. For newly discovered objects, this may be the only 
+   and/or most accurate information available anywhere.
 
  - Added `NOVAS_EMB` (Earth-Moon Barycenter) and `NOVAS_PLUTO_BARYCENTER` to `enum novas_planets` to distinguish
    from the corresponding planet centers in calculations.

--- a/include/novas.h
+++ b/include/novas.h
@@ -584,6 +584,16 @@ enum novas_nutation_direction {
 };
 
 /**
+ * The plane in which values, such as orbital parameyters are referenced.
+ *
+ * @since 1.2
+ */
+enum novas_reference_plane {
+  NOVAS_ECLIPTIC_PLANE = 0,     ///< the plane of the ecliptic
+  NOVAS_EQUATORIAL_PLANE        ///< The plane of the equator
+};
+
+/**
  * Fundamental Delaunay arguments of the Sun and Moon, from Simon section 3.4(b.3),
  * precession = 5028.8200 arcsec/cy)
  *
@@ -638,7 +648,9 @@ typedef struct {
  * @sa enum NOVAS_ORBITAL_OBJECT
  */
 typedef struct {
-  enum novas_planet center;         ///< major body at orbital center (default is NOVAS_SUN).
+  enum novas_planet center;         ///< major body at the center of the orbit (default is NOVAS_SUN).
+  enum novas_reference_plane plane; ///< Reference plane NOVAS_ECLIPTIC_PLANE (0) or NOVAS_EQUATORIAL_PLANE (1)
+  enum novas_equator_type sys;      ///< The type of equator to which coordinates are referenced (true, mean, or GCRS).
   double jd_tdb;                    ///< [day] Barycentri Dynamical Time (TDB) based Julian date of parameters.
   double a;                         ///< [AU] semi-major axis
   double e;                         ///< eccentricity
@@ -646,7 +658,7 @@ typedef struct {
   double Omega;                     ///< [rad] argument of ascending node
   double i;                         ///< [rad] inclination
   double M0;                        ///< [rad] mean anomaly at tjd
-  double n;                         ///< [rad/day] mean daily motion
+  double n;                         ///< [rad/day] mean daily motion, i.e. (_GM_/_a_<sup>3</sup>)<sup>1/2</sup> for the central body
 } novas_orbital_elements;
 
 /**
@@ -655,7 +667,7 @@ typedef struct {
  * @author Attila Kovacs
  * @since 1.2
  */
-#define NOVAS_ORBIT_INIT { NOVAS_SUN, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }
+#define NOVAS_ORBIT_INIT { NOVAS_SUN, NOVAS_ECLIPTIC_PLANE, NOVAS_GCRS_EQUATOR, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }
 
 /**
  * Celestial object of interest.
@@ -1340,6 +1352,10 @@ double novas_z_add(double z1, double z2);
 double novas_z_inv(double z);
 
 enum novas_planet novas_planet_for_name(const char *name);
+
+int make_orbital_object(const char *name, long num, const novas_orbital_elements *orbit, object *body);
+
+int novas_orbit_posvel(double jd_tdb, const novas_orbital_elements *orb, enum novas_accuracy accuracy, double *pos, double *vel);
 
 
 // <================= END of SuperNOVAS API =====================>

--- a/include/novas.h
+++ b/include/novas.h
@@ -640,8 +640,8 @@ typedef struct {
 
 /**
  * Specification of an orbital system, in which orbital elements are defined. Systems can be defined around
- * all major planets (and Sun, Moon, SSB). They may be referenced to the GCRS, mean, or true equator or ecliptic
- * of date, or to a plane that is tilted relative to that.
+ * all major planets and barycenters (and Sun, Moon, SSB..). They may be referenced to the GCRS, mean, or true equator
+ * or ecliptic of date, or to a plane that is tilted relative to that.
  *
  * For example, The Minor Planet Center (MPC) publishes up-to-date orbital elements for asteroids and comets,
  * which are heliocentric and referenced to the GCRS ecliptic. Hence 'center' for these is `NOVAS_SUN`, the `plane`
@@ -649,10 +649,11 @@ typedef struct {
  *
  * The orbits of planetary satellites may be parametrized in their local Laplace planes, which are typically close
  * to the host planet's equatorial planes. You can, for example, obtain the RA/Dec orientation of the planetary
- * North poles of planets from JPL Horizons, and use them as a proxy for the Laplace planes of their satellite orbits.
+ * North poles of planets from JPL Horizons, and use them as a proxy for the Laplace planes for their satellite orbits.
  * In this case you would set the `center` to the host planet (e.g. `NOVAS_SATURN`), the reference plane to
- * `NOVAS_EQUATORIAL_PLANE` and the `type` to `NOVAS_GCRS_EQUATOR` (since the equator's orientation is defined in
- * GCRS equatorial RA/Dec). The obliquity is then 90&deg; - Dec (in radians), and `phi` is RA (in radians).
+ * `NOVAS_EQUATORIAL_PLANE` and the `type` to `NOVAS_GCRS_EQUATOR` (since the plane is defined by the North pole
+ * orientation in GCRS equatorial RA/Dec). The obliquity is then 90&deg; - Dec<sub>pole</sub> (in radians), and `phi`
+ * is RA<sub>pole</sub> (in radians).
  *
  * @author Attila Kovacs
  * @since 1.2
@@ -660,11 +661,11 @@ typedef struct {
  * @sa novas_orbital_elements
  */
 typedef struct {
-  enum novas_planet center;          ///< major body at the center of the orbit (default is NOVAS_SUN).
+  enum novas_planet center;          ///< major planet or barycenter at the center of the orbit (default is NOVAS_SUN).
   enum novas_reference_plane plane;  ///< reference plane NOVAS_ECLIPTIC_PLANE (default) or NOVAS_EQUATORIAL_PLANE
   enum novas_equator_type type;      ///< the type of equator in which orientation is referenced (true, mean, or GCRS [default]).
-  double obl;                        ///< [rad] obliquity of orbital reference plane (e.g. 90&deg; - Dec<sub>pole</sub>)
-  double Omega;                      ///< [rad] argument of ascending node of the orbital reference plane (e.g. RA<sub>pole</sub>)
+  double obl;                        ///< [rad] relative obliquity of orbital reference plane (e.g. 90&deg; - Dec<sub>pole</sub>)
+  double Omega;                      ///< [rad] relative argument of ascending node of the orbital reference plane (e.g. RA<sub>pole</sub>)
 } novas_orbital_system;
 
 
@@ -702,8 +703,8 @@ typedef struct {
  * @sa enum NOVAS_ORBITAL_OBJECT
  */
 typedef struct {
-  novas_orbital_system system;      ///< orbital reference system assumed for the paramtetrization
-  double jd_tdb;                    ///< [day] Barycentri Dynamical Time (TDB) based Julian date of parameters.
+  novas_orbital_system system;      ///< orbital reference system assumed for the parametrization
+  double jd_tdb;                    ///< [day] Barycentri Dynamical Time (TDB) based Julian date of the parameters.
   double a;                         ///< [AU] semi-major axis
   double e;                         ///< eccentricity
   double omega;                     ///< [rad] argument of periapsis / perihelion
@@ -714,7 +715,7 @@ typedef struct {
 } novas_orbital_elements;
 
 /**
- * Initializer for novas_orbital_elements for heliocentric orbits
+ * Initializer for novas_orbital_elements for heliocentric orbits using GCRS ecliptic pqrametrization.
  *
  * @author Attila Kovacs
  * @since 1.2

--- a/include/novas.h
+++ b/include/novas.h
@@ -708,12 +708,14 @@ typedef struct {
   double jd_tdb;                    ///< [day] Barycentri Dynamical Time (TDB) based Julian date of the parameters.
   double a;                         ///< [AU] semi-major axis
   double e;                         ///< eccentricity
-  double omega;                     ///< [rad] argument of periapsis / perihelion, at the reference time
-  double Omega;                     ///< [rad] argument of ascending node, at the reference time
-  double i;                         ///< [rad] inclination
-  double M0;                        ///< [rad] mean anomaly at tjd
-  double n;                         ///< [rad/day] mean daily motion, i.e. (_GM_/_a_<sup>3</sup>)<sup>1/2</sup> for the central body,
-                                    ///< or 2&pi;/T, where T is orbital period in days.
+  double omega;                     ///< [deg] argument of periapsis / perihelion, at the reference time
+  double Omega;                     ///< [deg] argument of ascending node on the reference plane, at the reference time
+  double i;                         ///< [deg] inclination of orbit to reference plane
+  double M0;                        ///< [deg] mean anomaly at tjd
+  double n;                         ///< [deg/day] mean daily motion, i.e. (_GM_/_a_<sup>3</sup>)<sup>1/2</sup> for the central body,
+                                    ///< or 360/T, where T is orbital period in days.
+  double apsis_period;              ///< [day] Precession period of the apsis, if known.
+  double node_period;               ///< [day] Precession period of the ascending node, if known.
 } novas_orbital_elements;
 
 /**
@@ -722,7 +724,7 @@ typedef struct {
  * @author Attila Kovacs
  * @since 1.2
  */
-#define NOVAS_ORBIT_INIT { NOVAS_ORBITAL_SYSTEM_INIT, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }
+#define NOVAS_ORBIT_INIT { NOVAS_ORBITAL_SYSTEM_INIT, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }
 
 /**
  * Celestial object of interest.

--- a/include/novas.h
+++ b/include/novas.h
@@ -639,7 +639,61 @@ typedef struct {
 #define CAT_ENTRY_INIT { {'\0'}, {'\0'}, 0L, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }
 
 /**
- * Orbital elements for NOVAS_ORBITAL_OBJECT type.
+ * Specification of an orbital system, in which orbital elements are defined. Systems can be defined around
+ * all major planets (and Sun, Moon, SSB). They may be referenced to the GCRS, mean, or true equator or ecliptic
+ * of date, or to a plane that is tilted relative to that.
+ *
+ * For example, The Minor Planet Center (MPC) publishes up-to-date orbital elements for asteroids and comets,
+ * which are heliocentric and referenced to the GCRS ecliptic. Hence 'center' for these is `NOVAS_SUN`, the `plane`
+ * is `NOVAS_ECLIPTIC_PLANE` and the `type` is `NOVAS_GCRS_EQUATOR`.
+ *
+ * The orbits of planetary satellites may be parametrized in their local Laplace planes, which are typically close
+ * to the host planet's equatorial planes. You can, for example, obtain the RA/Dec orientation of the planetary
+ * North poles of planets from JPL Horizons, and use them as a proxy for the Laplace planes of their satellite orbits.
+ * In this case you would set the `center` to the host planet (e.g. `NOVAS_SATURN`), the reference plane to
+ * `NOVAS_EQUATORIAL_PLANE` and the `type` to `NOVAS_GCRS_EQUATOR` (since the equator's orientation is defined in
+ * GCRS equatorial RA/Dec). The obliquity is then 90&deg; - Dec (in radians), and `phi` is RA (in radians).
+ *
+ * @author Attila Kovacs
+ * @since 1.2
+ *
+ * @sa novas_orbital_elements
+ */
+typedef struct {
+  enum novas_planet center;          ///< major body at the center of the orbit (default is NOVAS_SUN).
+  enum novas_reference_plane plane;  ///< reference plane NOVAS_ECLIPTIC_PLANE (default) or NOVAS_EQUATORIAL_PLANE
+  enum novas_equator_type type;      ///< the type of equator in which orientation is referenced (true, mean, or GCRS [default]).
+  double obl;                        ///< [rad] obliquity of orbital reference plane (e.g. 90&deg; - Dec<sub>pole</sub>)
+  double Omega;                      ///< [rad] argument of ascending node of the orbital reference plane (e.g. RA<sub>pole</sub>)
+} novas_orbital_system;
+
+
+/// Default orbital system initializer for heliocentric GCRS ecliptic orbits.
+/// @since 1.2
+#define NOVAS_ORBITAL_SYSTEM_INIT { NOVAS_SUN, NOVAS_ECLIPTIC_PLANE, NOVAS_GCRS_EQUATOR, 0.0, 0.0 }
+
+/**
+ * Orbital elements for `NOVAS_ORBITAL_OBJECT` type. Orbital elements can be used to provide approximate
+ * positions for various Solar-system bodies. JPL publishes orbital parameters for the major planets and
+ * their satellites. However, these are suitable only for very approximate calculations, with up to
+ * degree scale errors for the gas giants for the time range between 1850 AD and 2050 AD. Accurate
+ * positions and velocities for planets and their satellites should generally require the use of precise
+ * ephemeris data instead, such as obtained from the JPL Horizons system.
+ *
+ * Orbital elements descrive motion from a purely Keplerian perspective. However, for short periods, for
+ * which the perturbing bodies can be ignored, this description can be quite accurate provided that an
+ * up-to-date set of values are used. The Minor Planet Center (MPC) thus regularly publishes orbital
+ * elements for all known asteroids and comets. For such objects, orbital elements can offer precise, and
+ * the most up-to-date positions and velocities.
+ *
+ * REFERENCES:
+ * <ol>
+ * <li>Up-to-date orbital elements for asteroids, comets, etc from the Minor Planet Center (MPC):
+ * https://minorplanetcenter.net/data</li>
+ * <li>Mean elements for planetary satellites from JPL Horizons: https://ssd.jpl.nasa.gov/sats/elem/</li>
+ * <li>Low accuracy mean elements for planets from JPL Horizons:
+ * https://ssd.jpl.nasa.gov/planets/approx_pos.html</li>
+ * </ol>
  *
  * @author Attila Kovacs
  * @since 1.2
@@ -648,9 +702,7 @@ typedef struct {
  * @sa enum NOVAS_ORBITAL_OBJECT
  */
 typedef struct {
-  enum novas_planet center;         ///< major body at the center of the orbit (default is NOVAS_SUN).
-  enum novas_reference_plane plane; ///< Reference plane NOVAS_ECLIPTIC_PLANE (0) or NOVAS_EQUATORIAL_PLANE (1)
-  enum novas_equator_type sys;      ///< The type of equator to which coordinates are referenced (true, mean, or GCRS).
+  novas_orbital_system system;      ///< orbital reference system assumed for the paramtetrization
   double jd_tdb;                    ///< [day] Barycentri Dynamical Time (TDB) based Julian date of parameters.
   double a;                         ///< [AU] semi-major axis
   double e;                         ///< eccentricity
@@ -667,7 +719,7 @@ typedef struct {
  * @author Attila Kovacs
  * @since 1.2
  */
-#define NOVAS_ORBIT_INIT { NOVAS_SUN, NOVAS_ECLIPTIC_PLANE, NOVAS_GCRS_EQUATOR, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }
+#define NOVAS_ORBIT_INIT { NOVAS_ORBITAL_SYSTEM_INIT, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }
 
 /**
  * Celestial object of interest.

--- a/include/novas.h
+++ b/include/novas.h
@@ -246,11 +246,17 @@ enum novas_object_type {
 
   /// Any non-solar system object that may be handled via 'catalog' coordinates, such as a star
   /// or a quasar.
-  NOVAS_CATALOG_OBJECT
+  /// @sa cat_entry
+  NOVAS_CATALOG_OBJECT,
+
+  /// Any Solar-system body, whose position is determined by a set of orbital elements
+  /// @since 1.2
+  /// @sa novas_orbital_elements
+  NOVAS_ORBITAL_OBJECT
 };
 
 /// The number of object types distinguished by NOVAS.
-#define NOVAS_OBJECT_TYPES      (NOVAS_CATALOG_OBJECT + 1)
+#define NOVAS_OBJECT_TYPES      (NOVAS_ORBITAL_OBJECT + 1)
 
 /**
  * Enumeration for the 'major planet' numbers in NOVAS to use as the solar-system body number whenever
@@ -623,6 +629,35 @@ typedef struct {
 #define CAT_ENTRY_INIT { {'\0'}, {'\0'}, 0L, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }
 
 /**
+ * Orbital elements for NOVAS_ORBITAL_OBJECT type.
+ *
+ * @author Attila Kovacs
+ * @since 1.2
+ *
+ * @sa object
+ * @sa enum NOVAS_ORBITAL_OBJECT
+ */
+typedef struct {
+  enum novas_planet center;         ///< major body at orbital center (default is NOVAS_SUN).
+  double jd_tdb;                    ///< [day] Barycentri Dynamical Time (TDB) based Julian date of parameters.
+  double a;                         ///< [AU] semi-major axis
+  double e;                         ///< eccentricity
+  double omega;                     ///< [rad] argument of periapsis / perihelion
+  double Omega;                     ///< [rad] argument of ascending node
+  double i;                         ///< [rad] inclination
+  double M0;                        ///< [rad] mean anomaly at tjd
+  double n;                         ///< [rad/day] mean daily motion
+} novas_orbital_elements;
+
+/**
+ * Initializer for novas_orbital_elements for heliocentric orbits
+ *
+ * @author Attila Kovacs
+ * @since 1.2
+ */
+#define NOVAS_ORBIT_INIT { NOVAS_SUN, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }
+
+/**
  * Celestial object of interest.
  *
  * Note, the memory footprint is different from NOVAS C due to the use of the enum vs short 'type'
@@ -633,7 +668,8 @@ typedef struct {
   enum novas_object_type type;    ///< NOVAS object type
   long number;                    ///< enum novas_planet, or minor planet ID (e.g. NAIF), or star catalog ID.
   char name[SIZE_OF_OBJ_NAME];    ///< name of the object (0-terminated)
-  cat_entry star;                 ///< basic astrometric data for any 'catalog' object.
+  cat_entry star;                 ///< basic astrometric data for NOVAS_CATALOG_OBJECT type.
+  novas_orbital_elements orbit;   ///< orbital data for NOVAS_ORBITAL_OBJECT TYPE
 } object;
 
 /**

--- a/include/novas.h
+++ b/include/novas.h
@@ -48,7 +48,6 @@
 // for compiling your code, which may have relied on these, you can add '-DCOMPAT=1' to the
 // compiler options
 //
-//
 #if COMPAT
 #  include <stdio.h>
 #  include <ctype.h>
@@ -664,8 +663,10 @@ typedef struct {
   enum novas_planet center;          ///< major planet or barycenter at the center of the orbit (default is NOVAS_SUN).
   enum novas_reference_plane plane;  ///< reference plane NOVAS_ECLIPTIC_PLANE (default) or NOVAS_EQUATORIAL_PLANE
   enum novas_equator_type type;      ///< the type of equator in which orientation is referenced (true, mean, or GCRS [default]).
-  double obl;                        ///< [rad] relative obliquity of orbital reference plane (e.g. 90&deg; - Dec<sub>pole</sub>)
-  double Omega;                      ///< [rad] relative argument of ascending node of the orbital reference plane (e.g. RA<sub>pole</sub>)
+  double obl;                        ///< [rad] relative obliquity of orbital reference plane
+                                     ///< (e.g. 90&deg; - &delta;<sub>pole</sub>)
+  double Omega;                      ///< [rad] relative argument of ascending node of the orbital reference plane
+                                     ///< (e.g. &alpha;<sub>pole</sub> + 90&deg;)
 } novas_orbital_system;
 
 
@@ -674,14 +675,14 @@ typedef struct {
 #define NOVAS_ORBITAL_SYSTEM_INIT { NOVAS_SUN, NOVAS_ECLIPTIC_PLANE, NOVAS_GCRS_EQUATOR, 0.0, 0.0 }
 
 /**
- * Orbital elements for `NOVAS_ORBITAL_OBJECT` type. Orbital elements can be used to provide approximate
- * positions for various Solar-system bodies. JPL publishes orbital parameters for the major planets and
- * their satellites. However, these are suitable only for very approximate calculations, with up to
- * degree scale errors for the gas giants for the time range between 1850 AD and 2050 AD. Accurate
- * positions and velocities for planets and their satellites should generally require the use of precise
- * ephemeris data instead, such as obtained from the JPL Horizons system.
+ * Keplerian orbital elements for `NOVAS_ORBITAL_OBJECT` type. Orbital elements can be used to provide
+ * approximate positions for various Solar-system bodies. JPL publishes orbital elements (and their evolution)
+ * for the major planets and their satellites. However, these are suitable only for very approximate
+ * calculations, with up to degree scale errors for the gas giants for the time range between 1850 AD and
+ * 2050 AD. Accurate positions and velocities for planets and their satellites should generally require the
+ * use of precise ephemeris data instead, such as obtained from the JPL Horizons system.
  *
- * Orbital elements descrive motion from a purely Keplerian perspective. However, for short periods, for
+ * Orbital elements describe motion from a purely Keplerian perspective. However, for short periods, for
  * which the perturbing bodies can be ignored, this description can be quite accurate provided that an
  * up-to-date set of values are used. The Minor Planet Center (MPC) thus regularly publishes orbital
  * elements for all known asteroids and comets. For such objects, orbital elements can offer precise, and
@@ -707,11 +708,12 @@ typedef struct {
   double jd_tdb;                    ///< [day] Barycentri Dynamical Time (TDB) based Julian date of the parameters.
   double a;                         ///< [AU] semi-major axis
   double e;                         ///< eccentricity
-  double omega;                     ///< [rad] argument of periapsis / perihelion
-  double Omega;                     ///< [rad] argument of ascending node
+  double omega;                     ///< [rad] argument of periapsis / perihelion, at the reference time
+  double Omega;                     ///< [rad] argument of ascending node, at the reference time
   double i;                         ///< [rad] inclination
   double M0;                        ///< [rad] mean anomaly at tjd
-  double n;                         ///< [rad/day] mean daily motion, i.e. (_GM_/_a_<sup>3</sup>)<sup>1/2</sup> for the central body
+  double n;                         ///< [rad/day] mean daily motion, i.e. (_GM_/_a_<sup>3</sup>)<sup>1/2</sup> for the central body,
+                                    ///< or 2&pi;/T, where T is orbital period in days.
 } novas_orbital_elements;
 
 /**
@@ -1405,6 +1407,8 @@ double novas_z_add(double z1, double z2);
 double novas_z_inv(double z);
 
 enum novas_planet novas_planet_for_name(const char *name);
+
+int novas_set_orbital_pole(double ra, double dec, novas_orbital_system *sys);
 
 int make_orbital_object(const char *name, long num, const novas_orbital_elements *orbit, object *body);
 

--- a/include/novas.h
+++ b/include/novas.h
@@ -376,6 +376,10 @@ enum novas_equator_type {
   NOVAS_GCRS_EQUATOR      ///< Geocentric Celestial Reference System (GCRS).
 };
 
+/// The number of equator types we define.
+/// @since 1.2
+#define NOVAS_EQUATOR_TYPES (NOVAS_GCRS_EQUATOR + 1)
+
 /**
  * Constants that determine the type of dynamical system type for gcrs2equ()
  */
@@ -660,13 +664,14 @@ typedef struct {
  * @sa novas_orbital_elements
  */
 typedef struct {
-  enum novas_planet center;          ///< major planet or barycenter at the center of the orbit (default is NOVAS_SUN).
-  enum novas_reference_plane plane;  ///< reference plane NOVAS_ECLIPTIC_PLANE (default) or NOVAS_EQUATORIAL_PLANE
-  enum novas_equator_type type;      ///< the type of equator in which orientation is referenced (true, mean, or GCRS [default]).
+  enum novas_planet center;          ///< major planet or barycenter at the center of the orbit.
+  enum novas_reference_plane plane;  ///< reference plane NOVAS_ECLIPTIC_PLANE or NOVAS_EQUATORIAL_PLANE
+  enum novas_equator_type type;      ///< the type of equator in which orientation is referenced (NOVAS_TRUE_EQUATOR,
+                                     ///< NOVAS_MEAN_EQUATOR, or NOVAS_GCRS_EQUATOR).
   double obl;                        ///< [rad] relative obliquity of orbital reference plane
-                                     ///< (e.g. 90&deg; - &delta;<sub>pole</sub>)
+                                     ///<       (e.g. 90&deg; - &delta;<sub>pole</sub>)
   double Omega;                      ///< [rad] relative argument of ascending node of the orbital reference plane
-                                     ///< (e.g. &alpha;<sub>pole</sub> + 90&deg;)
+                                     ///<       (e.g. &alpha;<sub>pole</sub> + 90&deg;)
 } novas_orbital_system;
 
 
@@ -710,8 +715,8 @@ typedef struct {
   double e;                         ///< eccentricity
   double omega;                     ///< [deg] argument of periapsis / perihelion, at the reference time
   double Omega;                     ///< [deg] argument of ascending node on the reference plane, at the reference time
-  double i;                         ///< [deg] inclination of orbit to reference plane
-  double M0;                        ///< [deg] mean anomaly at tjd
+  double i;                         ///< [deg] inclination of orbit to the reference plane
+  double M0;                        ///< [deg] mean anomaly at the reference time
   double n;                         ///< [deg/day] mean daily motion, i.e. (_GM_/_a_<sup>3</sup>)<sup>1/2</sup> for the central body,
                                     ///< or 360/T, where T is orbital period in days.
   double apsis_period;              ///< [day] Precession period of the apsis, if known.

--- a/include/solarsystem.h
+++ b/include/solarsystem.h
@@ -341,6 +341,8 @@ long novas_to_naif_planet(enum novas_planet id);
 
 long novas_to_dexxx_planet(enum novas_planet id);
 
+int novas_orbit_posvel(double jd_tdb, const novas_orbital_elements *orb, double *pos, double *vel);
+
 /// \cond PRIVATE
 
 

--- a/include/solarsystem.h
+++ b/include/solarsystem.h
@@ -341,8 +341,6 @@ long novas_to_naif_planet(enum novas_planet id);
 
 long novas_to_dexxx_planet(enum novas_planet id);
 
-int novas_orbit_posvel(double jd_tdb, const novas_orbital_elements *orb, double *pos, double *vel);
-
 /// \cond PRIVATE
 
 

--- a/src/frames.c
+++ b/src/frames.c
@@ -315,8 +315,8 @@ static int is_frame_initialized(const novas_frame *frame) {
 int novas_make_frame(enum novas_accuracy accuracy, const observer *obs, const novas_timespec *time, double dx, double dy,
         novas_frame *frame) {
   static const char *fn = "novas_make_frame";
-  static const object earth = { NOVAS_PLANET, NOVAS_EARTH, "Earth", CAT_ENTRY_INIT };
-  static const object sun = { NOVAS_PLANET, NOVAS_SUN, "Sun", CAT_ENTRY_INIT };
+  static const object earth = { NOVAS_PLANET, NOVAS_EARTH, "Earth", CAT_ENTRY_INIT, NOVAS_ORBIT_INIT };
+  static const object sun = { NOVAS_PLANET, NOVAS_SUN, "Sun", CAT_ENTRY_INIT, NOVAS_ORBIT_INIT };
 
   double tdb2[2];
   double mobl, tobl, ee, dpsi, deps;

--- a/src/super.c
+++ b/src/super.c
@@ -1395,8 +1395,8 @@ int novas_set_orbital_pole(double ra, double dec, novas_orbital_system *sys) {
     return novas_error(-1, EINVAL, "novas_set_orbital_pole", "input system is NULL");
 
   sys->plane = NOVAS_EQUATORIAL_PLANE;
-  sys->obl = remainder((90.0 - dec) * DEGREE, TWOPI);
-  sys->Omega = remainder((ra + 6.0) * HOURANGLE, TWOPI);
+  sys->obl = remainder(90.0 - dec, 360.0);
+  sys->Omega = remainder(15.0 * ra + 90.0, 360.0);
 
   return 0;
 }

--- a/src/super.c
+++ b/src/super.c
@@ -1329,3 +1329,4 @@ enum novas_planet novas_planet_for_name(const char *name) {
 
   return novas_error(-1, EINVAL, fn, "No match for name: '%s'", name);
 }
+

--- a/src/super.c
+++ b/src/super.c
@@ -1363,3 +1363,40 @@ enum novas_planet novas_planet_for_name(const char *name) {
   return novas_error(-1, EINVAL, fn, "No match for name: '%s'", name);
 }
 
+/**
+ * Sets the orientation of an orbital system using the RA and DEC coordinates of the pole
+ * of the Laplace (or else equatorial) plane relative to which the orbital elements are
+ * defined. Orbital parameters of planetary satellites normally include the R.A. and
+ * declination of the pole of the local Laplace plane in which the Keplerian orbital elements
+ * are referenced.
+ *
+ * The system will become referenced to the equatorial plane, the relative obliquity is set
+ * to (90&deg; - `dec`), while the argument of the ascending node ('Omega') is set to
+ * (90&deg; + `ra`).
+ *
+ * NOTES:
+ * <ol>
+ * <li>You should not expect much precision from the long-range orbital approximations for
+ * planetary satellites. For applications that require precision at any level, you should rely
+ * on appropriate ephemerides, or else on up-to-date short-term orbital elements.</li>
+ * </ol>
+ *
+ * @param ra    [h] the R.A. of the pole of the oribtal reference plane.
+ * @param dec   [deg] the declination of the pole of the oribtal reference plane.
+ * @param[out]  sys   The orbital system
+ * @return      0 if successful, or else -1 (errno will be set to EINVAL) if the output `sys`
+ *              pointer is NULL.
+ *
+ * @author Attila Kovacs
+ * @since 1.2
+ */
+int novas_set_orbital_pole(double ra, double dec, novas_orbital_system *sys) {
+  if (!sys)
+    return novas_error(-1, EINVAL, "novas_set_orbital_pole", "input system is NULL");
+
+  sys->plane = NOVAS_EQUATORIAL_PLANE;
+  sys->obl = remainder((90.0 - dec) * DEGREE, TWOPI);
+  sys->Omega = remainder((ra + 6.0) * HOURANGLE, TWOPI);
+
+  return 0;
+}

--- a/src/super.c
+++ b/src/super.c
@@ -990,6 +990,7 @@ int grav_undef(double jd_tdb, enum novas_accuracy accuracy, const double *pos_ap
  * @sa make_cat_entry()
  * @sa make_planet()
  * @sa make_ephem_object()
+ * @sa novas_geom_posvel()
  * @sa place()
  *
  * @since 1.1
@@ -1015,13 +1016,14 @@ int make_cat_object(const cat_entry *star, object *source) {
  *                      ephemeris provider used with NOVAS. (If the ephemeris provider is by name and not
  *                      ID number, then the number here is not important).
  * @param[out] body     Pointer to structure to populate.
- * @return              0 if successful, or else -1 if the 'planet' pointer is NULL or the name
+ * @return              0 if successful, or else -1 if the 'body' pointer is NULL or the name
  *                      is too long.
  *
  *
  * @sa set_ephem_provider()
  * @sa make_planet()
  * @sa make_cat_entry()
+ * @sa novas_geom_posvel()
  * @sa place()
  *
  * @since 1.0
@@ -1029,6 +1031,37 @@ int make_cat_object(const cat_entry *star, object *source) {
  */
 int make_ephem_object(const char *name, long num, object *body) {
   prop_error("make_ephem_object", (make_object(NOVAS_EPHEM_OBJECT, num, name, NULL, body) ? -1 : 0), 0);
+  return 0;
+}
+
+/**
+ * Sets a celestial object to be a Solar-system orbital body. Typically this would be used to define
+ * minor planets, asteroids, comets, or even planetary satellites.
+ *
+ * @param name          Name of object. It may be NULL if not relevant.
+ * @param num           Solar-system body ID number (e.g. NAIF). It is not required and can be set e.g. to
+ *                      -1 if not relevant to the caller.
+ * @param orbit         The orbital parameters to adopt. The data will be copied, not referenced.
+ * @param[out] body     Pointer to structure to populate.
+ * @return              0 if successful, or else -1 if the 'orbit' or 'body' pointer is NULL or the name
+ *                      is too long.
+ *
+ *
+ * @sa novas_orbit_posvel()
+ * @sa make_planet()
+ * @sa make_ephem_object()
+ * @sa novas_geom_posvel()
+ * @sa place()
+ *
+ * @since 1.2
+ * @author Attila Kovacs
+ */
+int make_orbital_object(const char *name, long num, const novas_orbital_elements *orbit, object *body) {
+  static const char *fn = "make_orbital_object";
+  if(!orbit)
+    return novas_error(-1, EINVAL, fn, "Input orbital elements is NULL");
+  prop_error(fn, (make_object(NOVAS_ORBITAL_OBJECT, num, name, NULL, body) ? -1 : 0), 0);
+  memcpy(&body->orbit, orbit, sizeof(novas_orbital_elements));
   return 0;
 }
 

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -2215,7 +2215,7 @@ static int test_planet_for_name() {
 
 static int test_orbit_posvel() {
   object ceres = {};
-  novas_orbital_elements orbit;
+  novas_orbital_elements orbit = NOVAS_ORBIT_INIT;
   observer obs = {};
   sky_pos pos = {};
 
@@ -2226,10 +2226,6 @@ static int test_orbit_posvel() {
   double rv0 = 21.138;            // km/s
   double r = 3.323;               // AU
   int n = 0;
-
-  orbit.center = NOVAS_SUN;
-  orbit.plane = NOVAS_ECLIPTIC_PLANE;
-  orbit.sys = NOVAS_GCRS_EQUATOR;
 
   orbit.jd_tdb = 2460600.5;
   orbit.a = 2.7666197;

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -2231,18 +2231,18 @@ static int test_orbit_place() {
   orbit.jd_tdb = 2460600.5;
   orbit.a = 2.7666197;
   orbit.e = 0.079184;
-  orbit.i = 10.5879 * DEGREE;
-  orbit.omega = 73.28579 * DEGREE;
-  orbit.Omega = 80.25414 * DEGREE;
-  orbit.M0 = 145.84905 * DEGREE;
-  orbit.n = 0.21418047 * DEGREE;
+  orbit.i = 10.5879;
+  orbit.omega = 73.28579;
+  orbit.Omega = 80.25414;
+  orbit.M0 = 145.84905;
+  orbit.n = 0.21418047;
 
   make_observer_at_geocenter(&obs);
   make_orbital_object("Ceres", -1, &orbit, &ceres);
 
   if(!is_ok("orbit_place", place(tjd, &ceres, &obs, ut12tt, NOVAS_TOD, NOVAS_REDUCED_ACCURACY, &pos))) return 1;
 
-  if(!is_equal("orbit_place:ra", pos.ra, RA0, 1e-5)) n++;
+  if(!is_equal("orbit_place:ra", pos.ra, RA0, 1e-5 / cos(DEC0 * DEGREE))) n++;
   if(!is_equal("orbit_place:dec", pos.dec, DEC0, 1e-4)) n++;
   if(!is_equal("orbit_place:dist", pos.dis, r, 1e-4)) n++;
   if(!is_equal("orbit_place:vrad", pos.rv, rv0, 1e-2)) n++;
@@ -2262,7 +2262,6 @@ static int test_orbit_posvel_callisto() {
   double dist = 4.62117513332102;
   double lt = 0.00577551831217194 * dist;                 // day
   double tjd = 2451545.00079861 - lt;   // 0 UT as TT, corrected or light time
-  double dyr;
 
   double RA0 = 23.86983 * DEGREE;
   double DEC0 = 8.59590 * DEGREE;
@@ -2281,15 +2280,15 @@ static int test_orbit_posvel_callisto() {
   novas_set_orbital_pole(268.7 / 15.0, 64.8, sys);
 
   orbit.jd_tdb = NOVAS_JD_J2000;
-  dyr = (tjd - orbit.jd_tdb) / 365.25;   //(yr) time since J2000.0
-
   orbit.a = 1882700.0 * 1e3 / AU;
   orbit.e = 0.007;
-  orbit.omega = remainder(43.8 * DEGREE + TWOPI * dyr / 277.921, TWOPI);
-  orbit.M0 = 87.4 * DEGREE;
-  orbit.i = 0.3 * DEGREE;
-  orbit.Omega = remainder(309.1 * DEGREE + TWOPI * dyr / 577.264, TWOPI);
+  orbit.omega = 43.8;
+  orbit.M0 = 87.4;
+  orbit.i = 0.3;
+  orbit.Omega = 309.1;
   orbit.n = TWOPI / 16.690440;
+  orbit.apsis_period = 277.921 * 365.25;
+  orbit.node_period = 577.264 * 365.25;
 
   if(!is_ok("orbit_posvel_callisto", novas_orbit_posvel(tjd, &orbit, NOVAS_FULL_ACCURACY, pos, vel))) return 1;
 

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -2213,6 +2213,47 @@ static int test_planet_for_name() {
 }
 
 
+static int test_orbit_posvel() {
+  object ceres = {};
+  novas_orbital_elements orbit;
+  observer obs = {};
+  sky_pos pos = {};
+
+  // This is for SMA, so topocentric with Earth rot...
+  double tjd = NOVAS_JD_MJD0 + 60627.796269;
+  double RA0 = 19.679722;         // 19:40:47.000
+  double DEC0 = -28.633014;       // -28:37:58.849
+  double rv0 = 21.138;            // km/s
+  double r = 3.323;               // AU
+  int n = 0;
+
+  orbit.center = NOVAS_SUN;
+  orbit.plane = NOVAS_ECLIPTIC_PLANE;
+  orbit.sys = NOVAS_GCRS_EQUATOR;
+
+  orbit.jd_tdb = 2460600.5;
+  orbit.a = 2.7666197;
+  orbit.e = 0.079184;
+  orbit.i = 10.5879 * DEGREE;
+  orbit.omega = 73.28579 * DEGREE;
+  orbit.Omega = 80.25414 * DEGREE;
+  orbit.M0 = 145.84905 * DEGREE;
+  orbit.n = 0.21418047 * DEGREE;
+
+  make_observer_at_geocenter(&obs);
+  make_orbital_object("Ceres", -1, &orbit, &ceres);
+
+  if(!is_ok("orbit_posvel", place(tjd, &ceres, &obs, ut12tt, NOVAS_TOD, NOVAS_REDUCED_ACCURACY, &pos))) return 1;
+
+  // TODO refine with HORIZONS data...
+  if(!is_equal("orbit_posvel:ra", pos.ra, RA0, 5e-5)) n++;
+  if(!is_equal("orbit_posvel:dec", pos.dec, DEC0, 1e-3)) n++;
+  if(!is_equal("orbit_posvel:dist", pos.dis, r, 2e-3)) n++;
+  if(!is_equal("orbit_posvel:vrad", pos.rv, rv0, 0.5)) n++;
+
+  return n;
+}
+
 int main(int argc, char *argv[]) {
   int n = 0;
 
@@ -2277,6 +2318,7 @@ int main(int argc, char *argv[]) {
   if(test_naif_to_novas_planet()) n++;
 
   if(test_planet_for_name()) n++;
+  if(test_orbit_posvel()) n++;
 
   n += test_dates();
 


### PR DESCRIPTION
### Added  
 - `NOVAS_ORBITAL_OBJECT` to `enum novas_planet`.
 - `novas_orbital_elements` structure, including `novas_orbital_system` substructure, and `enum novas_reference_plane` to distiguish ecliptic vs equatorial orbital parameters, and `novas_set_orbital_pole()` helper function to configure.
 - `object.orbit` field containing `novas_orbital_elements` data
 - `novas_orbit_posvel()` function to calculate position and velocity vectors from orbital elements.
 - `make_orbital_object()` function to ease the creation of objects with orbital parameters.

### Changed

 - `ephemeris()` call to process `NOVAS_ORBITAL_OBJECT` types via `novas_orbit_posvel()`.