### PR TITLE
Orbitals continued

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [1.2.0-rc2] - 2024-11-18
+## [Unreleased]
 
-Release candidate for the next feature release, expected around 1 February 2025.
+Changes exzpected for the next feature release, expected around 1 February 2025.
 
 
 ### Added
@@ -57,10 +57,10 @@ Release candidate for the next feature release, expected around 1 February 2025.
    [GNU standard](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html) to further customize the
    install locations.
  
- - #95: Added support for using orbital elements. `object.type` can now be set to `NOVAS_ORBITAL_OBJECT`, whose orbit
+ - #95, #98: Added support for using orbital elements. `object.type` can now be set to `NOVAS_ORBITAL_OBJECT`, whose orbit
    can be defined by the set of `novas_orbital_elements`, relative to a `novas_orbital_system`. You can initialize an 
    `object` with a set of orbital elements using `make_orbital_object()`, and for planetary satellite orbits you might
-   use `novas_set_orbital_pole()`. For orbital objects, `ephemeris()` will call on the new `novas_orbit_posvel()` to 
+   use `novas_set_orbsys_pole()`. For orbital objects, `ephemeris()` will call on the new `novas_orbit_posvel()` to 
    calculate positions. While orbital elements do not always yield precise positions, they can for shorter periods, 
    provided that the orbital elements are up-to-date. For example, the Minor Planer Center (MPC) publishes accurate 
    orbital elements for all known asteroids and comets regularly. For newly discovered objects, this may be the only 
@@ -69,6 +69,9 @@ Release candidate for the next feature release, expected around 1 February 2025.
  - #97: Added `NOVAS_EMB` (Earth-Moon Barycenter) and `NOVAS_PLUTO_BARYCENTER` to `enum novas_planets` to distinguish
    from the planet center in calculations.
    
+ - #98: Added `gcrs_to_tod()` / `tod_to_gcrs()` and `gcrs_to_mod()` / `mod_to_gcrs()` vector conversion functions for
+   convenience.
+ 
  - SuperNOVAS headers now include each other as system-headers, not local headers. This is unlikely to affect anything
    really but it is more proper for an installation of the library, and works with our own `Makefile` too.
    
@@ -78,6 +81,7 @@ Release candidate for the next feature release, expected around 1 February 2025.
 
  - #97: Updated `NOVAS_PLANETS`, `NOVAS_PLANET_NAMES_INIT`, and `NOVAS_RMASS_INIT` macros to include the added planet 
    constants.
+   
    
    
 ## [1.1.1] - 2024-10-28

--- a/README.md
+++ b/README.md
@@ -915,7 +915,7 @@ before that level of accuracy is reached.
  - Added support for using orbital elements. `object.type` can now be set to `NOVAS_ORBITAL_OBJECT`, whose orbit
    can be defined by the set of `novas_orbital_elements`, relative to a `novas_orbital_system`. You can initialize an 
    `object` with a set of orbital elements using `make_orbital_object()`, and for planetary satellite orbits you might
-   use `novas_set_orbital_pole()`. For orbital objects, `ephemeris()` will call on the new `novas_orbit_posvel()` to 
+   use `novas_set_orbsys_pole()`. For orbital objects, `ephemeris()` will call on the new `novas_orbit_posvel()` to 
    calculate positions. While orbital elements do not always yield precise positions, they can for shorter periods, 
    provided that the orbital elements are up-to-date. For example, the Minor Planer Center (MPC) publishes accurate 
    orbital elements for all known asteroids and comets regularly. For newly discovered objects, this may be the only 
@@ -923,7 +923,9 @@ before that level of accuracy is reached.
 
  - Added `NOVAS_EMB` (Earth-Moon Barycenter) and `NOVAS_PLUTO_BARYCENTER` to `enum novas_planets` to distinguish
    from the corresponding planet centers in calculations.
-   
+ 
+ - Added `gcrs_to_tod()` / `tod_to_gcrs()` and `gcrs_to_mod()` / `mod_to_gcrs()` vector conversion functions for
+   convenience.
 
 <a name="api-changes"></a>
 ### Refinements to the NOVAS C API

--- a/include/novas.h
+++ b/include/novas.h
@@ -715,15 +715,14 @@ typedef struct {
  * @author Attila Kovacs
  * @since 1.2
  *
- * @sa novas_set_orbital_pole()
+ * @sa novas_set_obsys_pole()
  * @sa novas_orbital_elements
  * @sa NOVAS_ORBITAL_SYSTEM_INIT
  */
 typedef struct {
   enum novas_planet center;          ///< major planet or barycenter at the center of the orbit.
   enum novas_reference_plane plane;  ///< reference plane NOVAS_ECLIPTIC_PLANE or NOVAS_EQUATORIAL_PLANE
-  enum novas_equator_type type;      ///< the type of equator in which orientation is referenced (NOVAS_TRUE_EQUATOR,
-                                     ///< NOVAS_MEAN_EQUATOR, or NOVAS_GCRS_EQUATOR).
+  enum novas_reference_system type;  ///< the coordinate reference system used for the reference plane and orbitals.
   double obl;                        ///< [rad] relative obliquity of orbital reference plane
                                      ///<       (e.g. 90&deg; - &delta;<sub>pole</sub>)
   double Omega;                      ///< [rad] relative argument of ascending node of the orbital reference plane
@@ -737,7 +736,7 @@ typedef struct {
  * @author Attila Kovacs
  * @since 1.2
  */
-#define NOVAS_ORBITAL_SYSTEM_INIT { NOVAS_SUN, NOVAS_ECLIPTIC_PLANE, NOVAS_GCRS_EQUATOR, 0.0, 0.0 }
+#define NOVAS_ORBITAL_SYSTEM_INIT { NOVAS_SUN, NOVAS_ECLIPTIC_PLANE, NOVAS_GCRS, 0.0, 0.0 }
 
 /**
  * Keplerian orbital elements for `NOVAS_ORBITAL_OBJECT` type. Orbital elements can be used to provide
@@ -1486,12 +1485,19 @@ double novas_z_inv(double z);
 
 enum novas_planet novas_planet_for_name(const char *name);
 
-int novas_set_orbital_pole(double ra, double dec, novas_orbital_system *sys);
+int novas_set_orbsys_pole(enum novas_reference_system type, double ra, double dec, novas_orbital_system *sys);
 
 int make_orbital_object(const char *name, long num, const novas_orbital_elements *orbit, object *body);
 
 int novas_orbit_posvel(double jd_tdb, const novas_orbital_elements *orb, enum novas_accuracy accuracy, double *pos, double *vel);
 
+int gcrs_to_tod(double jd_tdb, enum novas_accuracy accuracy, const double *in, double *out);
+
+int tod_to_gcrs(double jd_tdb, enum novas_accuracy accuracy, const double *in, double *out);
+
+int gcrs_to_mod(double jd_tdb, const double *in, double *out);
+
+int mod_to_gcrs(double jd_tdb, const double *in, double *out);
 
 // <================= END of SuperNOVAS API =====================>
 

--- a/src/super.c
+++ b/src/super.c
@@ -1381,6 +1381,7 @@ enum novas_planet novas_planet_for_name(const char *name) {
  * on appropriate ephemerides, or else on up-to-date short-term orbital elements.</li>
  * </ol>
  *
+ * @param type  Coordinate reference system in which `ra` and `dec` are defined (e.g. NOVAS_GCRS).
  * @param ra    [h] the R.A. of the pole of the oribtal reference plane.
  * @param dec   [deg] the declination of the pole of the oribtal reference plane.
  * @param[out]  sys   The orbital system
@@ -1392,11 +1393,12 @@ enum novas_planet novas_planet_for_name(const char *name) {
  *
  * @sa make_orbital_object()
  */
-int novas_set_orbital_pole(double ra, double dec, novas_orbital_system *sys) {
+int novas_set_orbsys_pole(enum novas_reference_system type, double ra, double dec, novas_orbital_system *sys) {
   if (!sys)
-    return novas_error(-1, EINVAL, "novas_set_orbital_pole", "input system is NULL");
+    return novas_error(-1, EINVAL, "novas_set_obsys_pole", "input system is NULL");
 
   sys->plane = NOVAS_EQUATORIAL_PLANE;
+  sys->type = type;
   sys->obl = remainder(90.0 - dec, 360.0);
   sys->Omega = remainder(15.0 * ra + 90.0, 360.0);
 

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -307,6 +307,48 @@ static int test_tod_to_j2000() {
   return n;
 }
 
+static int test_gcrs_to_tod() {
+  double p[3];
+  int n = 0;
+
+  if(check("gcrs_to_tod:in", -1, gcrs_to_tod(0.0, NOVAS_FULL_ACCURACY, NULL, p))) n++;
+  if(check("gcrs_to_tod:out", -1, gcrs_to_tod(0.0, NOVAS_FULL_ACCURACY, p, NULL))) n++;
+  if(check("gcrs_to_tod:accuracy", -1, gcrs_to_tod(0.0, -1, p, p))) n++;
+
+  return n;
+}
+
+static int test_tod_to_gcrs() {
+  double p[3] = {1.0};
+  int n = 0;
+
+  if(check("tod_to_gcrs:in", -1, tod_to_gcrs(0.0, NOVAS_FULL_ACCURACY, NULL, p))) n++;
+  if(check("tod_to_gcrs:out", -1, tod_to_gcrs(0.0, NOVAS_FULL_ACCURACY, p, NULL))) n++;
+  if(check("tod_to_gcrs:accuracy", -1, tod_to_gcrs(0.0, -1, p, p))) n++;
+
+  return n;
+}
+
+static int test_gcrs_to_mod() {
+  double p[3];
+  int n = 0;
+
+  if(check("gcrs_to_mod:in", -1, gcrs_to_mod(0.0, NULL, p))) n++;
+  if(check("gcrs_to_mod:out", -1, gcrs_to_mod(0.0, p, NULL))) n++;
+
+  return n;
+}
+
+static int test_mod_to_gcrs() {
+  double p[3] = {1.0};
+  int n = 0;
+
+  if(check("mod_to_gcrs:in", -1, mod_to_gcrs(0.0, NULL, p))) n++;
+  if(check("mod_to_gcrs:out", -1, mod_to_gcrs(0.0, p, NULL))) n++;
+
+  return n;
+}
+
 static int test_gcrs_to_cirs() {
   double p[3] = {1.0};
   int n = 0;
@@ -1511,38 +1553,40 @@ static int test_orbit_posvel() {
 
   orbit.a = 1.0;
 
-  if(check("set_orbital_pole:orbit", -1, novas_orbit_posvel(0.0, NULL, NOVAS_REDUCED_ACCURACY, pos, vel))) n++;
-  if(check("set_orbital_pole:pos=vel", -1, novas_orbit_posvel(0.0, &orbit, NOVAS_REDUCED_ACCURACY, pos, pos))) n++;
-  if(check("set_orbital_pole:pos=vel:NULL", -1, novas_orbit_posvel(0.0, &orbit, NOVAS_REDUCED_ACCURACY, NULL, NULL))) n++;
+  if(check("set_obsys_pole:orbit", -1, novas_orbit_posvel(0.0, NULL, NOVAS_REDUCED_ACCURACY, pos, vel))) n++;
+  if(check("set_obsys_pole:pos=vel", -1, novas_orbit_posvel(0.0, &orbit, NOVAS_REDUCED_ACCURACY, pos, pos))) n++;
+  if(check("set_obsys_pole:pos=vel:NULL", -1, novas_orbit_posvel(0.0, &orbit, NOVAS_REDUCED_ACCURACY, NULL, NULL))) n++;
+  if(check("set_obsys_pole:accuracy:-1", -1, novas_orbit_posvel(0.0, &orbit, -1, pos, vel))) n++;
+  if(check("set_obsys_pole:accuracy:2", -1, novas_orbit_posvel(0.0, &orbit, 2, pos, vel))) n++;
 
-  if(check("set_orbital_pole:orbit:converge", 0, novas_orbit_posvel(0.0, &orbit, NOVAS_REDUCED_ACCURACY, pos, vel))) n++;
+  if(check("set_obsys_pole:orbit:converge", 0, novas_orbit_posvel(0.0, &orbit, NOVAS_REDUCED_ACCURACY, pos, vel))) n++;
 
   novas_inv_max_iter = 0;
-  if(check("set_orbital_pole:orbit:converge", -1, novas_orbit_posvel(0.0, &orbit, NOVAS_REDUCED_ACCURACY, pos, vel))) n++;
-  else if(check("set_orbital_pole:orbit:converge:errno", ECANCELED, errno)) n++;
+  if(check("set_obsys_pole:orbit:converge", -1, novas_orbit_posvel(0.0, &orbit, NOVAS_REDUCED_ACCURACY, pos, vel))) n++;
+  else if(check("set_obsys_pole:orbit:converge:errno", ECANCELED, errno)) n++;
   novas_inv_max_iter = saved;
 
   orbit.system.type = -1;
-  if(check("set_orbital_pole:orbit:type:-1", -1, novas_orbit_posvel(0.0, &orbit, NOVAS_REDUCED_ACCURACY, pos, vel))) n++;
+  if(check("set_obsys_pole:orbit:type:-1", -1, novas_orbit_posvel(0.0, &orbit, NOVAS_REDUCED_ACCURACY, pos, vel))) n++;
 
-  orbit.system.type = NOVAS_EQUATOR_TYPES;
-  if(check("set_orbital_pole:orbit:type:hi", -1, novas_orbit_posvel(0.0, &orbit, NOVAS_REDUCED_ACCURACY, pos, vel))) n++;
+  orbit.system.type = NOVAS_REFERENCE_SYSTEMS;
+  if(check("set_obsys_pole:orbit:type:hi", -1, novas_orbit_posvel(0.0, &orbit, NOVAS_REDUCED_ACCURACY, pos, vel))) n++;
 
   orbit.system.plane = NOVAS_EQUATORIAL_PLANE;
-  orbit.system.type = NOVAS_EQUATOR_TYPES;
-  if(check("set_orbital_pole:orbit:type:-1:eq", -1, novas_orbit_posvel(0.0, &orbit, NOVAS_REDUCED_ACCURACY, pos, vel))) n++;
+  orbit.system.type = NOVAS_REFERENCE_SYSTEMS;
+  if(check("set_obsys_pole:orbit:type:-1:eq", -1, novas_orbit_posvel(0.0, &orbit, NOVAS_REDUCED_ACCURACY, pos, vel))) n++;
 
-  orbit.system.type = NOVAS_GCRS_EQUATOR;
+  orbit.system.type = NOVAS_GCRS;
   orbit.system.plane = -1;
-  if(check("set_orbital_pole:orbit:plane:-1", -1, novas_orbit_posvel(0.0, &orbit, NOVAS_REDUCED_ACCURACY, pos, vel))) n++;
+  if(check("set_obsys_pole:orbit:plane:-1", -1, novas_orbit_posvel(0.0, &orbit, NOVAS_REDUCED_ACCURACY, pos, vel))) n++;
 
   return n;
 }
 
-static int test_set_orbital_pole() {
+static int test_set_obsys_pole() {
   int n = 0;
 
-  if(check("set_orbital_pole:orbit", -1, novas_set_orbital_pole(0.0, 0.0, NULL))) n++;
+  if(check("set_obsys_pole:orbit", -1, novas_set_orbsys_pole(NOVAS_GCRS, 0.0, 0.0, NULL))) n++;
 
   return n;
 }
@@ -1677,8 +1721,13 @@ int main() {
 
   if(test_planet_for_name()) n++;
   if(test_make_orbital_object()) n++;
-  if(test_set_orbital_pole()) n++;
+  if(test_set_obsys_pole()) n++;
   if(test_orbit_posvel()) n++;
+
+  if(test_gcrs_to_tod()) n++;
+  if(test_tod_to_gcrs()) n++;
+  if(test_gcrs_to_mod()) n++;
+  if(test_mod_to_gcrs()) n++;
 
   if(n) fprintf(stderr, " -- FAILED %d tests\n", n);
   else fprintf(stderr, " -- OK\n");


### PR DESCRIPTION
- Tweak `enum novas_orbital_system` to o contain a proper reference coordinate system instead of just an equator type.
- Renamed `novas_set_orbital_pole()` to `novas_set_orbsys_pole()`, which now takes a coordinate reference system as an input, in line with the above.
- Exposed existing `gcrs_to_tod()` and `tod_to_gcrs()` functions.
- Added `gcrs_to_mod()` and `mod_to_gcrs()` functions for convenience.