### PR TITLE
Revert "Bump mattnotmitt/doxygen-action from 1.9.8 to 1.12.0"

### DIFF
--- a/.github/workflows/dox.yml
+++ b/.github/workflows/dox.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Generate headless README
       run: make README-orig.md
         
-    - uses: mattnotmitt/doxygen-action@v1.12.0
+    - uses: mattnotmitt/doxygen-action@v1.9.8
       with:
         additional-packages: font-roboto
        


### PR DESCRIPTION
Reverts Smithsonian/SuperNOVAS#119

It has the doxygen  bug for anchors.