### PR TITLE
Negative years to indicate B.C. dates consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@ Upcoming feature release, expected around 1 May 2025.
 ### Fixed
 
  - #116: `transform_cat()` to update parallax to the recalculated value when precessing or changing epochs.
- 
- - `julian_date()` to work with negative years (for B.C. dates). E.g. the year -1 denotes 1 BC.
   
 ### Added
 
  - #114: New `novas_lsr_to_ssb_vel()` can be used to convert velocity vectors referenced to the LSR to Solar-System 
    Barycentric velocities. And, `novas_ssb_to_lsr_vel()` to provide the inverse conversion.
+
+ - #121: New `cal_date2()`, which is exactly like `cal_date()` except that it takes `int` pointers instead of `short`.
 
  - New `novas_hms_hours()` and `novas_dms_degrees()` convenience functions to make it easier to parse HMS or DMS based 
    time or angle values, returning the result in units of hours or degrees, appropriately for use in SuperNOVAS, and
@@ -82,6 +82,9 @@ Upcoming feature release, expected around 1 May 2025.
    
  - Modified `julian_date()` to add range checking for month and day arguments, and return NAN (with errno set to 
    EINVAL) if the input values are invalid.
+
+ - #121: `julian_date()` to use negative years for B.C. dates. E.g. the year -1 denotes 1 BC. And, same for the inverse 
+   `cal_date()`.
 
  - Updated `README.md` for v1.3 and benchmarks, including comparisons to __astropy__.
 

--- a/README.md
+++ b/README.md
@@ -158,8 +158,6 @@ provided by SuperNOVAS over the upstream NOVAS C 3.1 code:
    
  - [__v1.3__] `transform_cat()` to update parallax to the recalculated value when precessing or changing epochs.
  
- - [__v1.3__] `julian_date()` to work with negative (B.C.) years also. E.g. the year -1 denotes 1 BC.
- 
    
 -----------------------------------------------------------------------------
 
@@ -1272,9 +1270,9 @@ one minute.
    corrections were applied for Earth too. However, these are below the mas-level accuracy promised in reduced 
    accuracy mode, and without it, the calculations for `place()` and `novas_sky_pos()` are significantly faster.
    
- - [__v1.3__] Modified `julian_date()` to allow BC dates as negative years, e.g. use -1 to indicate 1 BC. Also add 
-   range checking for month and day arguments, and return NAN (with errno set to EINVAL) if the input values are 
-   invalid.
+ - [__v1.3__] Modified `julian_date()` to use negative years for B.C. dates. E.g. the year -1 denotes 1 BC. And, same 
+   for the inverse `cal_date()`. Also add range checking for month and day arguments, and return NAN (with errno set to 
+   EINVAL) if the input values are invalid. And, same for the inverse `cal_date()`.
 
 
 -----------------------------------------------------------------------------

--- a/include/novas.h
+++ b/include/novas.h
@@ -1717,6 +1717,8 @@ int mod_to_gcrs(double jd_tdb, const double *in, double *out);
 
 // ---------------------- Added in 1.3.0 -------------------------
 
+int cal_date2(double tjd, int *year, int *month, int *day, double *hour);
+
 // in super.c
 double novas_lsr_to_ssb_vel(double epoch, double ra, double dec, double vLSR);
 

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -1020,6 +1020,23 @@ static int test_cal_date() {
   if(!is_ok("cal_date:d:null", cal_date(tdb, &y, &m, NULL, &h))) return 1;
   if(!is_ok("cal_date:h:null", cal_date(tdb, &y, &m, &d, NULL))) return 1;
 
+  if(!is_ok("cal_date:y:null", cal_date2(tdb, NULL, &m, &d, &h))) return 1;
+  if(!is_ok("cal_date:m:null", cal_date2(tdb, &y, NULL, &d, &h))) return 1;
+  if(!is_ok("cal_date:d:null", cal_date2(tdb, &y, &m, NULL, &h))) return 1;
+  if(!is_ok("cal_date:h:null", cal_date2(tdb, &y, &m, &d, NULL))) return 1;
+
+  if(!is_ok("cal_date:1AD", cal_date(1721426.0, &y, &m, &d, NULL))) return 1;
+  if(!is_equal("cal_date:1AD:check", y, 1, 1e-6)) return 1;
+
+  if(!is_ok("cal_date:1BC", cal_date(1721425.0, &y, &m, &d, NULL))) return 1;
+  if(!is_equal("cal_date:1BC:check", y, -1, 1e-6)) return 1;
+
+  return 0;
+}
+
+static int test_julian_date() {
+  if(!is_equal("julian_date:J2000", julian_date(2000, 1, 1, 12.0), NOVAS_JD_J2000, 1e-6)) return 1;
+  if(!is_equal("julian_date:AD-BC", julian_date(1, 1, 1, 0.0), julian_date(-1, 12, 31, 0.0) + 1, 1e-6)) return 1;
   return 0;
 }
 
@@ -3203,6 +3220,7 @@ int main(int argc, char *argv[]) {
   if(test_iso_timestamp()) n++;
   if(test_timestamp()) n++;
   if(test_timescale_for_string()) n++;
+  if(test_julian_date()) n++;
 
   n += test_dates();
 


### PR DESCRIPTION
Affects:

- `julian_date()`
- `cal_date()`
- `novas_parse_date_format()` / `novas_parse_date()`
- `novas_timestamp()` / `novas_iso_timestamp()`

Adds:

- `cal_date2()`, which works like `cal_date()` but takes `int *` pointers intead of `short *`.