### PR TITLE
Disambiguate Gregorian and Roman/Julian calendars.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ Upcoming feature release, expected around 1 May 2025.
  - #114: New `novas_lsr_to_ssb_vel()` can be used to convert velocity vectors referenced to the LSR to Solar-System 
    Barycentric velocities. And, `novas_ssb_to_lsr_vel()` to provide the inverse conversion.
 
- - #121: New `cal_date2()`, which is exactly like `cal_date()` except that it takes `int` pointers instead of `short`.
+ - #122: New `novas_jd_to_calendar()`, and `novas_calendar_to_jd()` which convert between JD day and calendar dates 
+   using the specific type of calendar: Gregorian, Roman/Julian, or the conventional calendar of date.
 
  - New `novas_hms_hours()` and `novas_dms_degrees()` convenience functions to make it easier to parse HMS or DMS based 
    time or angle values, returning the result in units of hours or degrees, appropriately for use in SuperNOVAS, and

--- a/README.md
+++ b/README.md
@@ -1137,6 +1137,9 @@ one minute.
  - New `novas_lsr_to_ssb_vel()` can be used to convert velocity vectors referenced to the LSR to Solar-System 
    Barycentric velocities. And, `novas_ssb_to_lsr_vel()` to provide the inverse conversion.
 
+ - New `novas_jd_to_calendar()`, and `novas_calendar_to_jd()` which convert between JD day and calendar dates using 
+   the specific type of calendar (Gregorian, Roman/Julian, or the conventional Western calendar).
+
  - New `novas_hms_hours()` and `novas_dms_degrees()` convenience functions to make it easier to parse HMS or DMS based 
    time or angle values, returning the result in units of hours or degrees, appropriately for use in SuperNOVAS, and
 

--- a/include/novas.h
+++ b/include/novas.h
@@ -190,6 +190,9 @@
 /// @since 1.3
 #define NOVAS_SOLAR_CONSTANT      1367.0
 
+/// [day] The Julian day the Gregorian calendar was introduced in 15 October 1582.
+/// The day prior to that was 4 October 1582 in the Julian Calendar.
+#define NOVAS_JD_START_GREGORIAN  2299160.5
 
 #if !COMPAT
 // If we are not in the strict compatibility mode, where constants are defined
@@ -1323,6 +1326,23 @@ enum novas_date_format {
 };
 
 
+/**
+ * Constants to disambiguate which type of calendar yo use for interpreting calendar dates. Roman/Julian or Gregorian/
+ *
+ * @since 1.3
+ * @author Attila Kovacs
+ *
+ * @sa novas_calendar_to_jd()
+ * @sa novas_jd_to_calendar()
+ */
+enum novas_calendar_type {
+  NOVAS_ROMAN_CALENDAR = -1,    ///< The Roman (a.k.a. Julian) calendar by Julius Caesar, introduced in -45 B.C.
+  NOVAS_CALENDAR_OF_DATE,       ///< Roman (a.k.a. Julian) calendar until the Gregorian calendar reform,
+                                ///< after which it is the Gregorian calendar
+  NOVAS_GREGORIAN_CALENDAR      ///< The Gregorian calendar introduced on 15 October 1582, the day after 4 October
+                                ///< 1582 in the Roman (a.k.a. Julian) calendar.
+};
+
 short app_star(double jd_tt, const cat_entry *star, enum novas_accuracy accuracy, double *ra, double *dec);
 
 short virtual_star(double jd_tt, const cat_entry *star, enum novas_accuracy accuracy, double *ra, double *dec);
@@ -1717,7 +1737,9 @@ int mod_to_gcrs(double jd_tdb, const double *in, double *out);
 
 // ---------------------- Added in 1.3.0 -------------------------
 
-int cal_date2(double tjd, int *year, int *month, int *day, double *hour);
+int novas_jd_to_calendar(double tjd, enum novas_calendar_type calendar, int *year, int *month, int *day, double *hour);
+
+double novas_calendar_to_jd(enum novas_calendar_type calendar, short year, short month, short day, double hour);
 
 // in super.c
 double novas_lsr_to_ssb_vel(double epoch, double ra, double dec, double vLSR);
@@ -1772,7 +1794,7 @@ int novas_track_pos(const novas_track *track, const novas_timespec *time, double
 // in timescale.c
 double novas_parse_date(const char *date, char **tail);
 
-double novas_parse_date_format(enum novas_date_format format, const char *date, char **tail);
+double novas_parse_date_format(enum novas_calendar_type calendar, enum novas_date_format format, const char *date, char **tail);
 
 int novas_iso_timestamp(const novas_timespec *time, char *dst, int maxlen);
 

--- a/src/super.c
+++ b/src/super.c
@@ -19,6 +19,7 @@
 #include <math.h>
 #include <errno.h>
 #include <string.h>
+#include <strings.h>              // strcasecmp() / strncasecmp()
 
 /// \cond PRIVATE
 #define __NOVAS_INTERNAL_API__    ///< Use definitions meant for internal use by SuperNOVAS only

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -1847,25 +1847,25 @@ static int test_parse_date() {
   if(check_nan("parse_date:null", novas_parse_date(NULL, &tail))) n++;
   if(check_nan("parse_date:empty", novas_parse_date("", &tail))) n++;
 
-  if(check_nan("parse_date_time:format:-1", novas_parse_date_format(-1, "2025-01-28", &tail))) n++;
-  if(check_nan("parse_date_time:format:3", novas_parse_date_format(3, "2025-01-28", &tail))) n++;
+  if(check_nan("parse_date_time:format:-1", novas_parse_date_format(0, -1, "2025-01-28", &tail))) n++;
+  if(check_nan("parse_date_time:format:3", novas_parse_date_format(0, 3, "2025-01-28", &tail))) n++;
 
-  if(check_nan("parse_date_time:few", novas_parse_date_format(NOVAS_YMD, "2025-01", &tail))) n++;
-  if(check_nan("parse_date_time:sep:invalid", novas_parse_date_format(3, "2025$01$28", &tail))) n++;
+  if(check_nan("parse_date_time:few", novas_parse_date_format(0, NOVAS_YMD, "2025-01", &tail))) n++;
+  if(check_nan("parse_date_time:sep:invalid", novas_parse_date_format(0, 3, "2025$01$28", &tail))) n++;
 
-  if(check_nan("parse_date_time:m:0", novas_parse_date_format(NOVAS_YMD, "2025-00-28", &tail))) n++;
-  if(check_nan("parse_date_time:m:13", novas_parse_date_format(NOVAS_YMD, "2025-13-28", &tail))) n++;
-  if(check_nan("parse_date_time:d:0", novas_parse_date_format(NOVAS_YMD, "2025-2-0", &tail))) n++;
-  if(check_nan("parse_date_time:feb:d:30", novas_parse_date_format(NOVAS_YMD, "2025-2-30", &tail))) n++;
+  if(check_nan("parse_date_time:m:0", novas_parse_date_format(0, NOVAS_YMD, "2025-00-28", &tail))) n++;
+  if(check_nan("parse_date_time:m:13", novas_parse_date_format(0, NOVAS_YMD, "2025-13-28", &tail))) n++;
+  if(check_nan("parse_date_time:d:0", novas_parse_date_format(0, NOVAS_YMD, "2025-2-0", &tail))) n++;
+  if(check_nan("parse_date_time:feb:d:30", novas_parse_date_format(0, NOVAS_YMD, "2025-2-30", &tail))) n++;
 
-  if(check_nan("parse_date_time:m:invalid", novas_parse_date_format(NOVAS_YMD, "2025-blah-28", &tail))) n++;
+  if(check_nan("parse_date_time:m:invalid", novas_parse_date_format(0, NOVAS_YMD, "2025-blah-28", &tail))) n++;
 
-  if(check_nan("parse_date_time:zone:missing", novas_parse_date_format(NOVAS_YMD, "2025-01-28 12:50:00+", &tail))) n++;
-  if(check_nan("parse_date_time:zone:bad", novas_parse_date_format(NOVAS_YMD, "2025-01-28 12:50:00+:", &tail))) n++;
-  if(check_nan("parse_date_time:zone:bad2", novas_parse_date_format(NOVAS_YMD, "2025-01-28 12:50:00+0:", &tail))) n++;
-  if(check_nan("parse_date_time:zone:hours:24", novas_parse_date_format(NOVAS_YMD, "2025-01-28 12:50:00+2400", &tail))) n++;
-  if(check_nan("parse_date_time:zone:mins:60", novas_parse_date_format(NOVAS_YMD, "2025-01-28 12:50:00+0260", &tail))) n++;
-  if(check_nan("parse_date_time:zone:mins:incomplete", novas_parse_date_format(NOVAS_YMD, "2025-01-28 12:50:00+020", &tail))) n++;
+  if(check_nan("parse_date_time:zone:missing", novas_parse_date_format(0, NOVAS_YMD, "2025-01-28 12:50:00+", &tail))) n++;
+  if(check_nan("parse_date_time:zone:bad", novas_parse_date_format(0, NOVAS_YMD, "2025-01-28 12:50:00+:", &tail))) n++;
+  if(check_nan("parse_date_time:zone:bad2", novas_parse_date_format(0, NOVAS_YMD, "2025-01-28 12:50:00+0:", &tail))) n++;
+  if(check_nan("parse_date_time:zone:hours:24", novas_parse_date_format(0, NOVAS_YMD, "2025-01-28 12:50:00+2400", &tail))) n++;
+  if(check_nan("parse_date_time:zone:mins:60", novas_parse_date_format(0, NOVAS_YMD, "2025-01-28 12:50:00+0260", &tail))) n++;
+  if(check_nan("parse_date_time:zone:mins:incomplete", novas_parse_date_format(0, NOVAS_YMD, "2025-01-28 12:50:00+020", &tail))) n++;
 
   return n;
 }


### PR DESCRIPTION
- Replace `cal_date2()` from #121 with `novas_jd_to_calendar()` which converts to dates in the specified type of calendar.
- Add `novas_calendar_to_jd()` to convert dates in specific calendars to JD days.