### PR TITLE
Reinstate CI testing on s390x and ppc64le platforms

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,9 +77,9 @@ jobs:
           - arch: riscv64
             distro: ubuntu_latest
           - arch: s390x
-            distro: ubuntu22.04
+            distro: ubuntu_latest
           - arch: ppc64le
-            distro: ubuntu22.04
+            distro: ubuntu_latest
     steps:
       - uses: actions/checkout@v4
       - uses: uraimo/run-on-arch-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,10 +76,10 @@ jobs:
             distro: ubuntu_latest
           - arch: riscv64
             distro: ubuntu_latest
-#          - arch: s390x
-#            distro: ubuntu_latest
-#          - arch: ppc64le
-#            distro: ubuntu_latest
+          - arch: s390x
+            distro: ubuntu22.04
+          - arch: ppc64le
+            distro: ubuntu22.04
     steps:
       - uses: actions/checkout@v4
       - uses: uraimo/run-on-arch-action@v2


### PR DESCRIPTION
The `run-on-arch-action` workflow has been broken for ppc64le and s390x platforms for a while, with `cc` failing with a Segmentation fault on `ubuntu-latest`. It seems like a compiler bug for the version of `gcc` that is currently on `ubuntu_latest`. Once it is fixed, and the compilation is successful, we can re-merge to `main`.