### PR TITLE
Further date parsing functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,8 @@ such as for handling times and angles as strings, rise and set times, and other 
    "TAI", and `novas_print_timescale()` to convert to string representation.
  
  - #118: New `novas_iso_timestamp()` to print UTC timestamps in ISO date format with millisecond precision, and
-   `novas_timestamp()` to print timestamps in specific timescales.
+   `novas_timestamp()` to print timestamps in specific timescales, and `novas_date()` to convert timestamps back
+   to JD dates.
 
  - #122: New `novas_jd_to_date()`, and `novas_jd_from_date()` which convert between JD day and calendar dates 
    using the specific type of calendar: Gregorian, Roman/Julian, or the conventional calendar of date.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,11 +77,13 @@ such as for handling times and angles as strings, rise and set times, and other 
    "TAI", and `novas_print_timescale()` to convert to string representation.
  
  - #118: New `novas_iso_timestamp()` to print UTC timestamps in ISO date format with millisecond precision, and
-   `novas_timestamp()` to print timestamps in specific timescales, and `novas_date()` to convert timestamps back
-   to JD dates.
+   `novas_timestamp()` to print timestamps in specific timescales.
 
  - #122: New `novas_jd_to_date()`, and `novas_jd_from_date()` which convert between JD day and calendar dates 
    using the specific type of calendar: Gregorian, Roman/Julian, or the conventional calendar of date.
+
+ - #131: New `novas_date()` and `novas_date_scale()` for the simplest conversion of string times to Julian days, and 
+   in case of the latter also to a corresponding timescale.
 
  - Added `example-time.c` and `example-rise-set.c` under `examples/`, for demonstrating date/time handling functions
    and rise, set, and transit time calculations.

--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ dox: README.md Doxyfile apidoc $(SRC) $(INC) README-orig.md
 	@echo "   [doxygen]"
 	@$(DOXYGEN)
 	@rm -f apidoc/html/resources
-	@( cd apidoc/html; ln -s ../../resources )
+	@( cd apidoc/html; rm -f resources; ln -s ../../resources )
 
 .INTERMEDIATE: Doxyfile.local
 Doxyfile.local: Doxyfile Makefile
@@ -212,7 +212,7 @@ Doxyfile.local: Doxyfile Makefile
 .PHONY: local-dox
 local-dox: README-orig.md Doxyfile.local
 	$(DOXYGEN) Doxyfile.local
-	( cd apidoc/html; ln -s ../../resources )
+	( cd apidoc/html; rm -f resources; ln -s ../../resources )
 
 # Default values for install locations
 # See https://www.gnu.org/prep/standards/html_node/Directory-Variables.html 

--- a/examples/example-time.c
+++ b/examples/example-time.c
@@ -44,7 +44,6 @@ int main() {
   int year, month, day;         // broken-down date components
   double hours;                 // broken-down time-of-day component
   char timestamp[40];           // String timestamp, at leat 29 characters.
-  char *tail;                   // Parse position after
 
   // Intermediate variables we'll use -------------------------------------->
   struct timespec ts;           // precision UNIX time
@@ -56,7 +55,7 @@ int main() {
   //   flexibility on how the components are separated, but they must be year,
   //   month, day, then optionally time and possibly time zone also. For
   //   example:
-  jd = novas_parse_date("2025-01-29 18:09:29.333+0200", &tail);
+  jd = novas_date("2025-01-29T18:09:29.333+0200");
 
   // - Next, convert that date to an astronomical time of a specific time
   //   scale. Let's say the above date was on the TAI... (It could be UTC, or

--- a/include/novas.h
+++ b/include/novas.h
@@ -1807,10 +1807,16 @@ int novas_track_pos(const novas_track *track, const novas_timespec *time, double
         double *restrict dist, double *restrict z);
 
 // in timescale.c
+double novas_date(const char *restrict date);
+
+double novas_date_scale(const char *restrict date, enum novas_timescale *restrict scale);
+
 double novas_parse_date(const char *restrict date, char **restrict tail);
 
 double novas_parse_date_format(enum novas_calendar_type calendar, enum novas_date_format format, const char *restrict date,
         char **restrict tail);
+
+enum novas_timescale novas_timescale_for_string(const char *restrict str);
 
 int novas_iso_timestamp(const novas_timespec *restrict time, char *restrict dst, int maxlen);
 
@@ -1818,7 +1824,6 @@ int novas_timestamp(const novas_timespec *restrict time, enum novas_timescale sc
 
 int novas_print_timescale(enum novas_timescale scale, char *restrict buf);
 
-enum novas_timescale novas_timescale_for_string(const char *restrict str);
 
 
 // <================= END of SuperNOVAS API =====================>

--- a/include/novas.h
+++ b/include/novas.h
@@ -1816,11 +1816,11 @@ double novas_parse_date(const char *restrict date, char **restrict tail);
 double novas_parse_date_format(enum novas_calendar_type calendar, enum novas_date_format format, const char *restrict date,
         char **restrict tail);
 
-enum novas_timescale novas_timescale_for_string(const char *restrict str);
-
 int novas_iso_timestamp(const novas_timespec *restrict time, char *restrict dst, int maxlen);
 
 int novas_timestamp(const novas_timespec *restrict time, enum novas_timescale scale, char *restrict dst, int maxlen);
+
+enum novas_timescale novas_timescale_for_string(const char *restrict str);
 
 int novas_print_timescale(enum novas_timescale scale, char *restrict buf);
 

--- a/src/super.c
+++ b/src/super.c
@@ -1554,8 +1554,8 @@ double novas_hms_hours(const char *restrict hms) {
  * (arc)second components may be separated by spaces, tabs, colons `:`, underscore `_`, or a
  * combination thereof. Additionally, the degree and minutes may be semarated by the letter `d`
  * or `D`, and the minutes and seconds may be separated by `m` or `M`, or a single quote `'`.
- * The last component may also be followed by a letter 'N', 'E', 'S', or 'W' signifying a
- * compass direction.
+ * The last component may also be followed immediately by an upper-case letter 'N', 'E', 'S',
+ * or 'W' signifying a compass direction.
  *
  * For example, all of the lines below specify the same angle:
  *
@@ -1565,7 +1565,7 @@ double novas_hms_hours(const char *restrict hms) {
  *  -179d 59' 59.999
  *  -179D59'59.999
  *  179:59:59.999W
- *  179:59:59.999S
+ *  179 59 59.999S
  * </pre>
  *
  *
@@ -1635,14 +1635,19 @@ double novas_parse_dms(const char *restrict dms, char **restrict tail) {
  * Returns the decimal degrees for a DMS string specification. The degree, (arc)minute, and
  * (arc)second components may be separated by spaces, tabs, colons `:`, or a combination thereof.
  * Additionally, the degree and minutes may be semarated by the letter `d` or `D`, and the
- * minutes and seconds may be separated by `m` or `M`, or a single quote `'`. For example, all of
- * the lines below specify the same angle:
+ * minutes and seconds may be separated by `m` or `M`, or a single quote `'`. The last component
+ * may also be followed immediately by an upper-case letter 'N', 'E', 'S', or 'W' signifying a
+ * compass direction.
+ *
+ * For example, all of the lines below specify the same angle:
  *
  * <pre>
  *  -179:59:59.999
  *  -179 59m 59.999
  *  -179d 59' 59.999
  *  -179D59'59.999
+ *  179:59:59.999S
+ *  179 59 59.999W
  * </pre>
  *
  *

--- a/src/super.c
+++ b/src/super.c
@@ -1554,6 +1554,9 @@ double novas_hms_hours(const char *restrict hms) {
  * (arc)second components may be separated by spaces, tabs, colons `:`, underscore `_`, or a
  * combination thereof. Additionally, the degree and minutes may be semarated by the letter `d`
  * or `D`, and the minutes and seconds may be separated by `m` or `M`, or a single quote `'`.
+ * The last component may also be followed by a letter 'N', 'E', 'S', or 'W' signifying a
+ * compass direction.
+ *
  * For example, all of the lines below specify the same angle:
  *
  * <pre>
@@ -1561,6 +1564,8 @@ double novas_hms_hours(const char *restrict hms) {
  *  -179 59m 59.999
  *  -179d 59' 59.999
  *  -179D59'59.999
+ *  179:59:59.999W
+ *  179:59:59.999S
  * </pre>
  *
  *
@@ -1611,12 +1616,19 @@ double novas_parse_dms(const char *restrict dms, char **restrict tail) {
     return NAN;
   }
 
+  s = abs(d) + (m / 60.0) + (s / 3600.0);
+  if (d < 0) s = -s;
+
+  if(dms[n] == 'N' || dms[n] == 'E') n++;
+  else if (dms[n] == 'S' || dms[n] == 'W') {
+    s = -s;
+    n++;
+  }
+
   if(tail)
     *tail += n;
 
-  s = abs(d) + (m / 60.0) + (s / 3600.0);
-
-  return d < 0 ? -s : s;
+  return s;
 }
 
 /**

--- a/src/timescale.c
+++ b/src/timescale.c
@@ -566,7 +566,6 @@ static int parse_zone(const char *str, char **tail) {
 }
 
 
-
 /**
  * Parses a calndar date/time string, expressed in the specified type of calendar, into a Julian
  * day (JD). The date must be composed of a full year (e.g. 2025), a month (numerical or name or
@@ -614,9 +613,9 @@ static int parse_zone(const char *str, char **tail) {
  *                    after the parsed time. The parsing will consume empty space characters after
  *                    the time specification also, returning a pointer to the next token after.
  *
- * @return            The Julian Day corresponding to the string date/time specification or NAN
- *                    if the string is NULL or if it does not specify a date/time in the expected
- *                    format.
+ * @return            [day] The Julian Day corresponding to the string date/time specification or
+ *                    NAN if the string is NULL or if it does not specify a date/time in the
+ *                    expected format.
  *
  * @since 1.3
  * @author Attila Kovacs
@@ -779,13 +778,14 @@ double novas_parse_date_format(enum novas_calendar_type calendar, enum novas_dat
  *                    after the parsed time. The parsing will consume empty space characters after
  *                    the time specification also, returning a pointer to the next token after.
  *
- * @return            The Julian Day corresponding to the string date/time specification or NAN
- *                    if the string is NULL or if it does not specify a date/time in the expected
- *                    format.
+ * @return            [day] The Julian Day corresponding to the string date/time specification or
+ *                    NAN if the string is NULL or if it does not specify a date/time in the
+ *                    expected format.
  *
  * @since 1.3
  * @author Attila Kovacs
  *
+ * @sa novas_date()
  * @sa novas_parse_date_format()
  * @sa novas_timescale_for_string()
  * @sa novas_iso_timestamp()
@@ -795,6 +795,75 @@ double novas_parse_date(const char *restrict date, char **restrict tail) {
   double jd = novas_parse_date_format(NOVAS_ASTRONOMICAL_CALENDAR, NOVAS_YMD, date, tail);
   if(isnan(jd))
     return novas_trace_nan("novas_parse_date");
+  return jd;
+}
+
+/**
+ * Returns a Julian date (in non-specific timescale) corresponding the specified input
+ * string date/time. E.g. for "2025-02-28T09:41:12.041+0200", with some flexibility
+ * on how the date is represented as long as it's YMD date followed by HMS time. For
+ * other date formats (MDY or DMY) you can use `novas_parse_date_format()` instead.
+ *
+ * @param date  The date specification, possibly including time and timezone, in a standard
+ *              format. See novas_parse_date() on more information on acceptable date/time
+ *              formats.
+ * @return      [day] The Julian Day corresponding to the string date/time specification or
+ *              NAN if the string is NULL or if it does not specify a date/time in the
+ *              expected format.
+ *
+ * @since 1.3
+ * @author Attila Kovacs
+ *
+ * @sa novas_date_scale()
+ * @sa novas_parse_date()
+ * @sa novas_parse_date_format()
+ * @sa novas_iso_timestamp()
+ */
+double novas_date(const char *restrict date) {
+  return novas_parse_date(date, NULL);
+}
+
+/**
+ * Returns a Julian date and the timescale corresponding the specified input
+ * string date/time and timescale marker. E.g. for "2025-02-28T09:41:12.041+0200 TAI", with
+ * some flexibility on how the date is represented as long as it's YMD date followed by HMS
+ * time. For other date formats (MDY or DMY) you can use `novas_parse_date_format()` instead.
+ *
+ * @param date          The date specification, possibly including time and timezone, in a
+ *                      standard format. See novas_parse_date() on more information on
+ *                      acceptable date/time formats.
+ * @param[out] scale    The timescale constant, or else -1 if the string could not be parsed
+ *                      into a date and timescale. If the string is a bare timestamp without
+ *                      an hint of a timescale marker, then NOVAS_UTC will be assumed.
+ * @return      [day] The Julian Day corresponding to the string date/time specification or
+ *              NAN if the string is NULL or if it does not specify a date/time in the
+ *              expected format.
+ *
+ * @since 1.3
+ * @author Attila Kovacs
+ *
+ * @sa novas_date()
+ * @sa novas_timestamp()
+ */
+double novas_date_scale(const char *restrict date, enum novas_timescale *restrict scale) {
+  const char *fn = "novas_date_scale";
+
+  char *tail = (char *) date, s[4] = {};
+  double jd = novas_parse_date(date, &tail);
+
+  if(!scale) return novas_error(-1, EINVAL, fn, "output scale is NULL");
+
+  if(isnan(jd))
+    return novas_trace_nan(fn);
+
+  if(sscanf(tail, "%3s", s) == 1) {
+    *scale = novas_timescale_for_string(s);
+    return novas_trace_nan(fn);
+  }
+  else {
+    *scale = NOVAS_UTC;
+  }
+
   return jd;
 }
 

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -1866,6 +1866,25 @@ static int test_parse_date() {
   return n;
 }
 
+static int test_date() {
+  int n = 0;
+
+  if(check_nan("date:null", novas_date(NULL))) n++;
+
+  return n;
+}
+
+static int test_date_scale() {
+  int n = 0;
+  enum novas_timescale scale;
+
+  if(check_nan("date_scale:date:null", novas_date_scale(NULL, &scale))) n++;
+  if(check("date_scale:date:null:scale", -1, scale)) n++;
+  if(check_nan("date_scale:scale:null", novas_date_scale("2025-03-01T11:08:38.338+0200", NULL))) n++;
+
+  return n;
+}
+
 static int test_iso_timestamp() {
   int n = 0;
   char buf[30] = {};
@@ -2065,6 +2084,8 @@ int main() {
   if(test_xyz_to_los()) n++;
   if(test_julian_date()) n++;
   if(test_parse_date()) n++;
+  if(test_date()) n++;
+  if(test_date_scale()) n++;
   if(test_iso_timestamp()) n++;
   if(test_timestamp()) n++;
   if(test_timescale_for_string()) n++;

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -2499,12 +2499,22 @@ static int test_dms_degrees() {
   if(!is_equal("dms_degrees:signed", novas_dms_degrees("+179 59 59.999"), degs, 1e-9)) n++;
   if(!is_equal("dms_degrees:parse", novas_parse_dms("179 59 59.999", &tail), degs, 1e-9)) n++;
 
+  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("179d 59' 59.999N"), degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("-179d 59' 59.999S"), degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("179d 59' 59.999E"), degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("-179d 59' 59.999W"), degs, 1e-9)) n++;
+
   if(!is_equal("dms_degrees:neg:colons", novas_dms_degrees("-179:59:59.999"), -degs, 1e-9)) n++;
   if(!is_equal("dms_degrees:neg:spaces", novas_dms_degrees("-179 59 59.999"), -degs, 1e-9)) n++;
   if(!is_equal("dsm_degrees:neg:dm", novas_dms_degrees("-179d59m59.999"), -degs, 1e-9)) n++;
   if(!is_equal("dms_degrees:neg:DM", novas_dms_degrees("-179D59M59.999"), -degs, 1e-9)) n++;
   if(!is_equal("dms_degrees:neg:dprime", novas_dms_degrees("-179d59'59.999"), -degs, 1e-9)) n++;
   if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("-179d 59' 59.999"), -degs, 1e-9)) n++;
+
+  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("-179d 59' 59.999N"), -degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("179d 59' 59.999S"), -degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("-179d 59' 59.999E"), -degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("179d 59' 59.999W"), -degs, 1e-9)) n++;
 
   return n;
 }
@@ -3091,6 +3101,31 @@ static int test_parse_date_format() {
   return n;
 }
 
+static int test_date() {
+  int n = 0;
+
+  double jd = julian_date(2025, 3, 01, 0.0);
+
+  if(!is_equal("parse_date_format:YMD", novas_date("2025-03-01"), jd, 1e-6)) n++;
+
+  return n;
+}
+
+static int test_date_scale() {
+  int n = 0;
+
+  enum novas_timescale scale;
+  double jd = julian_date(2025, 3, 01, 0.0);
+
+  if(!is_equal("date_scale:check:jd", novas_date_scale("2025-03-01", &scale), jd, 1e-6)) n++;
+  if(!is_equal("date_scale:check:scale:default", scale, NOVAS_UTC, 1e-6)) n++;
+
+  if(!is_equal("date_scale:tai:check:jd", novas_date_scale("2025-03-01 TAI", &scale), jd, 1e-6)) n++;
+  if(!is_equal("date_scale:tai:check:scale:default", scale, NOVAS_TAI, 1e-6)) n++;
+
+  return n;
+}
+
 static int test_iso_timestamp() {
   int n = 0;
   int i;
@@ -3273,6 +3308,8 @@ int main(int argc, char *argv[]) {
   if(test_lsr_vel()) n++;
   if(test_parse_date()) n++;
   if(test_parse_date_format()) n++;
+  if(test_date()) n++;
+  if(test_date_scale()) n++;
   if(test_iso_timestamp()) n++;
   if(test_timestamp()) n++;
   if(test_timescale_for_string()) n++;

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -2504,6 +2504,11 @@ static int test_dms_degrees() {
   if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("179d 59' 59.999E"), degs, 1e-9)) n++;
   if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("-179d 59' 59.999W"), degs, 1e-9)) n++;
 
+  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("179d 59' 59.999 N"), degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("-179d 59' 59.999 S"), degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("179d 59' 59.999 E"), degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("-179d 59' 59.999 W"), degs, 1e-9)) n++;
+
   if(!is_equal("dms_degrees:neg:colons", novas_dms_degrees("-179:59:59.999"), -degs, 1e-9)) n++;
   if(!is_equal("dms_degrees:neg:spaces", novas_dms_degrees("-179 59 59.999"), -degs, 1e-9)) n++;
   if(!is_equal("dsm_degrees:neg:dm", novas_dms_degrees("-179d59m59.999"), -degs, 1e-9)) n++;


### PR DESCRIPTION
- `double novas_date(const char *restrict date);`
- `double novas_date_scale(const char *restrict date, enum novas_timescale *restrict scale);`
- Add parsing tailing compass directions (N, E, S, W) to `novas_parse_dms()` and `novas_dms_degrees()`.