### PR TITLE
degree, minutes, and seconds as extended ASCII symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 Changes for the upcoming feature release, expected around 1 May 2025. It brings many new convenience functions, 
-such as for handling times and angles as strings, rise and set times, and other common astrometric calculations.
+such as for handling times and angles as strings; calculating rise, set, transit times; and other common astrometric 
+calculations.
    
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -869,15 +869,22 @@ __SuperNOVAS__ provides a set of functions to convert broken-down string values 
   
  // ... or with colons
  ra_h = novas_hms_hours("09:18:49.068");
+
+ // ... or with extended ASCII symbols
+ dec_d = novas_dms_degrees("09 18’49.068”");
+  
   
  // Declination as space separated degrees, arc-minutes, and arc-seconds
  double dec_d = novas_dms_degrees("-53 10 07.33");
   
- // .. or separated by colons
+ // ... or separated by colons
  dec_d = novas_dms_degrees("-53:10:07.33");
   
- // .. or with 'd', 'm'...
+ // ... or with 'd', 'm'...
  dec_d = novas_dms_degrees("-53d10m07.33s");
+ 
+ // ... or with extended ASCII symbols
+ dec_d = novas_dms_degrees("-52°10’07.22”");
 ```
 
 <a name="string-dates"></a>

--- a/examples/example-time.c
+++ b/examples/example-time.c
@@ -58,15 +58,14 @@ int main() {
   //   example:
   jd = novas_date("2025-01-29T18:09:29.333+0200");
 
+  // Alternatively, you could use a string time that also contains a timescale
+  // specification:
+  jd = novas_date_scale("2025-01-29 18:09:29.333+0200 TAI", &scale);
+
   // - Next, convert that date to an astronomical time of a specific time
   //   scale. Let's say the above date was on the TAI... (It could be UTC, or
   //   GPS, or TDB...)
   novas_set_time(NOVAS_TAI, jd, LEAP_SECONDS, DUT1, &time1);
-
-  // Alternatively, you could use a string time that also contains a timescale
-  // specification:
-  jd = novas_date_scale("2025-01-29 18:09:29.333+0200 TAI", &scale);
-  novas_set_time(scale, jd, LEAP_SECONDS, DUT1, &time1);
 
 
   // -------------------------------------------------------------------------

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -2488,7 +2488,7 @@ static int test_hms_hours() {
 
 static int test_dms_degrees() {
   int n = 0;
-  double degs = 179.0 + 59.0/60.0 + 59.999/3600.0;
+  double degs = 179.0 + 59.0 / 60.0 + 59.999 / 3600.0;
   char *tail = NULL;
 
   if(!is_equal("dms_degrees:colons", novas_dms_degrees("179:59:59.999"), degs, 1e-9)) n++;
@@ -2500,15 +2500,15 @@ static int test_dms_degrees() {
   if(!is_equal("dms_degrees:signed", novas_dms_degrees("+179 59 59.999"), degs, 1e-9)) n++;
   if(!is_equal("dms_degrees:parse", novas_parse_dms("179 59 59.999", &tail), degs, 1e-9)) n++;
 
-  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("179d 59' 59.999N"), degs, 1e-9)) n++;
-  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("-179d 59' 59.999S"), degs, 1e-9)) n++;
-  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("179d 59' 59.999E"), degs, 1e-9)) n++;
-  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("-179d 59' 59.999W"), degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:combo:N", novas_dms_degrees("179d 59' 59.999N"), degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:combo:S", novas_dms_degrees("-179d 59' 59.999S"), degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:combo:E", novas_dms_degrees("179d 59' 59.999E"), degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:combo:W", novas_dms_degrees("-179d 59' 59.999W"), degs, 1e-9)) n++;
 
-  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("179d 59' 59.999 N"), degs, 1e-9)) n++;
-  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("-179d 59' 59.999 S"), degs, 1e-9)) n++;
-  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("179d 59' 59.999 E"), degs, 1e-9)) n++;
-  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("-179d 59' 59.999 W"), degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:combo:+N", novas_dms_degrees("179d 59' 59.999 N"), degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:combo:+S", novas_dms_degrees("-179d 59' 59.999 S"), degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:combo:+E", novas_dms_degrees("179d 59' 59.999 E"), degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:combo:+W", novas_dms_degrees("-179d 59' 59.999 W"), degs, 1e-9)) n++;
 
   if(!is_equal("dms_degrees:neg:colons", novas_dms_degrees("-179:59:59.999"), -degs, 1e-9)) n++;
   if(!is_equal("dms_degrees:neg:spaces", novas_dms_degrees("-179 59 59.999"), -degs, 1e-9)) n++;
@@ -2517,11 +2517,17 @@ static int test_dms_degrees() {
   if(!is_equal("dms_degrees:neg:dprime", novas_dms_degrees("-179d59'59.999"), -degs, 1e-9)) n++;
   if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("-179d 59' 59.999"), -degs, 1e-9)) n++;
 
-  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("-179d 59' 59.999N"), -degs, 1e-9)) n++;
-  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("179d 59' 59.999S"), -degs, 1e-9)) n++;
-  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("-179d 59' 59.999E"), -degs, 1e-9)) n++;
-  if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("179d 59' 59.999W"), -degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:neg:combo:N", novas_dms_degrees("-179d 59' 59.999N"), -degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:neg:combo:S", novas_dms_degrees("179d 59' 59.999S"), -degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:neg:combo:E", novas_dms_degrees("-179d 59' 59.999E"), -degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:neg:combo:W", novas_dms_degrees("179d 59' 59.999W"), -degs, 1e-9)) n++;
 
+
+  if(!is_equal("dms_degrees:neg:combo:W+", novas_parse_dms("179d 59' 59.999W ", NULL), -degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:neg:combo:_W_", novas_parse_dms("179_59_59.999W_", NULL), -degs, 1e-9)) n++;
+
+  if(!is_equal("dms_degrees:neg:combo:Whatever", novas_dms_degrees("179d 59' 59.999 Whatever"), degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:neg:combo:_Whatever", novas_dms_degrees("179_59_59.999_Whatever"), degs, 1e-9)) n++;
   return n;
 }
 

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -2476,8 +2476,9 @@ static int test_hms_hours() {
 
   if(!is_equal("hms_hours:colons", novas_hms_hours("23:59:59.999"), hours, 1e-10)) n++;
   if(!is_equal("hms_hours:spaces", novas_hms_hours("23 59 59.999"), hours, 1e-10)) n++;
-  if(!is_equal("hms_hours:hm", novas_hms_hours("23h59m59.999"), hours, 1e-10)) n++;
-  if(!is_equal("hms_hours:HM", novas_hms_hours("23H59M59.999"), hours, 1e-10)) n++;
+  if(!is_equal("hms_hours:hm", novas_hms_hours("23h59m59.999s"), hours, 1e-10)) n++;
+  if(!is_equal("hms_hours:HM", novas_hms_hours("23H59M59.999S"), hours, 1e-10)) n++;
+  if(!is_equal("hms_hours:HM", novas_hms_hours("23 59’59.999”"), hours, 1e-10)) n++;
   if(!is_equal("hms_hours:hprime", novas_hms_hours("23h59'59.999"), hours, 1e-10)) n++;
   if(!is_equal("hms_hours:combo", novas_hms_hours("23h 59' 59.999"), hours, 1e-10)) n++;
   if(!is_equal("hms_hours:parse", novas_parse_hms("23 59 59.999", &tail), hours, 1e-10)) n++;
@@ -2492,8 +2493,8 @@ static int test_dms_degrees() {
 
   if(!is_equal("dms_degrees:colons", novas_dms_degrees("179:59:59.999"), degs, 1e-9)) n++;
   if(!is_equal("dms_degrees:spaces", novas_dms_degrees("179 59 59.999"), degs, 1e-9)) n++;
-  if(!is_equal("dsm_degrees:dm", novas_dms_degrees("179d59m59.999"), degs, 1e-9)) n++;
-  if(!is_equal("dms_degrees:DM", novas_dms_degrees("179D59M59.999"), degs, 1e-9)) n++;
+  if(!is_equal("dsm_degrees:dms", novas_dms_degrees("179d59m59.999s"), degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:symbols", novas_dms_degrees("179°59’59.999”"), degs, 1e-9)) n++;
   if(!is_equal("dms_degrees:dprime", novas_dms_degrees("179d59'59.999"), degs, 1e-9)) n++;
   if(!is_equal("dms_degrees:combo", novas_dms_degrees("179d 59' 59.999"), degs, 1e-9)) n++;
   if(!is_equal("dms_degrees:signed", novas_dms_degrees("+179 59 59.999"), degs, 1e-9)) n++;
@@ -2511,8 +2512,8 @@ static int test_dms_degrees() {
 
   if(!is_equal("dms_degrees:neg:colons", novas_dms_degrees("-179:59:59.999"), -degs, 1e-9)) n++;
   if(!is_equal("dms_degrees:neg:spaces", novas_dms_degrees("-179 59 59.999"), -degs, 1e-9)) n++;
-  if(!is_equal("dsm_degrees:neg:dm", novas_dms_degrees("-179d59m59.999"), -degs, 1e-9)) n++;
-  if(!is_equal("dms_degrees:neg:DM", novas_dms_degrees("-179D59M59.999"), -degs, 1e-9)) n++;
+  if(!is_equal("dsm_degrees:neg:dms", novas_dms_degrees("-179d59m59.999s"), -degs, 1e-9)) n++;
+  if(!is_equal("dms_degrees:neg:symbols", novas_dms_degrees("-179°59’59.999”"), -degs, 1e-9)) n++;
   if(!is_equal("dms_degrees:neg:dprime", novas_dms_degrees("-179d59'59.999"), -degs, 1e-9)) n++;
   if(!is_equal("dms_degrees:neg:combo", novas_dms_degrees("-179d 59' 59.999"), -degs, 1e-9)) n++;
 


### PR DESCRIPTION
Be able to parse, e.g.:

```
 -179°59’59.999”
```