### PR TITLE
Add novas_parse_timescale()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,10 @@ calculations.
    using the specific type of calendar: Gregorian, Roman/Julian, or the conventional calendar of date.
 
  - #131: New `novas_date()` and `novas_date_scale()` for the simplest conversion of string times to Julian days, and 
-   in case of the latter also to a corresponding timescale.
+   in case of the latter also to a corresponding timescale.'
+   
+ - #133: New `novas_parse_timescale()` to parse a timescale from a string specification, and return the updated parse
+   position after also.
 
  - Added `example-time.c` and `example-rise-set.c` under `examples/`, for demonstrating date/time handling functions
    and rise, set, and transit time calculations.

--- a/include/novas.h
+++ b/include/novas.h
@@ -1822,6 +1822,8 @@ int novas_timestamp(const novas_timespec *restrict time, enum novas_timescale sc
 
 enum novas_timescale novas_timescale_for_string(const char *restrict str);
 
+enum novas_timescale novas_parse_timescale(const char *restrict str, char **restrict tail);
+
 int novas_print_timescale(enum novas_timescale scale, char *restrict buf);
 
 

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -1921,6 +1921,16 @@ static int test_timescale_for_string() {
   return n;
 }
 
+static int test_parse_timescale() {
+  int n = 0;
+  char *tail = NULL;
+
+  if(check("parse_timescale:null", -1, novas_parse_timescale(NULL, &tail))) n++;
+  if(check("parse_timescale:invalid", -1, novas_parse_timescale("blah", &tail))) n++;
+
+  return n;
+}
+
 int test_print_timescale() {
   int n = 0;
   char buf[4] = {};
@@ -2089,6 +2099,7 @@ int main() {
   if(test_iso_timestamp()) n++;
   if(test_timestamp()) n++;
   if(test_timescale_for_string()) n++;
+  if(test_parse_timescale()) n++;
   if(test_print_timescale()) n++;
 
   if(n) fprintf(stderr, " -- FAILED %d tests\n", n);

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -3201,6 +3201,19 @@ static int test_timescale_for_string() {
   return n;
 }
 
+static int test_parse_timescale() {
+  int n = 0;
+  char *str = "UTC";
+  char *tail = NULL;
+
+  if(!is_equal("parse_timescale:UTC", novas_parse_timescale(str, &tail), NOVAS_UTC, 1e-6)) n++;
+  if(!is_equal("parse_timescale:UTC:tail", (double) (tail - str), 3, 1e-6)) n++;
+  if(!is_equal("parse_timescale:UTC:notail", novas_parse_timescale("UTC", NULL), NOVAS_UTC, 1e-6)) n++;
+  if(!is_equal("parse_timescale:UTC:leading", novas_parse_timescale(" UTC", &tail), NOVAS_UTC, 1e-6)) n++;
+
+  return n;
+}
+
 static int test_timestamp() {
   int n = 0;
   int i;
@@ -3325,6 +3338,7 @@ int main(int argc, char *argv[]) {
   if(test_iso_timestamp()) n++;
   if(test_timestamp()) n++;
   if(test_timescale_for_string()) n++;
+  if(test_parse_timescale()) n++;
   if(test_julian_date()) n++;
   if(test_jd_to_calendar()) n++;
   if(test_calendar_to_jd()) n++;


### PR DESCRIPTION
Like `novas_timescale_for_string()` but ignores leading white spaces and also returns an updated parse position.