### PR TITLE
Add `novas_str_degrees()` and `novas_str_hours()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@ calculations.
    floating point values for SuperNOVAS, and return the parse position after the time/angle specification.
 
  - #135: New `novas_str_hours()` and `novas_str_degrees()` for the simplest conversion of strings in decimal or 
-   HMS/DMS formats to floating point values for SuperNOVAS.
+   HMS/DMS formats to floating point values for SuperNOVAS (without parse position).
 
  - Added `example-time.c` and `example-rise-set.c` under `examples/`, for demonstrating date/time handling functions
    and rise, set, and transit time calculations. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,8 +92,11 @@ calculations.
  - #134: New `novas_parse_hours()` and `novas_parse_degrees()` to convert strings in decimal or HMS/DMS formats to 
    floating point values for SuperNOVAS, and return the parse position after the time/angle specification.
 
+ - #135: New `novas_str_hours()` and `novas_str_degrees()` for the simplest conversion of strings in decimal or 
+   HMS/DMS formats to floating point values for SuperNOVAS.
+
  - Added `example-time.c` and `example-rise-set.c` under `examples/`, for demonstrating date/time handling functions
-   and rise, set, and transit time calculations.
+   and rise, set, and transit time calculations. 
 
 ### Changed
  

--- a/README.md
+++ b/README.md
@@ -858,33 +858,34 @@ __SuperNOVAS__ functions typically input and output time and angles as decimal v
 days and hour-angles), but that is not how these are represented in many cases. Time and right-ascention are often 
 given as string values indicating hours, minutes, and seconds (e.g. "11:32:31.595", or "11h 32m 31.595s"). Similarly 
 angles, are commonly represented as degrees, arc-minutes, and arc-seconds (e.g. "+53 60 19.9"). For that reason, 
-__SuperNOVAS__ provides a set of functions to convert broken-down string values to decimal representations. E.g.,
+__SuperNOVAS__ provides a set of functions to convert string values expressed in decimal or broken-down format to floating
+point representation. E.g.,
 
 ```c
- // Right ascention as space-separated values
- double ra_h = novas_hms_hours("9 18 49.068");
+ // Right ascention from string
+ double ra_h = novas_str_hours("9 18 49.068");
 
- // ... or separated by 'h', 'm'...
- ra_h = novas_hms_hours("09h18m49.068s");
-  
- // ... or with colons
- ra_h = novas_hms_hours("09:18:49.068");
- 
- // ... or with single/double quotes for minutes/seconds
- ra_h = novas_hms_hours("09h18'49.068\""); 
- 
- // Declination as space separated degrees, arc-minutes, and arc-seconds
- double dec_d = novas_dms_degrees("-53 10 07.33");
-  
- // ... or separated by colons
- dec_d = novas_dms_degrees("-53:10:07.33");
-  
- // ... or with 'd', 'm'...
- dec_d = novas_dms_degrees("-53d10m07.33s");
- 
- // ... or with single/double quotes for minutes/seconds
- dec_d = novas_dms_degrees("-53d10'07.33s\"");
+ // Declination from string
+ double dec_d = novas_str_degrees("-53 10 07.33");
 ```
+
+The conversions have a lot of flexibility. Components can be separated by spaces (as above), by colons, commas, or
+underscores, by the letters 'h'/'d', 'm', and 's', by single (minutes) and double quotes (seconds), or any combination 
+thereof. Decimal values may be followed by 'h' or 'd' unit markers. Additionally angles can end with a compass 
+direction, such as 'N', 'E', 'S' or 'W'. So the above could also have been:
+
+```c
+ double ra_h = novas_str_hours("9h_18:49.068\"");
+ double dec_d = novas_str_degrees("53d 10'_07.33W");
+```
+
+or as decimals:
+
+```c
+ double ra_h = novas_str_hours("19.31363");
+ double dec_d = novas_str_degrees("53.16870278d S");
+```
+
 
 <a name="string-dates"></a>
 ### String dates

--- a/README.md
+++ b/README.md
@@ -871,7 +871,7 @@ point representation. E.g.,
 
 The conversions have a lot of flexibility. Components can be separated by spaces (as above), by colons, commas, or
 underscores, by the letters 'h'/'d', 'm', and 's', by single (minutes) and double quotes (seconds), or any combination 
-thereof. Decimal values may be followed by 'h' or 'd' unit markers. Additionally angles can end with a compass 
+thereof. Decimal values may be followed by 'h' or 'd' unit markers. Additionally, angles can end with a compass 
 direction, such as 'N', 'E', 'S' or 'W'. So the above could also have been:
 
 ```c

--- a/examples/example-high-z.c
+++ b/examples/example-high-z.c
@@ -58,8 +58,13 @@ int main() {
   // -------------------------------------------------------------------------
   // Define a high-z source.
 
-  // 12h29m6.6997s +2d3m8.598s (ICRS) z=0.158339
-  if(make_redshifted_object("3c273", 12.4851944, 2.0523883, 0.158339, &source) != 0) {
+  // 3c273: 12h29m6.6997s +2d3m8.598s (ICRS), z=0.158339
+
+  // Convert string coordinates to hours/degrees...
+  double ra0 = novas_str_hours("12h29m6.6997s");
+  double dec0 = novas_str_degrees("+2d3m8.598s");
+
+  if(make_redshifted_object("3c273", ra0, dec0, 0.158339, &source) != 0) {
     fprintf(stderr, "ERROR! defining cat_entry.\n");
     return 1;
   }

--- a/examples/example-star.c
+++ b/examples/example-star.c
@@ -63,11 +63,15 @@ int main() {
   // NOTE, that make_cat_entry() expects radial velocities defined relative to the
   // Solar-System Barycenter (SSB). But you can convert LSR-basec velocities to
   // the required SSB-based radial velocities using novas_lsr_to_ssb_vel() if needed.
-  if(make_cat_entry("Antares", "FK4", 1, 16.43894213, -26.323094, -12.11, -23.30, 5.89, -3.4, &star) != 0) {
+
+  // Convert string coordinates to hours/degrees...
+  double ra0 = novas_str_hours("16h26m20.1918s");
+  double dec0 =  novas_str_degrees("-26d19m23.138s");
+
+  if(make_cat_entry("Antares", "FK4", 1, ra0, dec0, -12.11, -23.30, 5.89, -3.4, &star) != 0) {
     fprintf(stderr, "ERROR! defining cat_entry.\n");
     return 1;
   }
-
   // First change the catalog coordinates (in place) to the J2000 (FK5) system...
   if(transform_cat(CHANGE_EPOCH, NOVAS_JD_B1950, &star, NOVAS_JD_J2000, "FK5", &star) != 0) {
     fprintf(stderr, "ERROR! converting B1950 catalog coordinates to J2000.\n");

--- a/include/novas.h
+++ b/include/novas.h
@@ -1761,6 +1761,10 @@ double novas_hms_hours(const char *restrict hms);
 
 double novas_dms_degrees(const char *restrict dms);
 
+double novas_str_hours(const char *restrict hms);
+
+double novas_str_degrees(const char *restrict dms);
+
 double novas_parse_hms(const char *restrict str, char **restrict tail);
 
 double novas_parse_dms(const char *restrict str, char **restrict tail);

--- a/src/parse.c
+++ b/src/parse.c
@@ -25,16 +25,18 @@
  * minutes and seconds may be separated by `m` or a single quote `'`. The seconds may be followed
  * by 's' or double quote `"`.
  *
- * Additionally, the hour and minutes may be separated by the letter `h`, and the minutes and
- * seconds may be separated by `m`, or a single quote `'`. For example, all of the lines below
- * specify the same time:
+ * For example, all of the lines below are valid specifications:
  *
  * <pre>
  *  23:59:59.999
  *  23h 59m 59.999
  *  23h59'59.999
  *  23 59 59.999
+ *  23 59
  * </pre>
+ *
+ * At least the leading two components (hours and minutes) are required. If the seconds are
+ * ommitted, they will be assumed zero, i.e. `23:59` is the same as `23:59:00.000`.
  *
  * @param hms         String specifying hours, minutes, and seconds, which correspond to
  *                    a time between 0 and 24 h. Time in any range is permitted, but the minutes and
@@ -48,13 +50,14 @@
  * @author Attila Kovacs
  *
  * @sa novas_hms_hours()
+ * @sa novas_parse_hours()
  * @sa novas_parse_dms()
  */
 double novas_parse_hms(const char *restrict hms, char **restrict tail) {
   static const char *fn = "novas_hms_hours";
 
   int h = 0, m = 0, n = 0, k = 0;
-  double s = NAN;
+  double s = 0.0;
   char next;
 
   if(tail)
@@ -69,7 +72,7 @@ double novas_parse_hms(const char *restrict hms, char **restrict tail) {
     return NAN;
   }
 
-  if(sscanf(hms, "%d%*[:hH _\t]%d%*[:mM'’ _\t]%lf%n", &h, &m, &s, &n) < 3) {
+  if(sscanf(hms, "%d%*[:hH _\t]%d%n%*[:mM'’ _\t]%lf%n", &h, &m, &n, &s, &n) < 2) {
     novas_error(0, EINVAL, fn, "not in HMS format: '%s'", hms);
     return NAN;
   }
@@ -89,7 +92,7 @@ double novas_parse_hms(const char *restrict hms, char **restrict tail) {
 
   // The trailing markers must be standalone (end of string or followed by white space)
   next = hms[n + k];
-  if(next == '\0' || next == '_' || isspace(next))
+  if(next == '\0' || next == '_' || isspace(next) || ispunct(next))
     n += k;
 
   if(tail)
@@ -113,7 +116,19 @@ double novas_parse_hms(const char *restrict hms, char **restrict tail) {
  *  23h 59m 59.999s
  *  23h59'59.999
  *  23 59 59.999
+ *  23 59
+ *  23h
  * </pre>
+ *
+ * At least the leading two components (hours and minutes) are required. If the seconds are
+ * ommitted, they will be assumed zero, i.e. `23:59` is the same as `23:59:00.000`.
+ *
+ * NOTES:
+ * <ol>
+ * <li> To see if the string was fully parsed when returning a valid (non-NAN) value, you can check
+ * `errno`: it should be zero (0) if all non-whitespace characters have been parsed from the input
+ * string, or else `EINVAL` if the parsed value used only the leading part of the string.</li>
+ * </ol>
  *
  * @param hms         String specifying hours, minutes, and seconds, which correspond to
  *                    a time between 0 and 24 h. Time in any range is permitted, but the minutes and
@@ -124,10 +139,24 @@ double novas_parse_hms(const char *restrict hms, char **restrict tail) {
  * @since 1.3
  * @author Attila Kovacs
  *
+ * @sa novas_str_hours()
+ * @sa novas_parse_hms()
  * @sa novas_dms_degrees()
  */
 double novas_hms_hours(const char *restrict hms) {
-  return novas_parse_hms(hms, NULL);
+  char *tail = (char *) hms;
+  double h = novas_parse_hms(hms, &tail);
+  if(isnan(h))
+    return novas_trace_nan("novas_hms_hours");
+
+  errno = 0;
+
+  // Skip trailing white spaces / punctuation
+  while(*tail && (isspace(*tail) || ispunct(*tail))) tail++;
+  if(*tail)
+    errno = EINVAL;
+
+  return h;
 }
 
 /**
@@ -139,7 +168,7 @@ double novas_hms_hours(const char *restrict hms) {
  * be followed by a standalone upper-case letter 'N', 'E', 'S', or 'W' signifying a compass
  * direction.
  *
- * For example, all of the lines below specify the same angle:
+ * For example, all of the lines below are valid specifications:
  *
  * <pre>
  *  -179:59:59.999
@@ -148,7 +177,11 @@ double novas_hms_hours(const char *restrict hms) {
  *  179:59:59.999S
  *  179:59:59.999 W
  *  179_59_59.999__S
+ *  179 59 S
  * </pre>
+ *
+ * At least the leading two components (degrees and arcminutes) are required. If the arcseconds
+ * are ommitted, they will be assumed zero, i.e. `179:59` is the same as `179:59:00.000`.
  *
  * @param dms         String specifying degrees, minutes, and seconds, which correspond to
  *                    an angle. Angles in any range are permitted, but the minutes and
@@ -161,14 +194,16 @@ double novas_hms_hours(const char *restrict hms) {
  * @since 1.3
  * @author Attila Kovacs
  *
+ *
  * @sa novas_dms_degrees()
+ * @sa novas_parse_degrees()
  * @sa novas_parse_hms()
  */
 double novas_parse_dms(const char *restrict dms, char **restrict tail) {
   static const char *fn = "novas_dms_degrees";
 
   int d = 0, m = 0, n = 0, k = 0, l = 0;
-  double s = NAN;
+  double s = 0.0;
   char next, compass[3] = {};
 
   if(tail)
@@ -183,7 +218,7 @@ double novas_parse_dms(const char *restrict dms, char **restrict tail) {
     return NAN;
   }
 
-  if(sscanf(dms, "%d%*[:d _\t]%d%*[:m' _\t]%lf%n", &d, &m, &s, &n) < 3) {
+  if(sscanf(dms, "%d%*[:d _\t]%d%n%*[:m' _\t]%lf%n", &d, &m, &n, &s, &n) < 2) {
     novas_error(0, EINVAL, fn, "not in DMS format: '%s'", dms);
     return NAN;
   }
@@ -213,7 +248,7 @@ double novas_parse_dms(const char *restrict dms, char **restrict tail) {
 
   // Compass direction (if any)
   if(sscanf(&dms[n + k], "%2s%n", compass, &l) > 0) {
-    if(compass[1] == '_')
+    if(compass[1] == '_' || ispunct(compass[1]))
       compass[1] = '\0';
 
     if(strcmp(compass, "N") == 0 || strcmp(compass, "E") == 0) {
@@ -227,7 +262,7 @@ double novas_parse_dms(const char *restrict dms, char **restrict tail) {
 
   // The trailing markers must be standalone (end of string or followed by white space)
   next = dms[n + k];
-  if(next == '\0' || next == '_' || isspace(next))
+  if(next == '\0' || next == '_' || isspace(next) || ispunct(next))
     n += k;
 
   if(tail)
@@ -244,7 +279,7 @@ double novas_parse_dms(const char *restrict dms, char **restrict tail) {
  * double quote `"`. Finally, the last component may additionally be followed by a standalone
  * upper-case letter 'N', 'E', 'S', or 'W' signifying a compass direction.
  *
- * For example, all of the lines below specify the same angle:
+ * For example, all of the lines below are valid specifications:
  *
  * <pre>
  *  -179:59:59.999
@@ -255,6 +290,16 @@ double novas_parse_dms(const char *restrict dms, char **restrict tail) {
  *  179_59_59.999__S
  * </pre>
  *
+ * At least the leading two components (degrees and arcminutes) are required. If the arcseconds
+ * are ommitted, they will be assumed zero, i.e. `179:59` is the same as `179:59:00.000`.
+ *
+ * NOTES:
+ * <ol>
+ * <li> To see if the string was fully parsed when returning a valid (non-NAN) value, you can check
+ * `errno`: it should be zero (0) if all non-whitespace characters have been parsed from the input
+ * string, or else `EINVAL` if the parsed value used only the leading part of the string.</li>
+ * </ol>
+ *
  * @param dms         String specifying degrees, minutes, and seconds, which correspond to
  *                    an angle. Angles in any range are permitted, but the minutes and
  *                    seconds must be &gt;=0 and &lt;60.
@@ -264,22 +309,38 @@ double novas_parse_dms(const char *restrict dms, char **restrict tail) {
  * @since 1.3
  * @author Attila Kovacs
  *
+ * @sa novas_str_degrees()
+ * @sa novas_parse_dms()
  * @sa novas_hms_hours()
  */
 double novas_dms_degrees(const char *restrict dms) {
-  return novas_parse_dms(dms, NULL);
+  char *tail = (char *) dms;
+  double deg = novas_parse_dms(dms, &tail);
+  if(isnan(deg))
+    return novas_trace_nan("novas_dms_degrees");
+
+  errno = 0;
+
+  // Skip trailing white spaces / punctuation
+  while(*tail && (isspace(*tail) || ispunct(*tail))) tail++;
+  if(*tail)
+    errno = EINVAL;
+
+  return deg;
 }
 
 /**
- * Parses an angle in degrees from a string that contains either a decimal degrees
- * or else a broken-down DMS representation. Like in the case of `novas_dms_degrees()`
- * and `novas_parse_dms()`, the decimal value may also be followed by a compass
- * direction: `N`, `E`, `S`, or `W`. A few examples of angles that may be parsed:
+ * Parses an angle in degrees from a string that contains either a decimal degrees or else a
+ * broken-down DMS representation. Like in the case of `novas_parse_dms()`, the decimal value
+ * may also be followed by a compass direction: `N`, `E`, `S`, or `W`.
+ *
+ * A few examples of angles that may be parsed:
  *
  * <pre>
  *  -179:59:59.999
  *  -179d 59m 59.999s
  *  179 59 59.999 S
+ *  179 59 S
  *  -179.99999d
  *  -179.99999
  *  179.99999W
@@ -289,19 +350,22 @@ double novas_dms_degrees(const char *restrict dms) {
  *
  * @param str         The input string that specified an angle either as decimal degrees
  *                    or as a broken down DMS speficication. The decimal value may be
- *                    followed by the letter d or the degree symbol (`0xB0`) immediately. And both the
- *                    decimal and DMS representation may be ended with a compass direction marker,
- *                    `N`, `E`, `S`, or `W`. See more in `novas_parse_dms()` on acceptable DSM
+ *                    followed by the letter `d` immediately. And both the decimal and DMS
+ *                    representation may be ended with a compass direction marker,
+ *                    `N`, `E`, `S`, or `W`. See more in `novas_parse_dms()` on acceptable DMS
  *                    specifications.
  * @param[out] tail   (optional) If not NULL it will be set to the next character in the string after
  *                    the parsed angle.
- * @return            [deg] The angle represented by the string
+ * @return            [deg] The angle represented by the string, or else NAN if the
+ *                    string could not be parsed into an angle value (errno will indicate
+ *                    the type of error).
  *
  * @since 1.3
  * @author Attila Kovacs
  *
- * @sa novas_parse_hours()
+ * @sa novas_str_degrees()
  * @sa novas_parse_dms()
+ * @sa novas_parse_hours()
  */
 double novas_parse_degrees(const char *restrict str, char **restrict tail) {
   static const char *fn = "novas_parse_degrees";
@@ -334,6 +398,9 @@ double novas_parse_degrees(const char *restrict str, char **restrict tail) {
         n++;
 
       if(sscanf(&str[n], "%2s%n", compass, &n2) > 0) {
+        if(compass[1] == '_' || ispunct(compass[1])) /// Punctuation after first character
+          compass[1] = '\0';
+
         if(strcmp(compass, "N") == 0 || strcmp(compass, "E") == 0) {
           n += n2;
         }
@@ -347,7 +414,7 @@ double novas_parse_degrees(const char *restrict str, char **restrict tail) {
         *tail += n;
     }
     else {
-      novas_error(0, EINVAL, fn, "invalid angle specification: %s", str);
+      novas_error(0, EINVAL, fn, "invalid angle specification: '%s'", str);
       return NAN;
     }
   }
@@ -356,9 +423,9 @@ double novas_parse_degrees(const char *restrict str, char **restrict tail) {
 }
 
 /**
- * Parses a time or time-like angle from a string that contains either a decimal hours
- * or else a broken-down HMS representation. Like in the case of `novas_hms_hours()`
- * and `novas_parse_hms()`.
+ * Parses a time or time-like angle from a string that contains either a decimal hours or else a
+ * broken-down HMS representation.
+ *
  * A few examples of angles that may be parsed:
  *
  * <pre>
@@ -371,19 +438,22 @@ double novas_parse_degrees(const char *restrict str, char **restrict tail) {
  * </pre>
  *
  *
- * @param str         The input string that specified an angle either as decimal degrees
- *                    or as a broken down DMS speficication. The decimal value may be immediately
- *                    followed by a letter 'h'. See more in
- *                    `novas_parse_dms()` on acceptable DSM specifications.
+ * @param str         The input string that specified an angle either as decimal hours
+ *                    or as a broken down HMS speficication. The decimal value may be immediately
+ *                    followed by a letter 'h'. See more in `novas_parse_hms()` on acceptable HMS
+ *                    input specifications.
  * @param[out] tail   (optional) If not NULL it will be set to the next character in the string after
  *                    the parsed angle.
- * @return            [h] The time-like value represented by the string
+ * @return            [h] The time-like value represented by the string, or else NAN if the
+ *                    string could not be parsed into a time-like value (errno will indicate
+ *                    the type of error).
  *
  * @since 1.3
  * @author Attila Kovacs
  *
- * @sa novas_parse_hours()
- * @sa novas_parse_dms()
+ * @sa novas_str_hours()
+ * @sa novas_parse_hms()
+ * @sa novas_parse_degrees()
  */
 double novas_parse_hours(const char *restrict str, char **restrict tail) {
   static const char *fn = "novas_parse_hours";
@@ -413,10 +483,95 @@ double novas_parse_hours(const char *restrict str, char **restrict tail) {
         *tail += n;
     }
     else {
-      novas_error(0, EINVAL, fn, "invalid time specification: %s", str);
+      novas_error(0, EINVAL, fn, "invalid time specification: '%s'", str);
       return NAN;
     }
   }
 
   return h;
 }
+
+/**
+ * Returns an angle parsed from a string that contains either a decimal degrees or else a broken-down
+ * DMS representation. See `novas_parse_degrees()` to see what string representations may be used.
+ *
+ * To see if the string was fully parsed when returning a valid (non-NAN) value, you can check
+ * `errno`: it should be zero (0) if all non-whitespace and punctuation characters have been parsed
+ * from the input string, or else `EINVAL` if the parsed value used only the leading part of the
+ * string.
+ *
+ *
+ * @param str         The input string that specified an angle either as decimal degrees
+ *                    or as a broken down DMS speficication. The decimal value may be immediately
+ *                    followed by a letter 'd'. See more in `novas_parse_degrees()` on acceptable
+ *                    input specifications.
+ * @return            [deg] The angle represented by the string, or else NAN if the
+ *                    string could not be parsed into an angle  value (errno will indicate
+ *                    the type of error).
+ *
+ * @since 1.3
+ * @author Attila Kovacs
+ *
+ * @sa novas_parse_degrees()
+ * @sa novas_parse_dms()
+ * @sa novas_str_hours()
+ */
+double novas_str_degrees(const char *restrict str) {
+  char *tail = (char *) str;
+  double deg = novas_parse_degrees(str, &tail);
+  if(isnan(deg))
+    return novas_trace_nan("novas_str_degrees");
+
+  errno = 0;
+
+  // Skip trailing white spaces / punctuation
+  while(*tail && (isspace(*tail) || ispunct(*tail))) tail++;
+  if(*tail)
+    errno = EINVAL;
+
+  return deg;
+}
+
+/**
+ * Returns a time or time-like angleparsed  from a string that contains either a decimal hours
+ * or else a broken-down HMS representation. See `novas_parse_hours()` to see what string
+ * representations may be used.
+ *
+ * To check if the string was fully parsed when returning a valid (non-NAN) value you can check
+ * `errno`: it should be zero (0) if all non-whitespace and punctuation characters have been parsed
+ * from the input string, or else `EINVAL` if the parsed value used only the leading part of the
+ * string.
+ *
+ *
+ * @param str         The input string that specified an angle either as decimal hours
+ *                    or as a broken down HMS speficication. The decimal value may be
+ *                    immediately followed by a letter 'h'. See more in `novas_parse_hours()`
+ *                    on acceptable input specifications.
+ * @return            [h] The time-like value represented by the string, or else NAN if the
+ *                    string could not be parsed into a time-like value (errno will indicate
+ *                    the type of error).
+ *
+ * @since 1.3
+ * @author Attila Kovacs
+ *
+ * @sa novas_parse_hours()
+ * @sa novas_parse_hms()
+ * @sa novas_str_degrees()
+ */
+double novas_str_hours(const char *restrict str) {
+  char *tail = (char *) str;
+  double h = novas_parse_hours(str, &tail);
+  if(isnan(h))
+    return novas_trace_nan("novas_str_hours");
+
+  errno = 0;
+
+  // Skip trailing white spaces / punctuation
+  while(*tail && (isspace(*tail) || ispunct(*tail))) tail++;
+  if(*tail)
+    errno = EINVAL;
+
+  return h;
+}
+
+

--- a/src/parse.c
+++ b/src/parse.c
@@ -130,9 +130,9 @@ double novas_parse_hms(const char *restrict hms, char **restrict tail) {
  * string, or else `EINVAL` if the parsed value used only the leading part of the string.</li>
  * </ol>
  *
- * @param hms         String specifying hours, minutes, and seconds, which correspond to
- *                    a time between 0 and 24 h. Time in any range is permitted, but the minutes and
- *                    seconds must be &gt;=0 and &lt;60.
+ * @param hms     String specifying hours, minutes, and seconds, which correspond to
+ *                a time between 0 and 24 h. Time in any range is permitted, but the minutes and
+ *                seconds must be &gt;=0 and &lt;60.
  * @return        [hours] Corresponding decimal time value, or else NAN if there was an
  *                error parsing the string (errno will be set to EINVAL).
  *
@@ -300,11 +300,11 @@ double novas_parse_dms(const char *restrict dms, char **restrict tail) {
  * string, or else `EINVAL` if the parsed value used only the leading part of the string.</li>
  * </ol>
  *
- * @param dms         String specifying degrees, minutes, and seconds, which correspond to
- *                    an angle. Angles in any range are permitted, but the minutes and
- *                    seconds must be &gt;=0 and &lt;60.
- * @return            [deg] Corresponding decimal angle value, or else NAN if there was
- *                    an error parsing the string (errno will be set to EINVAL).
+ * @param dms     String specifying degrees, minutes, and seconds, which correspond to
+ *                an angle. Angles in any range are permitted, but the minutes and
+ *                seconds must be &gt;=0 and &lt;60.
+ * @return        [deg] Corresponding decimal angle value, or else NAN if there was
+ *                an error parsing the string (errno will be set to EINVAL).
  *
  * @since 1.3
  * @author Attila Kovacs
@@ -501,13 +501,13 @@ double novas_parse_hours(const char *restrict str, char **restrict tail) {
  * string.
  *
  *
- * @param str         The input string that specified an angle either as decimal degrees
- *                    or as a broken down DMS speficication. The decimal value may be immediately
- *                    followed by a letter 'd'. See more in `novas_parse_degrees()` on acceptable
- *                    input specifications.
- * @return            [deg] The angle represented by the string, or else NAN if the
- *                    string could not be parsed into an angle  value (errno will indicate
- *                    the type of error).
+ * @param str     The input string that specified an angle either as decimal degrees
+ *                or as a broken down DMS speficication. The decimal value may be immediately
+ *                followed by a letter 'd'. See more in `novas_parse_degrees()` on acceptable
+ *                input specifications.
+ * @return        [deg] The angle represented by the string, or else NAN if the
+ *                string could not be parsed into an angle value (errno will indicate
+ *                the type of error).
  *
  * @since 1.3
  * @author Attila Kovacs
@@ -543,13 +543,13 @@ double novas_str_degrees(const char *restrict str) {
  * string.
  *
  *
- * @param str         The input string that specified an angle either as decimal hours
- *                    or as a broken down HMS speficication. The decimal value may be
- *                    immediately followed by a letter 'h'. See more in `novas_parse_hours()`
- *                    on acceptable input specifications.
- * @return            [h] The time-like value represented by the string, or else NAN if the
- *                    string could not be parsed into a time-like value (errno will indicate
- *                    the type of error).
+ * @param str     The input string that specified an angle either as decimal hours
+ *                or as a broken down HMS speficication. The decimal value may be
+ *                immediately followed by a letter 'h'. See more in `novas_parse_hours()`
+ *                on acceptable input specifications.
+ * @return        [h] The time-like value represented by the string, or else NAN if the
+ *                string could not be parsed into a time-like value (errno will indicate
+ *                the type of error).
  *
  * @since 1.3
  * @author Attila Kovacs

--- a/src/timescale.c
+++ b/src/timescale.c
@@ -507,7 +507,7 @@ time_t novas_get_unix_time(const novas_timespec *restrict time, long *restrict n
 static int skip_white(const char *str, char **tail) {
   char *next = (char *) str;
 
-  // Consume trailing 'white' spaces
+  // Consume trailing 'white' spaces / punctuation
   for(; *next; next++)
     if(!isspace(*next) && *next != '_')
       break;

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -1600,7 +1600,7 @@ static int test_hms_hours() {
   if(check_nan("hms_hours:null", novas_hms_hours(NULL))) n++;
   if(check_nan("hms_hours:empty", novas_hms_hours(""))) n++;
   if(check_nan("hms_hours:empty", novas_hms_hours(""))) n++;
-  if(check_nan("hms_hours:few", novas_hms_hours("12 39"))) n++;
+  if(check_nan("hms_hours:few", novas_hms_hours("12"))) n++;
   if(check_nan("hms_hours:dms", novas_hms_hours("12d 39m 33.0"))) n++;
   if(check_nan("hms_hours:sep", novas_hms_hours("12,39,33.0"))) n++;
   if(check_nan("hms_hours:min:neg", novas_hms_hours("12 -1 33.0"))) n++;
@@ -1617,7 +1617,7 @@ static int test_dms_degrees() {
   if(check_nan("dms_degrees:null", novas_dms_degrees(NULL))) n++;
   if(check_nan("dms_degrees:empty", novas_dms_degrees(""))) n++;
   if(check_nan("dms_degrees:empty", novas_dms_degrees(""))) n++;
-  if(check_nan("dms_degrees:few", novas_dms_degrees("122 39"))) n++;
+  if(check_nan("dms_degrees:few", novas_dms_degrees("122"))) n++;
   if(check_nan("dms_degrees:hms", novas_dms_degrees("122h 39m 33.0"))) n++;
   if(check_nan("dms_degrees:sep", novas_dms_degrees("122,39,33.0"))) n++;
   if(check_nan("dms_degrees:min:neg", novas_dms_degrees("122 -1 33.0"))) n++;
@@ -1647,6 +1647,25 @@ static int test_parse_degrees() {
 
   return n;
 }
+
+static int test_str_hours() {
+  int n = 0;
+
+  if(check_nan("str_hours:null", novas_str_hours(NULL))) n++;
+  if(check_nan("str_hours:blah", novas_str_hours("blah"))) n++;
+
+  return n;
+}
+
+static int test_str_degrees() {
+  int n = 0;
+
+  if(check_nan("str_degrees:null", novas_str_degrees(NULL))) n++;
+  if(check_nan("str_degrees:blah", novas_str_degrees("blah"))) n++;
+
+  return n;
+}
+
 
 static int test_helio_dist() {
   int n = 0;
@@ -2104,6 +2123,9 @@ int main() {
   if(test_dms_degrees()) n++;
   if(test_parse_hours()) n++;
   if(test_parse_degrees()) n++;
+  if(test_str_hours()) n++;
+  if(test_str_degrees()) n++;
+
   if(test_helio_dist()) n++;
   if(test_xyz_to_uvw()) n++;
 


### PR DESCRIPTION
- Add `novas_str_degrees()` and `novas_str_hours()`
- `novas_dms_degrees()` / `novas_hms_hours()` to set `errno` to `EINVAL` if there are unparsed tokens.
- Allow ommitting the seconds component in HMS/DMS specifications.
- Some doxygen apidoc corrections.
- Allow 2-componend h+m or d+m parsing
- Allow punctuation after compass direction