### PR TITLE
Improved hours/degrees unit parsing

### DIFF
--- a/src/super.c
+++ b/src/super.c
@@ -1968,7 +1968,7 @@ double novas_epoch(const char *restrict system) {
   static const char *fn = "novas_epoch";
 
   double year;
-  char type = 0;
+  char type = 0, *tail = NULL;
 
   if(!system) {
     novas_error(0, EINVAL, fn, "epoch is NULL");
@@ -2003,7 +2003,8 @@ double novas_epoch(const char *restrict system) {
 
   errno = 0;
 
-  if(sscanf(system, "%lf", &year) < 1) {
+  year = strtod(system, &tail);
+  if(tail <= system) {
     novas_error(0, EINVAL, fn, "Invalid epoch: %s", system);
     return NAN;
   }

--- a/src/timescale.c
+++ b/src/timescale.c
@@ -610,8 +610,7 @@ static int parse_zone(const char *str, char **tail) {
  * @param date        The date specification, possibly including time and timezone, in the
  *                    specified standard format.
  * @param[out] tail   (optional) If not NULL it will be set to the next character in the string
- *                    after the parsed time. The parsing will consume empty space characters after
- *                    the time specification also, returning a pointer to the next token after.
+ *                    after the parsed time.
  *
  * @return            [day] The Julian Day corresponding to the string date/time specification or
  *                    NAN if the string is NULL or if it does not specify a date/time in the
@@ -696,6 +695,9 @@ double novas_parse_date_format(enum novas_calendar_type calendar, enum novas_dat
     return NAN;
   }
 
+  if(tail)
+    *tail += n;
+
   skip_white(&date[n], &next);
 
   if(*next) {
@@ -727,11 +729,9 @@ double novas_parse_date_format(enum novas_calendar_type calendar, enum novas_dat
       next = from; // Time parsing unsuccessful, no extra characters consumed.
     }
 
-    skip_white(next, &next);
+    if(tail)
+      *tail = next;
   }
-
-  if(tail)
-    *tail = next;
 
   return novas_jd_from_date(calendar, y, m, d, h);
 }
@@ -775,8 +775,7 @@ double novas_parse_date_format(enum novas_calendar_type calendar, enum novas_dat
  * @param date        The date specification, possibly including time and timezone, in a standard
  *                    format.
  * @param[out] tail   (optional) If not NULL it will be set to the next character in the string
- *                    after the parsed time. The parsing will consume empty space characters after
- *                    the time specification also, returning a pointer to the next token after.
+ *                    after the parsed time.
  *
  * @return            [day] The Julian Day corresponding to the string date/time specification or
  *                    NAN if the string is NULL or if it does not specify a date/time in the

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -2588,13 +2588,27 @@ static int test_parse_degrees() {
   if(!is_equal("parse_degrees:decimal", novas_parse_degrees("-179.9999999", &tail), -degs, 1e-6)) n++;
   if(!is_equal("parse_degrees:decimal:notail", novas_parse_degrees("-179.9999999", NULL), -degs, 1e-6)) n++;
   if(!is_equal("parse_degrees:decimal:d", novas_parse_degrees("-179.9999999d", &tail), -degs, 1e-6)) n++;
+  if(!is_equal("parse_degrees:decimal:d", *tail, 0, 1e-6)) n++;
 
   if(!is_equal("parse_degrees:N", novas_parse_degrees("179.9999999N", &tail), degs, 1e-6)) n++;
   if(!is_equal("parse_degrees:E", novas_parse_degrees("179.9999999E", &tail), degs, 1e-6)) n++;
   if(!is_equal("parse_degrees:W", novas_parse_degrees("179.9999999W", &tail), -degs, 1e-6)) n++;
+  if(!is_equal("parse_degrees:W", *tail, 0, 1e-6)) n++;
+
   if(!is_equal("parse_degrees:+S", novas_parse_degrees("179.9999999 S", &tail), -degs, 1e-6)) n++;
+  if(!is_equal("parse_degrees:+S:tail", *tail, 0, 1e-6)) n++;
+
   if(!is_equal("parse_degrees:+Whatever", novas_parse_degrees("179.9999999 Whatever", &tail), degs, 1e-6)) n++;
-  if(!is_equal("parse_degrees:d+S", novas_parse_degrees("179.9999999d S", &tail), -degs, 1e-6)) n++;
+  if(!is_equal("parse_degrees:+Whatever:tail", *tail, ' ', 1e-6)) n++;
+
+  if(!is_equal("parse_degrees:d+S", novas_parse_degrees("179.9999999d_S", &tail), -degs, 1e-6)) n++;
+  if(!is_equal("parse_degrees:d+S:tail", *tail, 0, 1e-6)) n++;
+
+  if(!is_equal("parse_degrees:deg+S", novas_parse_degrees("179.9999999_deg S", &tail), -degs, 1e-6)) n++;
+  if(!is_equal("parse_degrees:deg+S:tail", *tail, 0, 1e-6)) n++;
+
+  if(!is_equal("parse_degrees:degree+S", novas_parse_degrees("179.9999999 degree S", &tail), -degs, 1e-6)) n++;
+  if(!is_equal("parse_degrees:degree+S:tail", *tail, 0, 1e-6)) n++;
 
   if(!is_equal("parse_degrees:W+", novas_parse_degrees("179.9999999W ", &tail), -degs, 1e-6)) n++;
   if(!is_equal("parse_degrees:W_", novas_parse_degrees("179.9999999W_", &tail), -degs, 1e-6)) n++;
@@ -2614,7 +2628,13 @@ static int test_parse_hours() {
   if(!is_equal("parse_hours:decimal:h", novas_parse_hours("23.9999999h", &tail), h, 1e-6)) n++;
   if(!is_equal("parse_hours:decimal:notail", novas_parse_hours("23.9999999", NULL), h, 1e-6)) n++;
   if(!is_equal("parse_hours:decimal:h_", novas_parse_hours("23.9999999h_", &tail), h, 1e-6)) n++;
-  if(!is_equal("parse_hours:decimal:h!", novas_parse_hours("23.9999999h!", &tail), h, 1e-6)) n++;
+  if(!is_equal("parse_hours:decimal:h_:tail", *tail, '_', 1e-6)) n++;
+
+  if(!is_equal("parse_hours:decimal:_h!", novas_parse_hours("23.9999999_h!", &tail), h, 1e-6)) n++;
+  if(!is_equal("parse_hours:decimal:_h!:tail", *tail, '!', 1e-6)) n++;
+
+  if(!is_equal("parse_hours:decimal:hours!", novas_parse_hours("23.9999999 hour!", &tail), h, 1e-6)) n++;
+  if(!is_equal("parse_hours:decimal:hours!:tail", *tail, '!', 1e-6)) n++;
 
   return n;
 }
@@ -3179,7 +3199,7 @@ static int test_parse_date() {
 
   if(!is_equal("parse_date:5", novas_parse_date("2025/1/26 _", &tail), jd, 1e-6)) n++;
   if(!is_ok("parse_date:5:tail", tail == NULL)) n++;
-  if(!is_equal("parse_date:5:tail", *tail, 0, 1e-6)) n++;
+  if(!is_equal("parse_date:5:tail", *tail, ' ', 1e-6)) n++;
 
   if(!is_equal("parse_date:6", novas_parse_date("2025 1 26 blah", &tail), jd, 1e-6)) n++;
   if(!is_equal("parse_date:6:tail", *tail, 'b', 1e-6)) n++;
@@ -3216,10 +3236,10 @@ static int test_parse_date() {
   if(!is_equal("parse_date:13:tail", *tail, 0, 1e-6)) n++;
 
   if(!is_equal("parse_date:14", novas_parse_date("2025 1 26 19h33m08.113 _", &tail), jd, 1e-6)) n++;
-  if(!is_equal("parse_date:14:tail", *tail, 0, 1e-6)) n++;
+  if(!is_equal("parse_date:14:tail", *tail, ' ', 1e-6)) n++;
 
-  if(!is_equal("parse_date:15", novas_parse_date("2025 1 26 19h33m08.113z _", &tail), jd, 1e-6)) n++;
-  if(!is_equal("parse_date:15:tail", *tail, 0, 1e-6)) n++;
+  if(!is_equal("parse_date:15", novas_parse_date("2025 1 26 19h33m08.113z_ ", &tail), jd, 1e-6)) n++;
+  if(!is_equal("parse_date:15:tail", *tail, '_', 1e-6)) n++;
 
   return n;
 }


### PR DESCRIPTION
- recognize `d`, `dg`, `deg`, `degree`, and `degrees` (case insensitive) as degree units.
- recognize `h`, `hr`, `hrs`, `hour`, and `hours` (case insensitive) as hour units.
- Fixes to returned tail pointer when parsing hours/degrees
- `novas_parse_date()` / `novas_parse_date_format()` not to consume empty spaces after date specification.