### PR TITLE
Add caching to `ee_ct()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,7 @@ calculations.
  
  - #156: `tt2tdb()` now caches last calculation also.
  
- - #156: Eliminate redundant caching of calculations.
+ - #156: Eliminate redundant caching of calculations. (Also in #158).
  
  - #156: Tighten `precession()` time checking.
  
@@ -158,6 +158,9 @@ calculations.
   
  - #157: `fund_args()` to always calculate full series. There is little performance to gain from the truncation we 
    used in the vicinity of J2000. No real change in the results.
+  
+ - #159: Add caching to `ee_ct()`. Just in case someone wants to call it repeatedly with the same parameters, it will
+   be much much faster.
   
  - In reduced accuracy mode apply gravitational deflection for the Sun only. In prior versions, deflection corrections 
    were applied for Earth too. However, these are below the mas-level accuracy promised in reduced accuracy mode, and 


### PR DESCRIPTION
In case someone calls it repeatedly with the same input parameters, now it will be much much faster...