### PR TITLE
`parse_degrees()` check invalid seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Changed
+
+ - #166: Improved detection of invalid seconds in `parse_degrees()`.
+ 
+
 ## [1.3.0] - 2025-04-15
 
 Feature release with many new convenience functions, such as for handling times and angles as strings; calculating 

--- a/include/novas.h
+++ b/include/novas.h
@@ -65,10 +65,10 @@
 #define SUPERNOVAS_MINOR_VERSION  3
 
 /// Integer sub version of the release
-#define SUPERNOVAS_PATCHLEVEL     0
+#define SUPERNOVAS_PATCHLEVEL     1
 
 /// Additional release information in version, e.g. "-1", or "-rc1", or empty string "" for releases.
-#define SUPERNOVAS_RELEASE_STRING ""
+#define SUPERNOVAS_RELEASE_STRING "-devel"
 
 /// \cond PRIVATE
 

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -1666,6 +1666,9 @@ static int test_parse_degrees() {
 
   if(check_nan("parse_degrees:null", novas_parse_degrees(NULL, &tail))) n++;
   if(check_nan("parse_degrees:blah", novas_parse_degrees("blah", &tail))) n++;
+  if(check_nan("parse_degrees:East+space", novas_parse_degrees("East ", &tail))) n++;
+  if(check_nan("parse_degrees:East+blah", novas_parse_degrees("East blah", &tail))) n++;
+  if(check_nan("parse_degrees:East..0", novas_parse_degrees("East ..0", &tail))) n++;
 
   return n;
 }


### PR DESCRIPTION
Improved checking for invalid decimal seconds when parsing DSM angle strings.