### PR TITLE
Fixes for Debian i386 cross builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+Upcoming bug fix release, expected around 1 August 2025.
+
+### Fixed
+
+ - #167: Fixes for Debian i386 cross builds.
+
 ### Changed
 
  - #166: Improved detection of invalid seconds in `parse_degrees()`.
+
  
 
 ## [1.3.0] - 2025-04-15

--- a/src/util.c
+++ b/src/util.c
@@ -523,7 +523,9 @@ double d_light(const double *pos_src, const double *pos_body) {
  */
 double novas_sep(double lon1, double lat1, double lon2, double lat2) {
   double c = sin(lat1 * DEGREE) * sin(lat2 * DEGREE) + cos(lat1 * DEGREE) * cos(lat2 * DEGREE) * cos((lon1 - lon2) * DEGREE);
-  return atan2(sqrt(1.0 - c * c), c) / DEGREE;
+  double c2 = c * c;
+  // Ensure that argument to sqrt() is not negative given rounding errors.
+  return atan2(c2 < 1.0 ? sqrt(1.0 - c2) : 0.0, c) / DEGREE;
 }
 
 /**

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -1628,7 +1628,7 @@ static int test_ira_equinox() {
   double e1 = ira_equinox(tdb, NOVAS_MEAN_EQUINOX, NOVAS_FULL_ACCURACY);
   double e2 = ira_equinox(tdb, NOVAS_MEAN_EQUINOX, NOVAS_FULL_ACCURACY);
 
-  if(!is_ok("ira_equinox", e1 != e2)) return 1;
+  if(!is_equal("ira_equinox", e1, e2, 1e-11)) return 1;
 
   e2 = ira_equinox(tdb, NOVAS_MEAN_EQUINOX, NOVAS_REDUCED_ACCURACY);
   if(!is_equal("ira_equinox:acc", e1, e2, 1e-8)) return 1;


### PR DESCRIPTION
- `novas_sep()` to check `sqrt()` argument, in case of rounding errors push it negative.
- testing of `ira_equinox()` with tolerance for rounding errors.