### PR TITLE
Parsing degrees in exponential notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Upcoming bug fix release, expected around 1 August 2025.
 
  - #166: Improved detection of invalid seconds in `parse_degrees()`.
  
+ - #169: `novas_parse_degrees()` to support parsing values in exponential notation also, e.g. `1.23E2`, `1.23E2W` etc.
+ 
  - Corrections and edits to API documentation.
 
  

--- a/src/parse.c
+++ b/src/parse.c
@@ -556,9 +556,19 @@ double novas_parse_degrees(const char *restrict str, char **restrict tail) {
 
     deg = strtod(num, &end);
     n = end - num;
+
     if(n > 0) {
       char unit[9] = {'\0'};
       int n1, nu = 0;
+
+      // Check if exponential notation.
+      if(toupper(next[n]) == 'E' && next[n+1] && !isspace(next[n+1]) && next[n+1] != '_') {
+        int exp = strtol(&next[n+1], &end, 10);
+        if(end > &next[n+1]) {
+          deg *= pow(10.0, exp);
+          n = end - next;
+        }
+      }
 
       // Skip underscores and white spaces
       for(n1 = n; next[n1] && (next[n1] == '_' || isspace(next[n1]));) n1++;

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -2727,6 +2727,21 @@ static int test_parse_degrees() {
   if(!is_equal("parse_degrees:W_", novas_parse_degrees("179.9999999W_", &tail), -degs, 1e-6)) n++;
   if(!is_equal("parse_degrees:W,", novas_parse_degrees("179.9999999W,", &tail), -degs, 1e-6)) n++;
 
+  if(!is_equal("parse_degrees:W,", novas_parse_degrees("179.9999999E0W", &tail), -degs, 1e-6)) n++;
+  if(!is_equal("parse_degrees:^W+degree+S:tail", *tail, 0, 1e-6)) n++;
+
+  if(!is_equal("parse_degrees:W,", novas_parse_degrees("179.9999999e0W", &tail), -degs, 1e-6)) n++;
+  if(!is_equal("parse_degrees:^W+degree+S:tail", *tail, 0, 1e-6)) n++;
+
+  if(!is_equal("parse_degrees:W,", novas_parse_degrees("179.9999999E?W", &tail), degs, 1e-6)) n++;
+  if(!is_equal("parse_degrees:^W+degree+S:tail", *tail, '?', 1e-6)) n++;
+
+  if(!is_equal("parse_degrees:W,", novas_parse_degrees("179.9999999E ", &tail), degs, 1e-6)) n++;
+  if(!is_equal("parse_degrees:^W+degree+S:tail", *tail, ' ', 1e-6)) n++;
+
+  if(!is_equal("parse_degrees:W,", novas_parse_degrees("179.9999999E_", &tail), degs, 1e-6)) n++;
+  if(!is_equal("parse_degrees:^W+degree+S:tail", *tail, '_', 1e-6)) n++;
+
   return n;
 }
 


### PR DESCRIPTION
- Add support for parsing degrees in exponential notation, e.g. `1.23E2` or `1.23E-2W` etc. (Previously this was not possible due to the the duality of `E` being used as a compass direction also.)