### PR TITLE
Add IAU/SOFA refraction model implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
    Sidereal Time (GST / GaST) and Local (apparent) Sidereal Time (LST / LaST) for a given astrometric time (and
    observer location) more easily. 
 
+ - 173: Added our own implementation of the wavelength-dependent IAU refraction model as `novas_wave_refraction()`, which 
+   is based on the SOFA `iauRefco()` function. The wavelength for which the refraction is calculated can be set by
+   `novas_refract_wavelength()`. By default 550 nm (0.55 &mu;m) is assumed.
+   
+### Changed
+
+ - #173: Added parameter range checking to `refract()` function and `novas_radio_refraction()` model. If called with
+   weather parameters or an elevation angle outside of readonable values, NaN will be returned and `errno` will be set 
+   to `EINVAL`.
+
 
 ## [1.3.1] - 2025-05-07
 

--- a/README.md
+++ b/README.md
@@ -1045,8 +1045,10 @@ before that level of accuracy is reached.
     option to include approximate _optical_ refraction corrections either for a standard atmosphere or more precisely 
     using the weather parameters defined in the `on_surface` data structure that specifies the observer locations.
     Note, that refraction at radio wavelengths is notably different from the included optical model, and a standard
-    radio refraction model is included as of version 1.1 also. In any case you may want to skip the refraction 
-    corrections offered in this library, and instead implement your own as appropriate (or not at all).
+    radio refraction model is included as of version 1.1 also. As of v1.4.0 we also offer our implementation of the 
+    wavelength-dependent IAU refraction model based on the SOFA `iauRefco()` function. In any case, you may want to 
+    skip the refraction corrections offered in this library, and instead implement your own as appropriate (or not at 
+    all).
   
 
 -----------------------------------------------------------------------------

--- a/include/novas.h
+++ b/include/novas.h
@@ -218,6 +218,11 @@
 /// @since 1.3
 #define NOVAS_SYSTEM_HIP           "HIP"
 
+/// [&mu;m] Default wavelength, e.g. for wavelength-dependent refraction models. It is set to the
+/// median wavelength of visible light.
+/// @since 1.4
+#define NOVAS_DEFAULT_WAVELENGTH      0.55
+
 #if !COMPAT
 // If we are not in the strict compatibility mode, where constants are defined
 // as variables in novascon.h (with implementation in novascon.c), then define
@@ -2069,6 +2074,11 @@ novas_nutation_provider get_nutation_lp_provider();
 double novas_time_gst(const novas_timespec *restrict time, enum novas_accuracy accuracy);
 
 double novas_time_lst(const novas_timespec *restrict time, double lon, enum novas_accuracy accuracy);
+
+// in refract.c
+int novas_refract_wavelength(double microns);
+
+double novas_wave_refraction(double jd_tt, const on_surface *loc, enum novas_refraction_type type, double el);
 
 // <================= END of SuperNOVAS API =====================>
 

--- a/src/frames.c
+++ b/src/frames.c
@@ -790,6 +790,7 @@ int novas_geom_to_app(const novas_frame *restrict frame, const double *restrict 
  * @sa novas_standard_refraction()
  * @sa novas_optical_refraction()
  * @sa novas_radio_refraction()
+ * @sa novas_wave_refraction()
  *
  * @since 1.1
  * @author Attila Kovacs
@@ -881,6 +882,7 @@ int novas_app_to_hor(const novas_frame *restrict frame, enum novas_reference_sys
  * @sa novas_standard_refraction()
  * @sa novas_optical_refraction()
  * @sa novas_radio_refraction()
+ * @sa novas_wave_refraction()
  *
  * @since 1.1
  * @author Attila Kovacs

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -193,7 +193,7 @@ static int test_z2v() {
 }
 
 static int test_refract() {
-  on_surface o = ON_SURFACE_INIT;
+  on_surface loc = ON_SURFACE_INIT, loc0 = ON_SURFACE_INIT;
   int n = 0;
 
   novas_debug(NOVAS_DEBUG_ON);
@@ -204,12 +204,26 @@ static int test_refract() {
   novas_debug(NOVAS_DEBUG_OFF);
 
   errno = 0;
-  r = refract(&o, -1, 30.0);
+  r = refract(&loc, -1, 30.0);
   if(check("refract:model", 1, r == 0.0 && errno == EINVAL)) n++;
 
   errno = 0;
-  r = refract(&o, NOVAS_STANDARD_ATMOSPHERE, 91.01);
+  r = refract(&loc, NOVAS_STANDARD_ATMOSPHERE, 91.01);
   if(check("refract:zd", 1, r == 0.0)) n++;
+
+  loc = loc0;
+  loc.temperature = -150.1;
+  if(check_nan("refract:loc:temperature:lo", refract(&loc, NOVAS_WEATHER_AT_LOCATION, 30.0))) n++;
+
+  loc.temperature = 100.1;
+  if(check_nan("refract:loc:temperature:hi", refract(&loc, NOVAS_WEATHER_AT_LOCATION, 30.0))) n++;
+
+  loc = loc0;
+  loc.pressure = -0.1;
+  if(check_nan("refract:loc:pressure:lo", refract(&loc, NOVAS_WEATHER_AT_LOCATION, 30.0))) n++;
+
+  loc.pressure = 2000.1;
+  if(check_nan("refract:loc:pressure:hi", refract(&loc, NOVAS_WEATHER_AT_LOCATION, 30.0))) n++;
 
   return n;
 }
@@ -240,6 +254,89 @@ static int test_inv_refract() {
 
   return n;
 }
+
+static int test_radio_refraction() {
+  int n = 0;
+
+  on_surface loc = ON_SURFACE_INIT, loc0 = ON_SURFACE_INIT;
+
+  if(check_nan("radio_refraction:loc:null", novas_radio_refraction(NOVAS_JD_J2000, NULL, NOVAS_REFRACT_ASTROMETRIC, 30.0))) n++;
+  if(check_nan("radio_refraction:loc:type:1", novas_radio_refraction(NOVAS_JD_J2000, &loc, 1, 30.0))) n++;
+  if(check_nan("radio_refraction:el:lo", novas_radio_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_ASTROMETRIC, -1.01))) n++;
+  if(check_nan("radio_refraction:el:hi", novas_radio_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_ASTROMETRIC, 90.01))) n++;
+
+  loc.temperature = -150.1;
+  if(check_nan("radio_refraction:temperature:lo", novas_radio_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_ASTROMETRIC, 30.0))) n++;
+
+  loc.temperature = 100.1;
+  if(check_nan("radio_refraction:temperature:hi", novas_radio_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_ASTROMETRIC, 30.0))) n++;
+
+  loc = loc0;
+  loc.pressure = -0.1;
+  if(check_nan("radio_refraction:pressure:lo", novas_radio_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_ASTROMETRIC, 30.0))) n++;
+
+  loc.pressure = 2000.1;
+  if(check_nan("radio_refraction:pressure:hi", novas_radio_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_ASTROMETRIC, 30.0))) n++;
+
+  loc = loc0;
+  loc.humidity = -0.1;
+  if(check_nan("radio_refraction:humidity:lo", novas_radio_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_ASTROMETRIC, 30.0))) n++;
+
+  loc.humidity = 100.1;
+  if(check_nan("radio_refraction:humidity:hi", novas_radio_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_ASTROMETRIC, 30.0))) n++;
+
+  return n;
+}
+
+static int test_wave_refraction() {
+  int n = 0;
+
+  on_surface loc = ON_SURFACE_INIT, loc0 = ON_SURFACE_INIT;
+
+  if(check_nan("wave_refraction:loc:null", novas_wave_refraction(NOVAS_JD_J2000, NULL, NOVAS_REFRACT_ASTROMETRIC, 30.0))) n++;
+  if(check_nan("wave_refraction:loc:type:1", novas_wave_refraction(NOVAS_JD_J2000, &loc, 1, 30.0))) n++;
+  if(check_nan("wave_refraction:el:lo", novas_wave_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_OBSERVED, 0.0))) n++;
+  if(check_nan("wave_refraction:el:hi", novas_wave_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_OBSERVED, 90.01))) n++;
+
+  loc.temperature = -150.1;
+  if(check_nan("wave_refraction:temperature:lo", novas_wave_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_ASTROMETRIC, 30.0))) n++;
+
+  loc.temperature = 200.1;
+  if(check_nan("wave_refraction:temperature:hi", novas_wave_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_ASTROMETRIC, 30.0))) n++;
+
+  loc = loc0;
+  loc.pressure = -0.1;
+  if(check_nan("wave_refraction:pressure:lo", novas_wave_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_ASTROMETRIC, 30.0))) n++;
+
+  loc.pressure = 10000.1;
+  if(check_nan("wave_refraction:pressure:hi", novas_wave_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_ASTROMETRIC, 30.0))) n++;
+
+  loc = loc0;
+  loc.humidity = -0.1;
+  if(check_nan("wave_refraction:humidity:lo", novas_wave_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_ASTROMETRIC, 30.0))) n++;
+
+  loc.humidity = 100.1;
+  if(check_nan("wave_refraction:humidity:hi", novas_wave_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_ASTROMETRIC, 30.0))) n++;
+
+  loc = loc0;
+  novas_refract_wavelength(0.099);
+  if(check_nan("wave_refraction:wl:lo", novas_wave_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_ASTROMETRIC, 30.0))) n++;
+
+  novas_refract_wavelength(NOVAS_DEFAULT_WAVELENGTH);
+
+  return n;
+}
+
+static int test_refract_wavelength() {
+  int n = 0;
+
+  if(check("refract:wavelength:0", -1, novas_refract_wavelength(0.0))) n++;
+  if(check("refract:wavelength:neg", -1, novas_refract_wavelength(-0.1))) n++;
+  if(check("refract:wavelength:nan", -1, novas_refract_wavelength(NAN))) n++;
+
+  return n++;
+}
+
 
 static int test_limb_angle() {
   double pos[3] = { 0.01 }, pn[3] = { -0.01 }, pz[3] = {0.0}, a, b;
@@ -2137,6 +2234,9 @@ int main() {
   if(test_refract()) n++;
   if(test_refract_astro()) n++;
   if(test_inv_refract()) n++;
+  if(test_radio_refraction()) n++;
+  if(test_wave_refraction()) n++;
+  if(test_refract_wavelength()) n++;
   if(test_limb_angle()) n++;
 
   if(test_ephemeris()) n++;

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -2107,9 +2107,50 @@ static int test_radio_refraction() {
     if(!is_equal(label, del, del1, 1e-4)) return 1;
   }
 
-  printf("\n");
-
   return 0;
+}
+
+static int test_wave_refraction() {
+  int n = 0;
+
+  on_surface loc = ON_SURFACE_INIT;
+
+  loc.temperature = 20.0;
+  loc.pressure = 1000.0;
+  loc.humidity = 40.0;
+
+  if(!is_ok("wave_refraction:set_wavelength:optical", novas_refract_wavelength(0.55))) n++;
+
+  if(!is_equal("wave_refraction:optical:obs",
+          novas_wave_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_OBSERVED, 50.0),
+          novas_optical_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_OBSERVED, 50.0),
+          3e-3
+  )) n++;
+
+  if(!is_equal("wave_refraction:optical:astro",
+          novas_wave_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_ASTROMETRIC, 50.0),
+          novas_optical_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_ASTROMETRIC, 50.0),
+          3e-3
+  )) n++;
+
+  if(!is_ok("wave_refraction:set_wavelength:radio", novas_refract_wavelength(10000.0))) n++;
+
+  if(!is_equal("wave_refraction:radio:obs",
+          novas_wave_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_OBSERVED, 50.0),
+          novas_radio_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_OBSERVED, 50.0),
+          3e-3
+  )) n++;
+
+  if(!is_equal("wave_refraction:radio:astro",
+          novas_wave_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_ASTROMETRIC, 50.0),
+          novas_radio_refraction(NOVAS_JD_J2000, &loc, NOVAS_REFRACT_ASTROMETRIC, 50.0),
+          3e-3
+  )) n++;
+
+
+  novas_refract_wavelength(NOVAS_DEFAULT_WAVELENGTH);
+
+  return n;
 }
 
 static int test_inv_refract() {
@@ -2120,7 +2161,7 @@ static int test_inv_refract() {
   obs.pressure = 1000.0;
   obs.humidity = 40.0;
 
-  for(el = 1; el < 90.0; el += 5) {
+  for(el = 1; el < 90.0; el += 1) {
     char label[50];
 
     sprintf(label, "inv_refract:observed:%d", el);
@@ -3750,6 +3791,7 @@ int main(int argc, char *argv[]) {
   if(test_optical_refraction()) n++;
   if(test_inv_refract()) n++;
   if(test_radio_refraction()) n++;
+  if(test_wave_refraction()) n++;
   if(test_make_frame()) n++;
   if(test_change_observer()) n++;
   if(test_transform()) n++;


### PR DESCRIPTION
- Add `novas_wave_refraction()`, which provides as `RefractionModel` implementation for SuperNOVAS that is based on the IAU/SOFA `iauRefco()` function.
- Add `novas_refract_wavelength()` to allow specifying the observing wavelength for which refraction is to be calculated for when using wavelength-dependent refraction models, such as the above. 
- Added range checking to `refract()` function and `novas_radio_refraction()` model.