### PR TITLE
New `enum novas_refraction_model` values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,11 +58,14 @@ Changes for the upcoming feature release, expected around 1 August 2025.
    
  - #177: Added `novas_day_of_week()` and `novas_day_of_year()` functions to convert JD dates to a 1-based day of week
    index, or to a day of the year in the calendar of choice.
-   
+
  - #185: Added `NOVAS_TIRS` and `NOVAS_ITRS` to `enum novas_reference_systems`. All frame-based functions now support
    these. Legacy `place()` and its variants support TIRS but not ITRS (because of the lack of information available
    to the legacy calls), while Keplerian orbitals may not be be defined in either TIRS or ITRS since these Earth 
    co-rotating systems are not inertial systems.
+
+ - #186: Added `NOVAS_RADIO_REFRACTION` and `NOVAS_WAVE_REFRACTION` to `enum novas_refraction_model`, for referencing 
+   the Berman &amp; Rockwell 1976 radio-wave model, or the IAU / SOFA wavelength-dependent model, respectively.
    
 ### Changed
 
@@ -72,6 +75,8 @@ Changes for the upcoming feature release, expected around 1 August 2025.
 
  - #181: Changed `nutation_angles()` to apply P03 model rescaling to IAU2000 nutation angles to provide 'IAU2006'
    values (see Capitaine et al. 2005). The same rescaling has been adopted by SOFA also.
+   
+ - #186: Tweaked error handling in atmopsheric refraction functions (in `refract.c`).
    
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -1545,15 +1545,16 @@ one minute.
  - Updated nutation model from IAU2000 to IAU2006 (P03) model, by applying scaling factors (Capitaine et al. 2005) to 
    match the IAU2006 precession model that was already implemented in NOVAS.
 
- - Approximate Keplerian orbital models for the major planets (Standish &amp; Williams, 1992) and the Moon (Chapront
-   et al. 2002), for when arcmin-scale accuracy is sufficient (e.g. rise-set times, approximate sky positions).
+ - Approximate Keplerian orbital models for the major planets (Standish &amp; Williams, 1992), EMB, and the Moon 
+   (Chapront et al. 2002), for when arcmin-scale accuracy is sufficient (e.g. rise-set times, approximate sky 
+   positions).
    
- - Add Moon phase calculator functions, based on above orbital modeling.
- 
- - Added IAU/SOFA wavelength-dependent refraction model.
+ - Moon phase calculator functions, based on above orbital modeling.
  
  - Improved support for expressing and using coordinates in TIRS (Terrestrial Intermediate Reference System) and ITRS 
    (International Terrestrial Reference System).
+   
+ - Improvemements to atmopsheric refraction modeling.
 
 
 <a name="api-changes"></a>

--- a/include/novas.h
+++ b/include/novas.h
@@ -518,11 +518,11 @@ enum novas_accuracy {
 };
 
 /**
- * Constants that determine whether refraction calculations should use a standard atmospheric
- * model, or whatever weather parameters have been been specified for the observing location.
+ * Constants that determine whether what model (if any) to use for implicit refraction calculations.
  *
  * @sa on_surface
  * @sa refract()
+ * @sa refract_astro()
  */
 enum novas_refraction_model {
   /// Do not apply atmospheric refraction correction
@@ -533,8 +533,27 @@ enum novas_refraction_model {
   NOVAS_STANDARD_ATMOSPHERE,
 
   /// Uses the weather parameters that are specified together with the observing location.
-  NOVAS_WEATHER_AT_LOCATION
+  NOVAS_WEATHER_AT_LOCATION,
+
+  /// Uses the Berman &amp; Rockwell 1976 refraction model for Radio wavelengths with the
+  /// weather parameters specified together with the observing location.
+  /// @since 1.4
+  NOVAS_RADIO_REFRACTION,
+
+  /// Uses the IAU / SOFA wavelength-depended refraction model with the weather parameters
+  /// specified together with the observing location. The wavelength can be  specified
+  /// via `novas_refract_wavelength()` or else it is assumed to be 550 nm (visible light).
+  /// @sa novas_refract_wavelength()
+  /// @since 1.4
+  NOVAS_WAVE_REFRACTION
 };
+
+/**
+ * The number of built-in refraction models available in SuperNOVAS.
+ *
+ * @sa enum novas_refraction_model
+ */
+#define NOVAS_REFRACTION_MODELS   (NOVAS_WAVE_REFRACTION + 1)
 
 /**
  * Constants that determine the type of rotation measure to use.
@@ -1693,7 +1712,7 @@ short cio_basis(double jd_tdb, double ra_cio, enum novas_cio_location_type loc_t
 short cio_array(double jd_tdb, long n_pts, ra_of_cio *restrict cio);
 
 // in refract.c
-double refract(const on_surface *restrict location, enum novas_refraction_model option, double zd_obs);
+double refract(const on_surface *restrict location, enum novas_refraction_model model, double zd_obs);
 
 // in calendar.c
 double julian_date(short year, short month, short day, double hour);
@@ -1781,7 +1800,7 @@ int radec_planet(double jd_tt, const object *restrict ss_body, const observer *r
         double *restrict dis, double *restrict rv);
 
 // in refract.c
-double refract_astro(const on_surface *restrict location, enum novas_refraction_model option, double zd_astro);
+double refract_astro(const on_surface *restrict location, enum novas_refraction_model model, double zd_astro);
 
 // in observer.c
 int light_time2(double jd_tdb, const object *restrict body, const double *restrict pos_obs, double tlight0,

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -198,6 +198,7 @@ static int test_refract() {
 
   novas_debug(NOVAS_DEBUG_ON);
   fprintf(stderr, ">>> Expecting error message...\n");
+
   errno = 0;
   double r = refract(NULL, NOVAS_STANDARD_ATMOSPHERE, 30.0);
   if(check("refract:loc", 1, r == 0.0 && errno == EINVAL)) n++;
@@ -205,7 +206,13 @@ static int test_refract() {
 
   errno = 0;
   r = refract(&loc, -1, 30.0);
-  if(check("refract:model", 1, r == 0.0 && errno == EINVAL)) n++;
+  if(check("refract:model:-1:ret", 1, r == 0.0)) n++;
+  if(check("refract:model:-1:errno", EINVAL, errno)) n++;
+
+  errno = 0;
+  r = refract(&loc, NOVAS_REFRACTION_MODELS, 30.0);
+  if(check("refract:model:hi:ret", 1, r == 0.0)) n++;
+  if(check("refract:model:hi:errno", EINVAL, errno)) n++;
 
   errno = 0;
   r = refract(&loc, NOVAS_STANDARD_ATMOSPHERE, 91.01);
@@ -233,6 +240,10 @@ static int test_refract_astro() {
   on_surface surf = ON_SURFACE_INIT;
   int n = 0;
 
+  if(check_nan("refract_astro:loc", refract_astro(NULL, NOVAS_STANDARD_ATMOSPHERE, 30.0))) n++;
+  if(check_nan("refract_astro:model:-1", refract_astro(&surf, -1, 30.0))) n++;
+  if(check_nan("refract_astro:model:hi", refract_astro(&surf, NOVAS_REFRACTION_MODELS, 30.0))) n++;
+
   novas_inv_max_iter = 0;
   if(check_nan("refract_astro:converge", refract_astro(&surf, NOVAS_STANDARD_ATMOSPHERE, 85.0))) n++;
   else if(check("refract_astro:converge:errno", ECANCELED, errno)) n++;
@@ -246,6 +257,8 @@ static int test_inv_refract() {
   extern int novas_inv_max_iter;
   on_surface surf = ON_SURFACE_INIT;
   int n = 0;
+
+  if(check_nan("inv_refract:loc", novas_inv_refract(novas_optical_refraction, NOVAS_JD_J2000, NULL, NOVAS_REFRACT_OBSERVED, 5.0))) n++;;
 
   novas_inv_max_iter = 0;
   if(check_nan("inv_refract:converge", novas_inv_refract(novas_optical_refraction, NOVAS_JD_J2000, &surf, NOVAS_REFRACT_OBSERVED, 5.0))) n++;
@@ -1132,7 +1145,7 @@ static int test_grav_undo_planets() {
   if(check("grav_undo_planets:pos_app", -1, grav_undo_planets(NULL, po, &planets, out))) n++;
   if(check("grav_undo_planets:pos_obs", -1, grav_undo_planets(p, NULL, &planets, out))) n++;
   if(check("grav_undo_planets:planets", -1, grav_undo_planets(p, po, NULL, out))) n++;
-    if(check("grav_undo_planets:pos_src", -1, grav_undo_planets(p, po, &planets, NULL))) n++;
+  if(check("grav_undo_planets:pos_src", -1, grav_undo_planets(p, po, &planets, NULL))) n++;
 
   planets.mask = 1 << NOVAS_SUN;
   novas_inv_max_iter = 0;

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -1501,7 +1501,7 @@ static int test_refract_astro() {
     double za = i;
     int j;
 
-    for(j = 0; j < 3; j++) {
+    for(j = 0; j < NOVAS_REFRACTION_MODELS; j++) {
       double r = refract_astro(&o.on_surf, j, za);
       double r1 = refract(&o.on_surf, j, za - r);
 


### PR DESCRIPTION
Added:

 - `NOVAS_RADIO_REFRACTION` to use the Berman & Rockwell 1972 radio refraction model.
 - `NOVAS_WAVE_REFRACTION` to use the IAU / SOFA wavelength-dependent refraction model. (The wavelength can be set via `novas_refract_wavelength()`)

Also, tweaks to error propagation...