### PR TITLE
Fix Makefile deps so reverse order build works also

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,3 +48,13 @@ jobs:
 
     - name: Generate CIO locator data
       run: make cio_file
+
+# Reverse build not yet supported in ubuntu-latest
+#
+#  reverse-build:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: actions/checkout@v4
+#    - name: Reverse order build
+#      run: make --shuffle=reverse
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+ - #197: Fix reverse target order builds via `make --shuffle=reverse`, which could also fail parallel builds in some 
+   cases. See also Debian Bug Tracker [#1105702](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1105702).
+
+### Changed
+
+ - Various improvements to documentation.
+ 
 
 ## [1.4.0] - 2025-06-02
 

--- a/Makefile
+++ b/Makefile
@@ -175,9 +175,8 @@ $(LIB)/libsolsys-cspice.so.$(SO_VERSION): SHLIBS := -lcspice
 $(LIB)/libsolsys-cspice.so.$(SO_VERSION): $(SRC)/solsys-cspice.c
 
 # Link submodules against the supernovas shared lib
-$(LIB)/libsolsys%.so.$(SO_VERSION): | $(LIB)/libsupernovas.so
-	@$(MAKE) $(LIB)
-	$(CC) -o $@ $(CPPFLAGS) $(CFLAGS) $^ -shared -fPIC -Wl,-soname,$(subst $(LIB)/,,$@) $(LDFLAGS) -L$(LIB) -lsupernovas $(SHLIBS)
+$(LIB)/libsolsys%.so.$(SO_VERSION): | $(LIB) $(LIB)/libsupernovas.so
+	$(CC) -o $@ $(SOFLAGS) -L$(LIB) -lsupernovas $(SHLIBS)
 
 # Static library: libsupernovas.a
 $(LIB)/libsupernovas.a: $(OBJECTS) | $(LIB) Makefile

--- a/Makefile
+++ b/Makefile
@@ -147,34 +147,37 @@ $(LIB)/libsolsys-cspice.so: $(LIB)/libsolsys-cspice.so.$(SO_VERSION)
 
 $(LIB)/libnovas.so: $(LIB)/libsupernovas.so
 
-$(LIB)/libsolsys%.so.$(SO_VERSION): LDFLAGS += -L$(LIB) -lsupernovas
-
 # Shared library: libsupernovas.so.1 -- same as novas.so except the builtin SONAME
 $(LIB)/libsupernovas.so.$(SO_VERSION): $(SOURCES)
 
 # Shared library: libsolsys1.so.1 (standalone solsys1.c functionality)
 $(LIB)/libsolsys1.so.$(SO_VERSION): BUILTIN_SOLSYS1 := 0
-$(LIB)/libsolsys1.so.$(SO_VERSION): $(SRC)/solsys1.c $(SRC)/eph_manager.c | $(LIB)/libsupernovas.so
+$(LIB)/libsolsys1.so.$(SO_VERSION): $(SRC)/solsys1.c $(SRC)/eph_manager.c
 
 # Shared library: libsolsys2.so.1 (standalone solsys2.c functionality)
 $(LIB)/libsolsys2.so.$(SO_VERSION): BUILTIN_SOLSYS2 := 0
-$(LIB)/libsolsys2.so.$(SO_VERSION): $(SRC)/solsys2.c | $(LIB)/libsupernovas.so
+$(LIB)/libsolsys2.so.$(SO_VERSION): $(SRC)/solsys2.c
 
 # Shared library: libsolsys3.so.1 (standalone solsys1.c functionality)
 $(LIB)/libsolsys3.so.$(SO_VERSION): BUILTIN_SOLSYS3 := 0
-$(LIB)/libsolsys3.so.$(SO_VERSION): $(SRC)/solsys3.c | $(LIB)/libsupernovas.so
+$(LIB)/libsolsys3.so.$(SO_VERSION): $(SRC)/solsys3.c
 
 # Shared library: libsolsys-ephem.so.1 (standalone solsys2.c functionality)
 $(LIB)/libsolsys-ephem.so.$(SO_VERSION): BUILTIN_SOLSYS_EPHEM := 0
-$(LIB)/libsolsys-ephem.so.$(SO_VERSION): $(SRC)/solsys-ephem.c | $(LIB)/libsupernovas.so
+$(LIB)/libsolsys-ephem.so.$(SO_VERSION): $(SRC)/solsys-ephem.c
 
 # Shared library: libsolsys-calceph.so.1 (standalone solsys2.c functionality)
-$(LIB)/libsolsys-calceph.so.$(SO_VERSION): LDFLAGS += -lcalceph
-$(LIB)/libsolsys-calceph.so.$(SO_VERSION): $(SRC)/solsys-calceph.c | $(LIB)/libsupernovas.so
+$(LIB)/libsolsys-calceph.so.$(SO_VERSION): SHLIBS := -lcalceph
+$(LIB)/libsolsys-calceph.so.$(SO_VERSION): $(SRC)/solsys-calceph.c
 
 # Shared library: libsolsys-cspice.so.1 (standalone solsys2.c functionality)
-$(LIB)/libsolsys-cspice.so.$(SO_VERSION): LDFLAGS += -lcspice
-$(LIB)/libsolsys-cspice.so.$(SO_VERSION): $(SRC)/solsys-cspice.c | $(LIB)/libsupernovas.so
+$(LIB)/libsolsys-cspice.so.$(SO_VERSION): SHLIBS := -lcspice
+$(LIB)/libsolsys-cspice.so.$(SO_VERSION): $(SRC)/solsys-cspice.c
+
+# Link submodules against the supernovas shared lib
+$(LIB)/libsolsys%.so.$(SO_VERSION): | $(LIB)/libsupernovas.so
+	@$(MAKE) $(LIB)
+	$(CC) -o $@ $(CPPFLAGS) $(CFLAGS) $^ -shared -fPIC -Wl,-soname,$(subst $(LIB)/,,$@) $(LDFLAGS) -L$(LIB) -lsupernovas $(SHLIBS)
 
 # Static library: libsupernovas.a
 $(LIB)/libsupernovas.a: $(OBJECTS) | $(LIB) Makefile

--- a/build.mk
+++ b/build.mk
@@ -11,9 +11,8 @@ $(OBJ)/%.o: $(SRC)/%.c $(OBJ) Makefile
 	$(CC) -o $@ -c $(CPPFLAGS) $(CFLAGS) $<
 
 # Share library recipe
-$(LIB)/%.so.$(SO_VERSION):
-	@$(MAKE) $(LIB)
-	$(CC) -o $@ $(CPPFLAGS) $(CFLAGS) $^ -shared -fPIC -Wl,-soname,$(subst $(LIB)/,,$@) $(LDFLAGS)
+$(LIB)/%.so.$(SO_VERSION): | $(LIB)
+	$(CC) -o $@ $(SOFLAGS)
 
 # Unversioned shared libs (for linking against)
 $(LIB)/lib%.so:

--- a/config.mk
+++ b/config.mk
@@ -231,6 +231,9 @@ endif
 OBJECTS := $(subst $(SRC),$(OBJ),$(SOURCES))
 OBJECTS := $(subst .c,.o,$(OBJECTS))
 
+# Compiler flags for building shared .so libraries.
+SOFLAGS = $(CPPFLAGS) $(CFLAGS) $^ -shared -fPIC -Wl,-soname,$(subst $(LIB)/,,$@) $(LDFLAGS)
+
 # Search for files in the designated locations
 vpath %.h $(INCLUDE)
 vpath %.c $(SRC)


### PR DESCRIPTION
Fix `Makefile` to work with reverse order (or parallel) builds.