### PR TITLE
Wean off CIO locator file internally.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,17 @@ Upcoming feature release, expected around 1 November 2025.
 
 ### Changed
 
+ - #208: `cio_location()` now always returns the CIO's right ascension relative to the true equinox of date (on the same
+   true equator of date). 
+
 
 ### Deprecated
 
-
+ - #208: Deprecated `cio_location()`. Going forward, SuperNOVAS no longer uses the CIO locator data files (`CIO_RA.TXT`
+   or `cio_ra.bin`) internally, and so `cio_location()` becomes redundant with `cio_ra()` and also `ira_equinox()` (which
+   returns the negative of the same value).
+   
+   
 ## [1.4.2-rc2]
 
 Bug fix release with updated nutation models.

--- a/src/cio.c
+++ b/src/cio.c
@@ -29,8 +29,9 @@
 static FILE *cio_file;
 
 /**
- * Computes the true right ascension of the celestial intermediate origin (CIO) at a given TT
- * Julian date.  This is the negative value for the equation of the origins.
+ * Computes the true right ascension of the celestial intermediate origin (CIO) vs the equinox of date
+ * on the true equator of date for a given TT Julian date. This is simply the negated return value of
+ * ira_equinox() for the true equator of date.
  *
  * REFERENCES:
  * <ol>
@@ -44,12 +45,11 @@ static FILE *cio_file;
  * @return            0 if successful, -1 if the output pointer argument is NULL,
  *                    1 if 'accuracy' is invalid, 10--20: 10 + error code from cio_location(),
  *                    or else 20 + error from cio_basis()
+ *
+ * @sa ira_equinox()
  */
 short cio_ra(double jd_tt, enum novas_accuracy accuracy, double *restrict ra_cio) {
   static const char *fn = "cio_ra";
-  const double unitx[3] = { 1.0, 0.0, 0.0 };
-  double jd_tdb, x[3], y[3], z[3], eq[3], az, r_cio;
-  short rs;
 
   if(!ra_cio)
     return novas_error(-1, EINVAL, fn, "NULL output array");
@@ -62,24 +62,8 @@ short cio_ra(double jd_tt, enum novas_accuracy accuracy, double *restrict ra_cio
     return novas_error(1, EINVAL, fn, "invalid accuracy: %d", accuracy);
 
   // For these calculations we can assume TDB = TT (< 2 ms difference)
-  jd_tdb = jd_tt;
 
-  // Obtain the basis vectors, in the GCRS, for the celestial intermediate
-  // system defined by the CIP (in the z direction) and the CIO (in the
-  // x direction).
-  prop_error(fn, cio_location(jd_tdb, accuracy, &r_cio, &rs), 10);
-  prop_error(fn, cio_basis(jd_tdb, r_cio, rs, accuracy, x, y, z), 20);
-
-  // Compute the direction of the true equinox in the GCRS.
-  tod_to_gcrs(jd_tdb, accuracy, unitx, eq);
-
-  // Compute the RA-like coordinate of the true equinox in the celestial
-  // intermediate system, in radians
-  az = atan2(novas_vdot(eq, y), novas_vdot(eq, x));
-
-  // The RA of the CIO is minus this coordinate, cast as hour-angle
-  *ra_cio = -az / HOURANGLE;
-
+  *ra_cio = -ira_equinox(jd_tt, NOVAS_TRUE_EQUINOX, accuracy);
   return 0;
 }
 
@@ -100,6 +84,9 @@ short cio_ra(double jd_tt, enum novas_accuracy accuracy, double *restrict ra_cio
  * @since 1.0
  * @author Attila Kovacs
  *
+ * @deprecated    SuperNOVAS no longer uses a NOVAS-type CIO locator file. However, if users want
+ *                to access such files  directly, this function remains accessible to provide API
+ *                compatibility with previous versions.
  */
 int set_cio_locator_file(const char *restrict filename) {
   FILE *old = cio_file;
@@ -153,9 +140,15 @@ int set_cio_locator_file(const char *restrict filename) {
  * @return            0 if successful, -1 if one of the pointer arguments is NULL or the
  *                    accuracy is invalid.
  *
- * @sa set_cio_locator_file()
  * @sa cio_ra()
- * @sa gcrs_to_cirs()
+ * @sa ira_equinox()
+ *
+ * @deprecated This function is no longer used internally in the library. Given that the CIO
+ *             is defined on the dynamical equator of date, it is not normally meaningful to
+ *             provide an R.A. coordinate for it in GCRS for users also. And, you can
+ *             use cio_ra() to get the same valye w.r.t. the equinox of date (on the same
+ *             CIRS/TOD dynamical equator, or else use  `ira_equinox()` to return its negated
+ *             value.
  */
 short cio_location(double jd_tdb, enum novas_accuracy accuracy, double *restrict ra_cio, short *restrict loc_type) {
   static const char *fn = "cio_location";
@@ -217,7 +210,7 @@ short cio_location(double jd_tdb, enum novas_accuracy accuracy, double *restrict
     novas_debug(saved_debug_state);
 
     // Calculate the equation of origins.
-    *ra_cio = -1.0 * ira_equinox(jd_tdb, NOVAS_TRUE_EQUINOX, accuracy);
+    *ra_cio = -ira_equinox(jd_tdb, NOVAS_TRUE_EQUINOX, accuracy);
     *loc_type = CIO_VS_EQUINOX;
   }
 
@@ -230,14 +223,12 @@ short cio_location(double jd_tdb, enum novas_accuracy accuracy, double *restrict
 }
 
 /**
- * Computes the orthonormal basis vectors, with respect to the GCRS (geocentric ICRS), of the
+ * Computes the CIRS basis vectors, with respect to the GCRS (geocentric ICRS), of the
  * celestial intermediate system defined by the celestial intermediate pole (CIP) (in the z
- * direction) and the celestial intermediate origin (CIO) (in the x direction).  A TDB Julian
- * date and the right ascension of the CIO at that date is required as input.  The right
- * ascension of the CIO can be with respect to either the GCRS origin or the true equinox of
- * date -- different algorithms are used in the two cases.
+ * direction) and the celestial intermediate origin (CIO) (in the x direction).
  *
- * This function effectively constructs the matrix C in eq. (3) of the reference.
+ * This function effectively constructs the CIRS to GCRS transformation matrix C in eq. (3) of the
+ * reference.
  *
  * NOTES:
  * <ol>
@@ -266,6 +257,7 @@ short cio_location(double jd_tdb, enum novas_accuracy accuracy, double *restrict
  *
  * @sa cio_location()
  * @sa gcrs_to_cirs()
+ *
  */
 short cio_basis(double jd_tdb, double ra_cio, enum novas_cio_location_type loc_type, enum novas_accuracy accuracy,
         double *restrict x, double *restrict y, double *restrict z) {
@@ -383,6 +375,9 @@ short cio_basis(double jd_tdb, double ra_cio, enum novas_cio_location_type loc_t
  *
  * @sa set_cio_locator_file()
  * @sa cio_location()
+ *
+ * @deprecated    This function is no longer used within SuperNOVAS. It is still provided, however,
+ *                in order to retain 100% API compatibility with NOVAS C.
  */
 short cio_array(double jd_tdb, long n_pts, ra_of_cio *restrict cio) {
   static const char *fn = "cio_array";
@@ -394,7 +389,6 @@ short cio_array(double jd_tdb, long n_pts, ra_of_cio *restrict cio) {
     double jd_interval;
     long n_recs;
   };
-
 
 
   static const FILE *last_file;

--- a/src/earth.c
+++ b/src/earth.c
@@ -139,8 +139,7 @@ int terra(const on_surface *restrict location, double lst, double *restrict pos,
  * @param[out] gst    [h] Greenwich (mean or apparent) sidereal time, in hours [0:24]. (In case
  *                    the returned error code is &gt;1 the gst value will be set to NAN.)
  * @return            0 if successful, or -1 if the 'gst' argument is NULL, 1 if 'accuracy' is
- *                    invalid 2 if 'method' is invalid, or else 10--30 with 10 + the error from
- *                    cio_location().
+ *                    invalid 2 if 'method' is invalid.
  *
  * @sa novas_time_gst()
  * @sa era()
@@ -198,12 +197,11 @@ short sidereal_time(double jd_ut1_high, double jd_ut1_low, double ut1_to_tt, enu
       // Use 'CIO-TIO-theta' method.  See Circular 179, Section 6.5.4.
       const double ux[3] = { 1.0, 0.0, 0.0 };
       double ra_cio, ha_eq, x[3], y[3], z[3], eq[3];
-      short ref_sys;
 
       // Obtain the basis vectors, in the GCRS, of the celestial intermediate system.
-      prop_error(fn, cio_location(jd_tdb, accuracy, &ra_cio, &ref_sys), 10);
+      ra_cio = -ira_equinox(jd_tdb, NOVAS_TRUE_EQUINOX, accuracy);
 
-      cio_basis(jd_tdb, ra_cio, ref_sys, accuracy, x, y, z);
+      cio_basis(jd_tdb, ra_cio, CIO_VS_EQUINOX, accuracy, x, y, z);
 
       // Compute the direction of the true equinox in the GCRS.
       tod_to_gcrs(jd_tdb, accuracy, ux, eq);

--- a/src/equinox.c
+++ b/src/equinox.c
@@ -384,7 +384,7 @@ double mean_obliq(double jd_tdb) {
  *                    If 'equinox' = 1 (i.e true equinox), then the returned value is
  *                    the equation of the origins.
  *
- * @sa cio_location()
+ * @sa cio_ra()
  * @sa gcrs_to_cirs()
  *
  * @deprecated      (<i>for internal use</i>) There is no good reason why this function should

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -505,6 +505,17 @@ static int test_cirs_to_gcrs() {
   return n;
 }
 
+static int test_cirs_to_tod() {
+  double p[3];
+  int n = 0;
+
+  if(check("cirs_to_tod:in", -1, cirs_to_tod(0.0, NOVAS_FULL_ACCURACY, NULL, p))) n++;
+  if(check("cirs_to_tod:out", -1, cirs_to_tod(0.0, NOVAS_FULL_ACCURACY, p, NULL))) n++;
+  if(check("cirs_to_tod:accuracy", -1, cirs_to_tod(0.0, -1, p, p))) n++;
+
+  return n;
+}
+
 static int test_cirs_to_app_ra() {
   int n = 0;
   if(check_nan("cirs_to_app_ra:accuracy:-1", cirs_to_app_ra(NOVAS_JD_J2000, -1, 0.0))) n++;
@@ -931,6 +942,7 @@ static int test_cio_location() {
 
   if(check("cio_location:ra", -1, cio_location(0.0, NOVAS_FULL_ACCURACY, NULL, &type))) n++;
   if(check("cio_location:type", -1, cio_location(0.0, NOVAS_FULL_ACCURACY, &x, NULL))) n++;
+  if(check("cio_location:accuracy", -1, cio_location(0.0, -1, &x, &type))) n++;
 
   return n;
 }
@@ -2344,6 +2356,7 @@ int main() {
   if(test_tod_to_j2000()) n++;
   if(test_gcrs_to_cirs()) n++;
   if(test_cirs_to_gcrs()) n++;
+  if(test_cirs_to_tod()) n++;
   if(test_cirs_to_app_ra()) n++;
   if(test_app_to_cirs_ra()) n++;
 

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -1460,6 +1460,27 @@ static int test_geom_posvel() {
   return 0;
 }
 
+static int test_cio_basis() {
+  double h = 0.0;
+  short sys;
+  double x0[3] = {0.0}, y0[3] = {0.0}, z0[3] = {0.0};
+  double x1[3] = {0.0}, y1[3] = {0.0}, z1[3] = {0.0};
+
+  if(!is_ok("cio_basis:cio_location", cio_location(tdb, NOVAS_FULL_ACCURACY, &h, &sys))) return 1;
+  if(!is_equal("cio_basis:cio_location:sys", sys, CIO_VS_GCRS, 1e-12)) return 1;
+
+  if(!is_ok("cio_basis:gcrs", cio_basis(tdb, h, sys, NOVAS_FULL_ACCURACY, x0, y0, z0))) return 1;
+
+  h = -ira_equinox(tdb, NOVAS_TRUE_EQUINOX, NOVAS_FULL_ACCURACY);
+  if(!is_ok("cio_basis:tod", cio_basis(tdb, h, CIO_VS_EQUINOX, NOVAS_FULL_ACCURACY, x1, y1, z1))) return 1;
+
+  if(!is_ok("cio_basis:check:x", check_equal_pos(x0, x1, 1e-11))) return 1;
+  if(!is_ok("cio_basis:check:y", check_equal_pos(y0, y1, 1e-11))) return 1;
+  if(!is_ok("cio_basis:check:z", check_equal_pos(z0, z1, 1e-11))) return 1;
+
+  return 0;
+}
+
 static int test_dates() {
   double offsets[] = {-10000.0, 0.0, 10000.0, 10000.0, 10000.01 };
   int i, n = 0;
@@ -1480,6 +1501,7 @@ static int test_dates() {
     if(test_set_time()) n++;
     if(test_get_time()) n++;
     if(test_geom_posvel()) n++;
+    if(test_cio_basis()) n++;
 
     for(k =0; k < NOVAS_REFERENCE_SYSTEMS; k++) if(test_sky_pos(k)) n++;
 


### PR DESCRIPTION
The CIO locator file (`CIO_RA.TXT` or `cio_ra.bin`) was always entirely optional. While it offers a minor performance boost (provided the required values are already cached), there is really no reason for the library to rely on this external data dependence. Not to mention that the locator table was prepared with the now obsoleted original IAU2000A precession/nutation model (hence it is not accurate at the &mu;as level decades away from J2000). It is better for the library to remain fully self-consistent, and self-contained. Thus, we'll stop using the CIO locator data internally in the library.

Users may continue to access the CIO locator file if needed for legacy applications if need be.