### PR TITLE
Add CMake build tooling

### DIFF
--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -1,0 +1,108 @@
+name: Build with CMake
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "src/**"
+      - "include/**"
+      - "CMakeLists.txt"
+      - "cmake/**"
+      - ".github/workflows/build.yml"
+
+  pull_request:
+    paths:
+      - "src/**"
+      - "include/**"
+      - "CMakeLists.txt"
+      - "cmake/**"
+      - ".github/workflows/build.yml"
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        build_type: [Release, Debug]
+        shared_libs: [ON, OFF]
+        include:
+          - os: ubuntu-latest
+            cc: gcc
+            cxx: g++
+          - os: macos-latest
+            cc: clang
+            cxx: clang++
+          - os: windows-latest
+            cc: gcc
+            cxx: g++
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configure CMake (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DBUILD_SHARED_LIBS=${{ matrix.shared_libs }} \
+            -DBUILD_STATIC_LIBS=ON \
+            -DCMAKE_C_COMPILER=${{ matrix.cc }} \
+            -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
+
+      - name: Configure CMake (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          cmake -B build `
+            -G "MinGW Makefiles" `
+            -DCMAKE_C_COMPILER=gcc `
+            -DCMAKE_CXX_COMPILER=g++ `
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} `
+            -DBUILD_SHARED_LIBS=${{ matrix.shared_libs }} `
+            -DBUILD_STATIC_LIBS=ON
+
+      - name: Build
+        run: cmake --build build --config ${{ matrix.build_type }}
+
+      - name: Install
+        run: cmake --install build --config ${{ matrix.build_type }} --prefix install
+
+      - name: Check Installation (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          echo Installation contents:
+          ls -la install/
+
+      - name: Check Installation (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          echo Installation contents:
+          dir install
+
+  build-freebsd:
+    runs-on: ubuntu-latest
+    name: Build on FreeBSD
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["13.2", "14.0"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build on FreeBSD ${{ matrix.version }}
+        uses: vmactions/freebsd-vm@v1
+        with:
+          release: ${{ matrix.version }}
+          usesh: true
+          prepare: |
+            pkg install -y cmake
+          run: |
+            echo Building on FreeBSD $(uname -m) version ${{ matrix.version }}
+            cmake -B build -DCMAKE_BUILD_TYPE=Release
+            cmake --build build
+            cmake --install build --prefix install
+            ls -la install/

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ TODO
 VERSION
 RELEASE-HOWTO.md
 infer-out
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,358 @@
+cmake_minimum_required(VERSION 3.20)
+
+# Project definition
+project(SuperNOVAS
+    VERSION 1.5.0
+    DESCRIPTION "SuperNOVAS astrometry library"
+    HOMEPAGE_URL "https://smithsonian.github.io/SuperNOVAS/"
+    LANGUAGES C
+)
+
+# Default build type if not specified
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type" FORCE)
+    message(STATUS "Setting build type to 'Release' as none was specified.")
+endif()
+
+# Include required modules
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+include(FeatureSummary)
+include(CheckLibraryExists)
+
+# Build options
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+option(BUILD_STATIC_LIBS "Build static libraries in addition to shared" ON)
+option(BUILD_EXAMPLES "Build example programs" ON)
+option(ENABLE_CALCEPH "Enable CALCEPH support" OFF)
+option(ENABLE_INSTALL "Enable installation" ON)
+
+# Set feature descriptions for summary
+add_feature_info(SharedLibs BUILD_SHARED_LIBS "Build shared libraries")
+add_feature_info(StaticLibs BUILD_STATIC_LIBS "Build static libraries")
+add_feature_info(Examples BUILD_EXAMPLES "Build example programs")
+add_feature_info(CALCEPH ENABLE_CALCEPH "CALCEPH ephemeris support")
+
+# Set output directories
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+# Debug postfix for libraries
+set(CMAKE_DEBUG_POSTFIX d)
+
+# Position Independent Code for shared libs
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# RPATH settings for installed binaries
+if(NOT APPLE)
+    set(CMAKE_INSTALL_RPATH $ORIGIN/../${CMAKE_INSTALL_LIBDIR})
+else()
+    set(CMAKE_INSTALL_RPATH @loader_path/../${CMAKE_INSTALL_LIBDIR})
+endif()
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# Windows-specific settings
+if(WIN32)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
+endif()
+
+# Sources
+set(SUPERNOVAS_CORE_SOURCES
+    src/target.c
+    src/observer.c
+    src/earth.c
+    src/equinox.c
+    src/system.c
+    src/transform.c
+    src/cio.c
+    src/orbital.c
+    src/spectral.c
+    src/grav.c
+    src/nutation.c
+    src/timescale.c
+    src/frames.c
+    src/place.c
+    src/calendar.c
+    src/refract.c
+    src/naif.c
+    src/parse.c
+    src/plugin.c
+    src/util.c
+    src/planets.c
+    src/itrf.c
+    src/solsys3.c
+    src/solsys-ephem.c
+)
+
+# Preprocessor definitions
+set(SUPERNOVAS_COMPILE_DEFINITIONS
+    BUILTIN_SOLSYS3=1
+    BUILTIN_SOLSYS_EPHEM_READER=1
+    DEFAULT_SOLSYS=3
+)
+
+# Check for math library
+check_library_exists(m sin "" HAVE_LIBM)
+
+# CALCEPH
+if(ENABLE_CALCEPH)
+    find_package(calceph CONFIG REQUIRED)
+    list(APPEND SUPERNOVAS_COMPILE_DEFINITIONS USE_CALCEPH=1)
+    set(CALCEPH_FOUND TRUE)
+    message(STATUS "Found calceph")
+endif()
+
+# Find threads (may be needed for some platforms)
+find_package(Threads)
+
+# Main library target
+add_library(supernovas ${SUPERNOVAS_CORE_SOURCES})
+add_library(SuperNOVAS::supernovas ALIAS supernovas)
+
+set_target_properties(supernovas PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+    POSITION_INDEPENDENT_CODE ON
+    EXPORT_NAME supernovas
+    OUTPUT_NAME supernovas
+    CLEAN_DIRECT_OUTPUT ON
+)
+
+target_include_directories(supernovas
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+target_compile_definitions(supernovas PRIVATE ${SUPERNOVAS_COMPILE_DEFINITIONS})
+
+# Compiler-specific warnings and flags
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(supernovas PRIVATE
+        $<$<CONFIG:Debug>:-g;-O0;-Wall;-Wextra;-Wpedantic;-Wconversion;-Wshadow>
+        $<$<CONFIG:Release>:-O3;-DNDEBUG;-Wall;-Wextra>
+        $<$<CONFIG:RelWithDebInfo>:-O2;-g;-DNDEBUG;-Wall;-Wextra>
+        $<$<CONFIG:MinSizeRel>:-Os;-DNDEBUG>
+    )
+
+    # Additional security flags
+    if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+        target_compile_options(supernovas PRIVATE
+            -fstack-protector-strong
+            -D_FORTIFY_SOURCE=2
+        )
+    endif()
+elseif(MSVC)
+    target_compile_options(supernovas PRIVATE
+        /W4
+        /permissive-
+        $<$<CONFIG:Debug>:/Zi;/Od;/RTC1>
+        $<$<CONFIG:Release>:/O2;/DNDEBUG>
+    )
+endif()
+
+# Link libraries
+target_link_libraries(supernovas
+    PRIVATE
+        $<$<BOOL:${HAVE_LIBM}>:m>
+        $<$<BOOL:${CMAKE_THREAD_LIBS_INIT}>:${CMAKE_THREAD_LIBS_INIT}>
+)
+
+# Optional static build
+if(BUILD_STATIC_LIBS)
+    add_library(supernovas_static STATIC ${SUPERNOVAS_CORE_SOURCES})
+    add_library(SuperNOVAS::supernovas_static ALIAS supernovas_static)
+
+    set_target_properties(supernovas_static PROPERTIES
+        OUTPUT_NAME supernovas
+        VERSION ${PROJECT_VERSION}
+        POSITION_INDEPENDENT_CODE ON
+        EXPORT_NAME supernovas_static
+        CLEAN_DIRECT_OUTPUT ON
+    )
+
+    target_include_directories(supernovas_static PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+
+    target_compile_definitions(supernovas_static PRIVATE
+        ${SUPERNOVAS_COMPILE_DEFINITIONS}
+    )
+
+    target_compile_options(supernovas_static PRIVATE
+        $<$<C_COMPILER_ID:GNU,Clang>:${CMAKE_C_COMPILE_OPTIONS_PIC}>
+    )
+
+    target_link_libraries(supernovas_static
+        PRIVATE
+            $<$<BOOL:${HAVE_LIBM}>:m>
+            $<$<BOOL:${CMAKE_THREAD_LIBS_INIT}>:${CMAKE_THREAD_LIBS_INIT}>
+    )
+endif()
+
+# Compatibility alias
+add_library(novas ALIAS supernovas)
+
+# Plugins
+if(ENABLE_CALCEPH)
+    add_library(solsys-calceph SHARED src/solsys-calceph.c)
+    add_library(SuperNOVAS::solsys-calceph ALIAS solsys-calceph)
+
+    set_target_properties(solsys-calceph PROPERTIES
+        VERSION ${PROJECT_VERSION}
+        SOVERSION ${PROJECT_VERSION_MAJOR}
+        POSITION_INDEPENDENT_CODE ON
+    )
+
+    target_include_directories(solsys-calceph PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+
+    target_compile_definitions(solsys-calceph PRIVATE ${SUPERNOVAS_COMPILE_DEFINITIONS})
+
+    target_link_libraries(solsys-calceph PRIVATE
+        supernovas
+        calceph
+        $<$<BOOL:${HAVE_LIBM}>:m>
+    )
+endif()
+
+# CIO data generator
+add_executable(cio_file src/cio_file.c)
+target_include_directories(cio_file PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries(cio_file PRIVATE $<$<BOOL:${HAVE_LIBM}>:m>)
+
+set(CIO_INPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/data/CIO_RA.TXT)
+set(CIO_OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/cio_ra.bin)
+
+add_custom_command(
+    OUTPUT ${CIO_OUTPUT_FILE}
+    COMMAND cio_file ${CIO_INPUT_FILE} ${CIO_OUTPUT_FILE}
+    DEPENDS cio_file ${CIO_INPUT_FILE}
+    COMMENT "Generating CIO binary data file"
+    VERBATIM
+)
+
+add_custom_target(cio_data ALL DEPENDS ${CIO_OUTPUT_FILE})
+
+# Examples
+if(BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()
+
+# Installation
+if(ENABLE_INSTALL)
+    set(INSTALL_TARGETS supernovas)
+    if(BUILD_STATIC_LIBS AND TARGET supernovas_static)
+        list(APPEND INSTALL_TARGETS supernovas_static)
+    endif()
+    if(ENABLE_CALCEPH)
+        list(APPEND INSTALL_TARGETS solsys-calceph)
+    endif()
+
+    install(TARGETS ${INSTALL_TARGETS}
+        EXPORT SuperNOVASTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+
+    install(DIRECTORY include/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        FILES_MATCHING PATTERN "*.h"
+    )
+
+    install(FILES
+        data/CIO_RA.TXT
+        ${CIO_OUTPUT_FILE}
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/supernovas
+    )
+
+    install(EXPORT SuperNOVASTargets
+        FILE SuperNOVASTargets.cmake
+        NAMESPACE SuperNOVAS::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/SuperNOVAS
+    )
+
+    configure_package_config_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/SuperNOVASConfig.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/SuperNOVASConfig.cmake
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/SuperNOVAS
+    )
+
+    write_basic_package_version_file(
+        ${CMAKE_CURRENT_BINARY_DIR}/SuperNOVASConfigVersion.cmake
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion
+    )
+
+    install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/SuperNOVASConfig.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/SuperNOVASConfigVersion.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/SuperNOVAS
+    )
+
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/supernovas.pc.in
+        ${CMAKE_CURRENT_BINARY_DIR}/supernovas.pc
+        @ONLY
+    )
+
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/supernovas.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    )
+endif()
+
+# Uninstall target
+if(NOT TARGET uninstall)
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+        IMMEDIATE @ONLY
+    )
+
+    add_custom_target(uninstall
+        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
+    )
+endif()
+
+# Summary
+feature_summary(WHAT ALL)
+message(STATUS "")
+message(STATUS "SuperNOVAS Configuration Summary:")
+message(STATUS "  Version:           ${PROJECT_VERSION}")
+message(STATUS "  Build type:        ${CMAKE_BUILD_TYPE}")
+message(STATUS "  Install prefix:    ${CMAKE_INSTALL_PREFIX}")
+message(STATUS "  Compiler:          ${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION}")
+message(STATUS "")
+message(STATUS "Options:")
+message(STATUS "  Shared libraries:  ${BUILD_SHARED_LIBS}")
+message(STATUS "  Static libraries:  ${BUILD_STATIC_LIBS}")
+if(ENABLE_CALCEPH)
+    message(STATUS "  CALCEPH support:   YES")
+else()
+    message(STATUS "  CALCEPH support:   NO")
+endif()
+message(STATUS "")
+message(STATUS "Detected:")
+if(HAVE_LIBM)
+    message(STATUS "  Math library:      Found")
+else()
+    message(STATUS "  Math library:      Not required")
+endif()
+if(CMAKE_THREAD_LIBS_INIT)
+    message(STATUS "  Threads:           ${CMAKE_THREAD_LIBS_INIT}")
+elseif(CMAKE_USE_PTHREADS_INIT)
+    message(STATUS "  Threads:           pthreads")
+elseif(CMAKE_USE_WIN32_THREADS_INIT)
+    message(STATUS "  Threads:           Win32 threads")
+else()
+    message(STATUS "  Threads:           Built-in")
+endif()
+message(STATUS "")

--- a/Doxyfile
+++ b/Doxyfile
@@ -1097,7 +1097,8 @@ RECURSIVE              = NO
 # run.
 
 EXCLUDE                = README.md \
-                         CODE_OF_CONDUCT.md
+                         CODE_OF_CONDUCT.md \
+                         CMakeLists.txt
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -1120,7 +1121,8 @@ EXCLUDE_PATTERNS       = */test/* \
                          */old/* \
                          */obsolete/* \
                          */examples/* \
-                         */tools/*
+                         */tools/* \
+                         */build/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/README_CMAKE.md
+++ b/README_CMAKE.md
@@ -1,0 +1,65 @@
+# SuperNOVAS CMake Build
+
+As an alternative to the traditional Makefile build, we provide a CMake build as well.
+This was done primarily to expand cross-platform support and simplify inclusion in external CMake builds.
+This build is not as feature-complete as the Makefile, but should support the most typical usecase.
+
+## Quick Start
+
+```bash
+# Basic build
+cmake -B build
+cmake --build build
+```
+
+## Build Options
+
+- `BUILD_SHARED_LIBS=ON|OFF` (default: ON) - Build shared libraries
+- `BUILD_STATIC_LIBS=ON|OFF` (default: ON) - Build static libraries in addition to shared
+- `BUILD_EXAMPLES=ON|OFF` (default: OFF) - Build the included examples
+- `ENABLE_CALCEPH=ON|OFF` (default: OFF) - Enable CALCEPH ephemeris support. Requires CALCEPH installed.
+
+## Build Examples
+
+### Debug Build
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Debug
+cmake --build build
+```
+
+### Full Release Build with CALCEPH
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_CALCEPH=ON
+cmake --build build
+```
+
+## Installation
+
+This will install all the libraries, headers, CIO data files, CMake config files, and a pkg-config file.
+
+```bash
+cmake --build build
+cmake --install build --prefix /usr/local
+```
+
+## Using in Your Project
+
+After installation:
+
+```cmake
+# Link core library
+find_package(SuperNOVAS REQUIRED)
+target_link_libraries(your_target PRIVATE SuperNOVAS::supernovas)
+
+# If you built with CALCEPH support, link the plugin library
+target_link_libraries(your_target PRIVATE SuperNOVAS::solsys-calceph)
+```
+
+## Key Differences from Makefile
+
+This CMake build generally follows the Makefile, except for a few key differences:
+- Always enables `BUILTIN_SOLSYS3=1` and `DEFAULT_SOLSYS=3`
+- Removes legacy compatibility options
+- Only supports CALEPH integration
+- Doesn't support buildilng the docs, tests, or benchmarks
+- *Does* support practically every platform you might want to build for (MacOS/Windows (MinGW)/FreeBSD)

--- a/cmake/SuperNOVASConfig.cmake.in
+++ b/cmake/SuperNOVASConfig.cmake.in
@@ -1,0 +1,50 @@
+@PACKAGE_INIT@
+
+# SuperNOVAS CMake configuration file
+
+include(CMakeFindDependencyMacro)
+
+# Find required dependencies
+find_dependency(Threads)
+
+# Find math library if needed
+if(NOT WIN32)
+    find_library(MATH_LIBRARY m)
+    if(NOT MATH_LIBRARY)
+        message(FATAL_ERROR "Math library not found")
+    endif()
+endif()
+
+# Include targets
+include("${CMAKE_CURRENT_LIST_DIR}/SuperNOVASTargets.cmake")
+
+# Set variables for backward compatibility
+set(SuperNOVAS_LIBRARIES SuperNOVAS::supernovas)
+set(SuperNOVAS_INCLUDE_DIRS "")
+
+# Get include directories from target properties
+get_target_property(SuperNOVAS_INCLUDE_DIRS SuperNOVAS::supernovas INTERFACE_INCLUDE_DIRECTORIES)
+
+# Check if optional components are available
+if(TARGET SuperNOVAS::solsys-calceph)
+    set(SuperNOVAS_CALCEPH_FOUND TRUE)
+else()
+    set(SuperNOVAS_CALCEPH_FOUND FALSE)
+endif()
+
+# Component support
+set(SuperNOVAS_FIND_COMPONENTS ${SuperNOVAS_FIND_COMPONENTS})
+
+foreach(component ${SuperNOVAS_FIND_COMPONENTS})
+    if(component STREQUAL "calceph")
+        if(NOT SuperNOVAS_CALCEPH_FOUND)
+            set(SuperNOVAS_FOUND FALSE)
+            set(SuperNOVAS_NOT_FOUND_MESSAGE "SuperNOVAS CALCEPH component not available")
+        endif()
+    else()
+        set(SuperNOVAS_FOUND FALSE)
+        set(SuperNOVAS_NOT_FOUND_MESSAGE "Unknown SuperNOVAS component: ${component}")
+    endif()
+endforeach()
+
+check_required_components(SuperNOVAS)

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -1,0 +1,27 @@
+# cmake_uninstall.cmake.in
+#
+# Uninstall target template for CMake projects
+#
+
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+    message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+
+foreach(file ${files})
+    message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+    if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+        exec_program(
+            "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+            OUTPUT_VARIABLE rm_out
+            RETURN_VALUE rm_retval
+        )
+        if(NOT "${rm_retval}" STREQUAL 0)
+            message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+        endif()
+    else()
+        message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+    endif()
+endforeach()

--- a/cmake/supernovas.pc.in
+++ b/cmake/supernovas.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: SuperNOVAS
+Description: @PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -lsupernovas
+Libs.private: -lm
+Cflags: -I${includedir}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,56 @@
+# List of example programs to build
+set(EXAMPLE_PROGRAMS
+    example-star
+    example-time
+    example-high-z
+    example-orbital
+    example-rise-set
+)
+
+if(ENABLE_CALCEPH)
+    list(APPEND EXAMPLE_PROGRAMS example-calceph)
+endif()
+
+# Build each example
+foreach(EXAMPLE ${EXAMPLE_PROGRAMS})
+    set(EXAMPLE_SOURCE ${EXAMPLE}.c)
+
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${EXAMPLE_SOURCE})
+        add_executable(${EXAMPLE} ${EXAMPLE_SOURCE})
+
+        # Link against the supernovas library
+        target_link_libraries(${EXAMPLE} PRIVATE
+            supernovas
+            $<$<BOOL:${HAVE_LIBM}>:m>
+        )
+
+        # Special handling for CALCEPH example
+        if(${EXAMPLE} STREQUAL "example-calceph")
+            target_link_libraries(${EXAMPLE} PRIVATE
+                solsys-calceph
+                calceph
+            )
+        endif()
+
+        # Set RPATH for the example to find the library
+        if(NOT WIN32)
+            set_target_properties(${EXAMPLE} PROPERTIES
+                INSTALL_RPATH "$ORIGIN/../lib"
+                BUILD_RPATH "${CMAKE_BINARY_DIR}/lib"
+            )
+        endif()
+
+        # Add a custom target to run this specific example
+        add_custom_target(run-${EXAMPLE}
+            COMMAND ${EXAMPLE}
+            DEPENDS ${EXAMPLE}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            COMMENT "Running ${EXAMPLE}"
+            VERBATIM
+        )
+
+        message(STATUS "Added example: ${EXAMPLE}")
+    else()
+        message(WARNING "Source file ${EXAMPLE_SOURCE} not found - ${EXAMPLE} will not be built")
+    endif()
+endforeach()


### PR DESCRIPTION
Ok, as an alternative to PR #221, here is a CMake version of the build.

It is trimmed-down compared to the Makefile build, but is pretty useful as it allows easy inclusion in other CMake projects, generates a pkgconfig file, and builds on everything (inlcuding windows!). It does not, however, build the tests/benchmarks/or docs.

If we go with this, we can leave your makefile untouched.