### PR TITLE
Improved CMake build support

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -46,7 +46,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y doxygen
           else
-            brew update
+            brew upgrade
             brew install doxygen
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,10 @@ Upcoming feature release, expected around 1 November 2025.
    reference ellipsoid of choice, and vice versa. The latter function is adapted from the IERS `GCONV2.F` routine.
    
  - #221: Now supporting Mac OS X builds, which are different from standard UNIX build, via GNU `make` also (by 
-   kiranshila).
+   kiranshila and attipaci).
    
- - #222: CMake build support, including Mac OS and Windows builds (by kiranshila).
+ - #222: CMake build support, including Mac OS and Windows builds (by kiranshila), with further tweaks in #228 (
+   (by attipaci).
 
  - #223: New functions `novas_clock_skew_tt()`, `novas_clock_skew_tcg()`, and `novas_clock_skew_tcb()` to calculate
    the incremental rate at which an observer's clock ticks faster than a TT, TCG, or TCB clock respectively would. 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,15 +23,23 @@ include(CheckLibraryExists)
 # Build options
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(BUILD_STATIC_LIBS "Build static libraries in addition to shared" ON)
+option(BUILD_DOC "Build HTML documetation" OFF)
+option(BUILD_TESTING "Build regression test suite" ON)
 option(BUILD_EXAMPLES "Build example programs" ON)
+option(BUILD_BENCHMARK "Build benchmark programs" OFF)
 option(ENABLE_CALCEPH "Enable CALCEPH support" OFF)
+option(ENABLE_CSPICE "Enable CSPICE support" OFF)
 option(ENABLE_INSTALL "Enable installation" ON)
 
 # Set feature descriptions for summary
 add_feature_info(SharedLibs BUILD_SHARED_LIBS "Build shared libraries")
 add_feature_info(StaticLibs BUILD_STATIC_LIBS "Build static libraries")
-add_feature_info(Examples BUILD_EXAMPLES "Build example programs")
+add_feature_info(Example BUILD_EXAMPLES "Build example programs")
+add_feature_info(Test BUILD_TESTING "Regression testing")
 add_feature_info(CALCEPH ENABLE_CALCEPH "CALCEPH ephemeris support")
+add_feature_info(CSPICE ENABLE_CSPICE "CSPICE ephemeris support")
+add_feature_info(Documentation BUILD_DOC "HTML documentation")
+add_feature_info(Benchmark BUILD_BENCHMARK "Build benchmarking programs")
 
 # Set output directories
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -43,14 +51,6 @@ set(CMAKE_DEBUG_POSTFIX d)
 
 # Position Independent Code for shared libs
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-# RPATH settings for installed binaries
-#if(NOT APPLE)
-#    set(CMAKE_INSTALL_RPATH ${ORIGIN}/../${CMAKE_INSTALL_LIBDIR})
-#else()
-#    set(CMAKE_INSTALL_RPATH @loader_path/../${CMAKE_INSTALL_LIBDIR})
-#endif()
-#set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # Windows-specific settings
 if(WIN32)
@@ -104,8 +104,13 @@ if(ENABLE_CALCEPH)
     message(STATUS "Found calceph")
 endif()
 
-# Find threads (may be needed for some platforms)
-find_package(Threads)
+# CSPICE
+if(ENABLE_CSPICE)
+    find_library(cspice cspice REGISTRY_VIEW TARGET REQUIRED)
+    list(APPEND SUPERNOVAS_COMPILE_DEFINITIONS USE_CSPICE=1)
+    set(CSPICE_FOUND TRUE)
+    message(STATUS "Found cspice")
+endif()
 
 # Main library target
 add_library(supernovas ${SUPERNOVAS_CORE_SOURCES})
@@ -199,56 +204,112 @@ endif()
 add_library(novas ALIAS supernovas)
 
 # Plugins
-if(ENABLE_CALCEPH)
-    add_library(solsys-calceph SHARED src/solsys-calceph.c)
-    add_library(SuperNOVAS::solsys-calceph ALIAS solsys-calceph)
+function(solsys_plugin PLUGIN_NAME)
+    add_library(solsys-${PLUGIN_NAME} SHARED src/solsys-${PLUGIN_NAME}.c)
+    add_library(SuperNOVAS::solsys-${PLUGIN_NAME} ALIAS solsys-${PLUGIN_NAME})
 
-    set_target_properties(solsys-calceph PROPERTIES
+    set_target_properties(solsys-${PLUGIN_NAME} PROPERTIES
         VERSION ${PROJECT_VERSION}
         SOVERSION ${PROJECT_VERSION_MAJOR}
         POSITION_INDEPENDENT_CODE ON
     )
 
-    target_include_directories(solsys-calceph PRIVATE
+    target_include_directories(solsys-${PLUGIN_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include
     )
 
-    target_compile_definitions(solsys-calceph PRIVATE ${SUPERNOVAS_COMPILE_DEFINITIONS})
+    target_compile_definitions(solsys-${PLUGIN_NAME} PRIVATE ${SUPERNOVAS_COMPILE_DEFINITIONS})
 
-    target_link_libraries(solsys-calceph PRIVATE
+    target_link_libraries(solsys-${PLUGIN_NAME} PRIVATE
         supernovas
-        calceph
+        ${PLUGIN_NAME}
         $<$<BOOL:${HAVE_LIBM}>:m>
     )
+endfunction()
+
+if(ENABLE_CALCEPH)
+    solsys_plugin(calceph)
 endif()
+
+if(ENABLE_CSPICE)
+    solsys_plugin(cspice)
+endif()
+
+# Run tests
+enable_testing()
 
 # Examples
 if(BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
+# Testing
+if(BUILD_TESTING)
+    add_subdirectory(test)
+endif()
 
-# Installation
+# Benchmarking
+if(BUILD_BENCHMARK)
+    add_subdirectory(benchmark)
+endif()
 
-if(UNIX)
-    include(GNUInstallDirs)
-else()
-    set(CMAKE_INSTALL_LIBDIR "lib")
-    set(CMAKE_INSTALL_DATADIR "share")
-    set(CMAKE_INSTALL_INCLUDEDIR "include")
-    set(CMAKE_INSTALL_BINDIR "bin")
-    set(CMAKE_INSTALL_LIBEXECDIR "libexec")
-    set(CMAKE_INSTALL_MANDIR "share/man")
+if(BUILD_DOC) 
+    find_package(Doxygen)
+
+    set(README ${PROJECT_SOURCE_DIR}/README.md)
+    set(DOXYFILE ${PROJECT_SOURCE_DIR}/Doxyfile)
+
+    if(Doxygen_FOUND)
+  
+        # Strip head from README.md, and from generate html docs
+        # This is a bit ugly as it requires UNIX shell, sed, tail...
+        add_custom_target(prep_docs
+            VERBATIM
+            COMMAND echo "LINE=`sed -n '/\# /{=;q;}' ${README}` && tail -n +$((LINE+2)) ${README}" > tmp.sh
+            COMMAND bash tmp.sh > ${PROJECT_SOURCE_DIR}/README-orig.md && rm -f tmp.sh
+            COMMAND sed s:resources/header.html::g ${DOXYFILE} > Doxyfile.headless
+            COMMAND sed s:apidoc:${CMAKE_CURRENT_BINARY_DIR}:g Doxyfile.headless > Doxyfile.local && rm -f Doxyfile.headless
+        )
+
+        # Run Doxygen
+        add_custom_target(project_docs 
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+            COMMAND Doxygen::doxygen ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile.local
+        )
+
+        # Clean up temporary generated files in source directory
+        add_custom_target(cleanup_docs
+            VERBATIM
+            COMMAND rm -f ${PROJECT_SOURCE_DIR}/README-orig.md
+        )
+    
+        add_dependencies(cleanup_docs project_docs)
+        add_dependencies(project_docs prep_docs)
+        add_dependencies(supernovas cleanup_docs)
+    endif()
 endif()
 
 
+
+# Installation
 if(ENABLE_INSTALL)
     set(INSTALL_TARGETS supernovas)
+
     if(BUILD_STATIC_LIBS AND TARGET supernovas_static)
         list(APPEND INSTALL_TARGETS supernovas_static)
     endif()
+
     if(ENABLE_CALCEPH)
         list(APPEND INSTALL_TARGETS solsys-calceph)
+    endif()
+
+    if(BUILD_DOC AND TARGET project_docs)
+        install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html
+           DESTINATION ${CMAKE_INSTALL_DOCDIR}/supernovas
+        )
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/supernovas.tag
+           DESTINATION ${CMAKE_INSTALL_DOCDIR}/supernovas
+        )
     endif()
 
     install(TARGETS ${INSTALL_TARGETS}
@@ -317,6 +378,10 @@ if(NOT TARGET uninstall)
     )
 endif()
 
+# Export the package for use from the build-tree
+# (this registers the build-tree with a global CMake-registry)
+export(PACKAGE SuperNOVAS)
+
 # Summary
 feature_summary(WHAT ALL)
 message(STATUS "")
@@ -333,6 +398,26 @@ if(ENABLE_CALCEPH)
     message(STATUS "  CALCEPH support:   YES")
 else()
     message(STATUS "  CALCEPH support:   NO")
+endif()
+if(ENABLE_CALCEPH)
+    message(STATUS "  CSPICE support:    YES")
+else()
+    message(STATUS "  CSPICE support:    NO")
+endif()
+if(BUILD_TESTING)
+    message(STATUS "  Regression test:   YES")
+else()
+    message(STATUS "  Regression test:    NO")
+endif()
+if(BUILD_EXAMPLES)
+    message(STATUS "  Examples:          YES")
+else()
+    message(STATUS "  Examples:          NO")
+endif()
+if(BUILD_DOC)
+    message(STATUS "  HTML docs:         YES")
+else()
+    message(STATUS "  HTML docs:         NO")
 endif()
 message(STATUS "")
 message(STATUS "Detected:")

--- a/Doxyfile
+++ b/Doxyfile
@@ -1121,7 +1121,9 @@ EXCLUDE_PATTERNS       = */test/* \
                          */old/* \
                          */obsolete/* \
                          */examples/* \
-                         */tools/*
+                         */tools/* \
+                         */ephem/* \
+                         */benchmark/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ all: distro static test coverage analyze
 
 # Run regression tests
 .PHONY: test
-test: cio_ra.bin
+test: data/cio_ra.bin
 	$(MAKE) -C test run
 
 .PHONY: benchmark
@@ -139,13 +139,13 @@ clean:
 .PHONY: distclean
 distclean: clean
 	rm -f $(LIB)/libsupernovas.$(SOEXT)* $(LIB)/libsupernovas.a \
-      $(LIB)/libnovas.$(SOEXT)* $(LIB)/libnovas.a $(LIB)/libsolsys*.$(SOEXT)* cio_ra.bin
+      $(LIB)/libnovas.$(SOEXT)* $(LIB)/libnovas.a $(LIB)/libsolsys*.$(SOEXT)* data/cio_ra.bin
 	$(MAKE) -C benchmark distclean
 
 .PHONY:
 check-cio-locator:
 ifndef CIO_LOCATOR_FILE
-	  $(info WARNING! No default CIO_LOCATOR_FILE defined. Will use local 'cio_ra.bin' if present.)
+	  $(info WARNING! No default CIO_LOCATOR_FILE defined. Will use local 'data/cio_ra.bin' if present.)
 endif
 
 
@@ -209,7 +209,10 @@ $(LIB)/libnovas.a: $(LIB)/libsupernovas.a
 	( cd $(LIB); ln -s libsupernovas.a libnovas.a )
 
 # CIO locator data
-cio_ra.bin: data/CIO_RA.TXT $(BIN)/cio_file
+.PHONY: cio_ra.bin
+cio_ra.bin: data/cio_ra.bin
+
+data/cio_ra.bin: data/CIO_RA.TXT $(BIN)/cio_file
 	$(BIN)/cio_file $< $@
 
 .INTERMEDIATE: $(BIN)/cio_file
@@ -218,7 +221,6 @@ bin/cio_file: $(OBJ)/cio_file.o | $(BIN)
 
 README-orig.md: README.md
 	LINE=`sed -n '/\# /{=;q;}' $<` && tail -n +$$((LINE+2)) $< > $@
-
 
 dox: 
 
@@ -320,7 +322,7 @@ help:
 	@echo "  solsys        Builds only the objects that may provide external 'solarsystem()'"
 	@echo "                call implentations (e.g. 'solsys1.o', 'eph_manager.o'...)."
 	@echo "  cio_ra.bin    Generates a platform-specific binary CIO locator lookup data file"
-	@echo "                'cio_ra.bin' from the ASCII 'data/CIO_RA.TXT'."
+	@echo "                'data/cio_ra.bin' from the ASCII 'data/CIO_RA.TXT'."
 	@echo "  test          Runs regression tests."
 	@echo "  benchmark     Runs benchmarks."
 	@echo "  analyze       Performs static code analysis with 'cppcheck'."

--- a/README.md
+++ b/README.md
@@ -308,8 +308,8 @@ NOTES:
 
 As of v1.5, __SuperNOVAS__ can be built using [CMake](https://cmake.org/) (thanks to Kiran Shila). CMake allows for 
 greater portability than the regular GNU `Makefile`. Note, however, that the CMake configuration does not support all 
-of the build options of the GNU `Makefile`, such as building with CSPICE support, automatic CALCEPH/CSPICE integration 
-on Linux, supporting legacy NOVAS C style builds, compiling the HTML API documentation, unit tests, or benchmarks. 
+of the build options of the GNU `Makefile`, such as automatic CALCEPH/CSPICE integration on Linux, supporting legacy 
+NOVAS C style builds, and code coverage tracking. 
 
 The basic build recipe for CMake is:
 
@@ -320,16 +320,19 @@ The basic build recipe for CMake is:
 
 The __SuperNOVAS__ CMake build supports the following options (in addition to the standard CMake options):
 
- - `BUILD_SHARED_LIBS=ON|OFF` (default: ON) - Build shared libraries
- - `BUILD_STATIC_LIBS=ON|OFF` (default: ON) - Build static libraries in addition to shared
- - `BUILD_EXAMPLES=ON|OFF` (default: OFF) - Build the included examples
- - `ENABLE_CALCEPH=ON|OFF` (default: OFF) - Enable CALCEPH ephemeris support. Requires CALCEPH installed.
-
+ - `BUILD_STATIC_LIBS=ON|OFF` (default: OFF) - Build static libraries in addition to shared
+ - `BUILD_DOC=ON|OFF` (default: ON) - Compile HTML documentation. Requires `doxygen`, `bash`, and `sed`.
+ - `BUILD_EXAMPLES=ON|OFF` (default: ON) - Build the included examples
+ - `BUILD_TESTING=ON|OFF` (default: ON - Build regression tests
+ - `BUILD_BENCHMARK=ON|OFF` (default: OFF - Build benachmarking programs 
+ - `ENABLE_CALCEPH=ON|OFF` (default: OFF) - Enable CALCEPH ephemeris support. Requires CALCEPH package.
+ - `ENABLE_CSPICE=ON|OFF` (default: OFF) - Enable CSPICE ephemeris support. Requires `cspice` library installed.
+ 
 For example, to build __SuperNOVAS__ with [CALCEPH](https://calceph.imcce.fr/docs/4.0.0/html/c/index.html) 
-integration for ephemeris support:
+integration for ephemeris support, and HTML documentation:
 
 ```bash
-  $ cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_CALCEPH=ON
+  $ cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_CALCEPH=ON -DBUILD_DOC=ON
   $ cmake --build build
 ```
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,0 +1,26 @@
+# List of example programs to build
+set(BENCHMARK_PROGRAMS
+    benchmark-nutation
+    benchmark-place
+)
+
+link_directories(${CMAKE_BINARY_DIR}/lib)
+
+# Build each example
+foreach(BENCHMARK ${BENCHMARK_PROGRAMS})
+    set(BENCHMARK_SOURCE ${BENCHMARK}.c)
+
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${BENCHMARK_SOURCE})
+        add_executable(${BENCHMARK} ${BENCHMARK_SOURCE})
+
+        # Link against the supernovas library
+        target_link_libraries(${BENCHMARK} PRIVATE
+            supernovas
+            $<$<BOOL:${HAVE_LIBM}>:m>
+        )
+
+        message(STATUS "Added benchmark: ${BENCHMARK}")
+    else()
+        message(WARNING "Source file ${BENCHMARK_SOURCE} not found - ${BENCHMARK} will not be built")
+    endif()
+endforeach()

--- a/cmake/SuperNOVASConfig.cmake.in
+++ b/cmake/SuperNOVASConfig.cmake.in
@@ -4,9 +4,6 @@
 
 include(CMakeFindDependencyMacro)
 
-# Find required dependencies
-find_dependency(Threads)
-
 # Find math library if needed
 if(NOT WIN32)
     find_library(MATH_LIBRARY m)
@@ -33,13 +30,16 @@ else()
 endif()
 
 # Component support
-set(SuperNOVAS_FIND_COMPONENTS ${SuperNOVAS_FIND_COMPONENTS})
-
 foreach(component ${SuperNOVAS_FIND_COMPONENTS})
     if(component STREQUAL "calceph")
         if(NOT SuperNOVAS_CALCEPH_FOUND)
             set(SuperNOVAS_FOUND FALSE)
             set(SuperNOVAS_NOT_FOUND_MESSAGE "SuperNOVAS CALCEPH component not available")
+        endif()
+    elseif(component STREQUAL "calceph")
+        if(NOT SuperNOVAS_CSPICE_FOUND)
+            set(SuperNOVAS_FOUND FALSE)
+            set(SuperNOVAS_NOT_FOUND_MESSAGE "SuperNOVAS CSPICE component not available")
         endif()
     else()
         set(SuperNOVAS_FOUND FALSE)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,6 +11,14 @@ if(ENABLE_CALCEPH)
     list(APPEND EXAMPLE_PROGRAMS example-calceph)
 endif()
 
+if(ENABLE_CSPICE)
+    list(APPEND EXAMPLE_PROGRAMS example-cspice)
+endif()
+
+link_directories(${CMAKE_BINARY_DIR}/lib)
+
+set(EPHEM ${PROJECT_SOURCE_DIR}/test/ephem/de440s-j2000.bsp)
+
 # Build each example
 foreach(EXAMPLE ${EXAMPLE_PROGRAMS})
     set(EXAMPLE_SOURCE ${EXAMPLE}.c)
@@ -30,25 +38,21 @@ foreach(EXAMPLE ${EXAMPLE_PROGRAMS})
                 solsys-calceph
                 calceph
             )
-        endif()
-
-        # Set RPATH for the example to find the library
-        if(NOT WIN32)
-            set_target_properties(${EXAMPLE} PROPERTIES
-                INSTALL_RPATH "$ORIGIN/../lib"
-                BUILD_RPATH "${CMAKE_BINARY_DIR}/lib"
+            #add_test(NAME ${EXAMPLE} COMMAND ${EXAMPLE} ${EPHEM})
+            
+        # Special handling for CSPICE example
+        elseif(${EXAMPLE} STREQUAL "example-cspice")
+            target_link_libraries(${EXAMPLE} PRIVATE
+                solsys-cspice
+                cspice
             )
+            #add_test(NAME ${EXAMPLE} COMMAND ${EXAMPLE} ${EPHEM})
+        
+        # All other tests
+        else()
+            add_test(NAME ${EXAMPLE} COMMAND ${EXAMPLE})
         endif()
-
-        # Add a custom target to run this specific example
-        add_custom_target(run-${EXAMPLE}
-            COMMAND ${EXAMPLE}
-            DEPENDS ${EXAMPLE}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            COMMENT "Running ${EXAMPLE}"
-            VERBATIM
-        )
-
+	
         message(STATUS "Added example: ${EXAMPLE}")
     else()
         message(WARNING "Source file ${EXAMPLE_SOURCE} not found - ${EXAMPLE} will not be built")

--- a/examples/example-calceph.c
+++ b/examples/example-calceph.c
@@ -38,7 +38,10 @@
 #define  POLAR_DX         230.0     ///< [mas] Earth polar offset x, e.g. from IERS Bulletin A.
 #define  POLAR_DY         -62.0     ///< [mas] Earth polar offset y, e.g. from IERS Bulletin A.
 
-int main() {
+int main(int argc, char *argv[]) {
+  // Program Options -------------------------------------------------------->
+  char *datafile = "/path/to/de440s.bsp";  // Ephemeris file to use
+
   // SuperNOVAS variables used for the calculations ------------------------->
   object source;                    // observed source
   observer obs;                     // observer location
@@ -54,6 +57,9 @@ int main() {
   t_calcephbin *de440;              // CALCEPH ephemeris binary
   struct timespec unix_time;        // Standard precision UNIX time structure
 
+  // Command line argument can define the ephemeris data to use.
+  if(argc > 1)
+    datafile = argv[1];
 
   // We'll print debugging messages and error traces...
   novas_debug(NOVAS_DEBUG_ON);
@@ -63,7 +69,7 @@ int main() {
 
   // First open one or more ephemeris files with CALCEPH to use
   // E.g. the DE440 (short-term) ephemeris data from JPL.
-  de440 = calceph_open("path/to/de440s.bsp");
+  de440 = calceph_open(datafile);
   if(!de440) {
     fprintf(stderr, "ERROR! could not open ephemeris data\n");
     return 1;

--- a/examples/example-cspice.c
+++ b/examples/example-cspice.c
@@ -43,7 +43,10 @@
 #define  POLAR_DX         230.0     ///< [mas] Earth polar offset x, e.g. from IERS Bulletin A.
 #define  POLAR_DY         -62.0     ///< [mas] Earth polar offset y, e.g. from IERS Bulletin A.
 
-int main() {
+int main(int argc, char *argv[]) {
+  // Program Options -------------------------------------------------------->
+   char *datafile = "/path/to/de440s.bsp";  // // Ephemeris file to use
+
   // SuperNOVAS variables used for the calculations ------------------------->
   object source;                    // observed source
   observer obs;                     // observer location
@@ -58,6 +61,9 @@ int main() {
   // Intermediate variables we'll use -------------------------------------->
   struct timespec unix_time;        // Standard precision UNIX time structure
 
+  // Command line argument can define the path where the ephemeris data is
+  if(argc > 1)
+    datafile = argv[1];
 
   // We'll print debugging messages and error traces...
   novas_debug(NOVAS_DEBUG_ON);
@@ -68,7 +74,7 @@ int main() {
 
   // Open one or more ephemeris files to use...'
   // E.g. the DE440 (short-term) ephemeris data from JPL.
-  if(cspice_add_kernel("path/to/de440s.bsp") != 0) {
+  if(cspice_add_kernel(datafile) != 0) {
     fprintf(stderr, "ERROR! could not open ephemeris data\n");
     return 1;
   }

--- a/include/novas.h
+++ b/include/novas.h
@@ -738,7 +738,7 @@ enum novas_cio_location_type {
 /// Path / name of file to use for interpolating the CIO location relative to GCRS
 /// This file can be generated with the <code>cio_file.c</code> tool using the
 /// <code>CIO_RA.TXT</code> data (both are included in the distribution)
-#    define DEFAULT_CIO_LOCATOR_FILE      "/usr/share/supernovas/cio_ra.bin"
+#    define DEFAULT_CIO_LOCATOR_FILE      "/usr/share/supernovas/CIO_RA.TXT"
 #  endif
 #endif
 

--- a/src/cio.c
+++ b/src/cio.c
@@ -97,7 +97,7 @@ int set_cio_locator_file(const char *restrict filename) {
   if(old)
     fclose(old);
 
-  return cio_file ? 0 : novas_error(-1, errno, "set_cio_locator_file", "File could not be opened");
+  return cio_file ? 0 : novas_error(-1, errno, "set_cio_locator_file", "%s: %s", filename, strerror(errno));
 }
 
 /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,75 @@
+
+# List of example programs to build
+set(TEST_PROGRAMS
+    test-compat
+    test-super
+    test-errors
+)
+
+if(ENABLE_CALCEPH)
+    list(APPEND TEST_PROGRAMS test-calceph)
+endif()
+
+if(ENABLE_CSPICE)
+    list(APPEND TEST_PROGRAMS test-cspice)
+endif()
+
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/data)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+link_directories(${CMAKE_BINARY_DIR}/lib)
+
+add_executable(cio_file ${PROJECT_SOURCE_DIR}/src/cio_file.c)
+
+add_custom_target(cio_bin_data
+    DEPENDS cio_file
+    COMMAND cio_file ${PROJECT_SOURCE_DIR}/data/CIO_RA.TXT ${PROJECT_SOURCE_DIR}/data/cio_ra.bin
+)
+
+set(EPHEM_DIR ${PROJECT_SOURCE_DIR}/test/ephem)
+set(CIO_DIR ${PROJECT_SOURCE_DIR}/data)
+
+# Build each example
+foreach(TEST ${TEST_PROGRAMS})
+    set(TEST_SOURCE src/${TEST}.c)
+
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${TEST_SOURCE})
+        add_executable(${TEST} ${TEST_SOURCE})
+        add_dependencies(${TEST} cio_bin_data)
+              
+        target_include_directories(${TEST} PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+        )
+        
+        # Link against the supernovas library
+        target_link_libraries(${TEST} PRIVATE
+            supernovas
+            $<$<BOOL:${HAVE_LIBM}>:m>
+        )
+
+        # Special handling for CALCEPH example
+        if(${TEST} STREQUAL "test-calceph")
+            target_link_libraries(${TEST} PRIVATE
+                solsys-calceph
+                calceph
+            )
+     	    add_test(NAME ${TEST} COMMAND ${TEST} ${EPHEM_DIR})
+     	    
+        # Special handling for CSPICE example
+        elseif(${TEST} STREQUAL "test-cspice")
+            target_link_libraries(${TEST} PRIVATE
+                solsys-cspice
+                cspice
+            )
+            add_test(NAME ${TEST} COMMAND ${TEST} ${EPHEM_DIR})
+        
+        # All other examples
+     	else()
+     	    add_test(NAME ${TEST} COMMAND ${TEST} ${CIO_DIR})
+        endif()
+        
+        message(STATUS "Added test: ${TEST}")
+    else()
+        message(WARNING "Source file ${TEST_SOURCE} not found - ${TEST} will not be built")
+    endif()
+endforeach()

--- a/test/Makefile
+++ b/test/Makefile
@@ -19,7 +19,7 @@ CHECKOPTS = --enable=performance,warning,portability --language=c \
 OBJECTS := $(subst $(OBJ)/,,$(OBJECTS))
 COVFILES := $(subst .o,.c.gcov,$(OBJECTS))
 
-TESTS := test-compat test-cio_file test-super test-errors
+TESTS := test-compat test-cio_file test-cio-data test-super test-errors
 
 ifeq ($(CALCEPH_SUPPORT), 1)
   LDFLAGS += -lcalceph
@@ -35,15 +35,24 @@ ifeq ($(CSPICE_SUPPORT), 1)
   COVFILES += solsys-cspice.c.gcov
 endif
 
-.PHONY: run
-run: clean-cov clean-data $(TESTS) data ../cio_ra.bin bad-data
-	./test-compat
-	ln -s ../cio_ra.bin
-	./test-cio_file
-	sed -i.tmp "s:-nan: nan:g" data/* && rm -f data/*.tmp
+.PHONY: check-compat
+check-compat:
+	@sed -i.tmp "s:-nan: nan:g" data/* && rm -f data/*.tmp
 	diff data reference
-	./test-super
-	rm -f cio_ra.bin
+
+.PHONY: check-cio_file
+check-cio_file: 
+	@ln -s ../data/cio_ra.bin
+	./test-cio_file
+	@rm -f cio_ra.bin
+
+.PHONY: run
+run: clean-cov clean-data $(TESTS) data bad-data
+	./test-compat
+	$(MAKE) check-cio_file
+	$(MAKE) check-compat
+	./test-cio-data
+	./test-super ../data
 	./test-errors
 ifeq ($(CALCEPH_SUPPORT), 1)
 	./test-calceph ephem
@@ -68,10 +77,10 @@ data:
 	mkdir data
 
 .PHONY: bad-data
-bad-data: ../cio_ra.bin bad-cio-data
+bad-data: ../data/cio_ra.bin bad-cio-data
 	@touch bad-cio-data/empty
-	@dd status=none if=../cio_ra.bin of=bad-cio-data/bad-1.bin bs=27 count=1
-	@dd status=none if=../cio_ra.bin of=bad-cio-data/bad-2.bin bs=63 count=1
+	@dd status=none if=../data/cio_ra.bin of=bad-cio-data/bad-1.bin bs=27 count=1
+	@dd status=none if=../data/cio_ra.bin of=bad-cio-data/bad-2.bin bs=63 count=1
 	@dd status=none if=../data/CIO_RA.TXT of=bad-cio-data/bad-1.txt bs=14 count=1
 	@dd status=none if=../data/CIO_RA.TXT of=bad-cio-data/bad-2.txt bs=79 count=1
 	@dd status=none if=../data/CIO_RA.TXT of=bad-cio-data/bad-3.txt bs=21 count=1

--- a/test/src/test-cio-data.c
+++ b/test/src/test-cio-data.c
@@ -1,0 +1,56 @@
+/**
+ * @file
+ *
+ * @date Created  on Sep 4, 2025
+ * @author Attila Kovacs
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <math.h>
+#include <string.h>
+
+#define __NOVAS_INTERNAL_API__      ///< Use definitions meant for internal use by SuperNOVAS only
+#include "novas.h"
+
+static int check(const char *func, int exp, int error) {
+  if(error != exp) {
+    fprintf(stderr, "ERROR! %s: expected %d, got %d\n", func, exp, error);
+    return 1;
+  }
+  return 0;
+}
+
+int main() {
+  ra_of_cio x[5];
+  int n = 0;
+
+  set_cio_locator_file("bad-cio-data/empty");
+  if(check("cio_array:bin:empty", 1, cio_array(2341952.6, 5, x))) n++;
+
+  set_cio_locator_file("bad-cio-data/bad-1.bin");
+  if(check("cio_array:bin:header", -1, cio_array(2341952.6, 2, x))) n++;
+
+  set_cio_locator_file("bad-cio-data/bad-2.bin");
+  if(check("cio_array:bin:incomplete", 6, cio_array(2341951.4, 2, x))) n++;
+  if(check("cio_array:bin:seek", -1, cio_array(2341965.4, 2, x))) n++;
+
+  set_cio_locator_file("bad-cio-data/bad-1.txt");
+  if(check("cio_array:ascii:header", -1, cio_array(2341952.6, 2, x))) n++;
+
+  set_cio_locator_file("bad-cio-data/bad-2.txt");
+  if(check("cio_array:ascii:incomplete", 6, cio_array(2341951.4, 2, x))) n++;
+  if(check("cio_array:ascii:seek", 2, cio_array(2341965.4, 2, x))) n++;
+
+  set_cio_locator_file("bad-cio-data/bad-3.txt");
+  if(check("cio_array:ascii:no-data", 1, cio_array(2341952.6, 2, x))) n++;
+
+  set_cio_locator_file("bad-cio-data/bad-4.txt");
+  if(check("cio_array:ascii:corrupt:first", -1, cio_array(2341952.6, 2, x))) n++;
+
+  set_cio_locator_file("bad-cio-data/bad-5.txt");
+  if(check("cio_array:ascii:corrupt", -1, cio_array(2341952.6, 2, x))) n++;
+
+  return n;
+}

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -20,7 +20,7 @@
 #define J2000   NOVAS_JD_J2000
 
 
-static char *workPath;
+static char *dataPath;
 
 static observer obs;
 static object source;
@@ -2008,6 +2008,10 @@ static int test_dxdy_to_dpsideps() {
 static int test_cio_location() {
   double loc, loc1;
   short type;
+  char path[1024] = {'\0'};
+
+  sprintf(path, "%s/CIO_RA.TXT", dataPath);
+  if(!is_ok("cio_location:set_path", set_cio_locator_file(path))) return 1;
 
   if(!is_ok("cio_location", cio_location(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, &loc, &type))) return 1;
   if(!is_ok("cio_location:repeat", cio_location(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, &loc1, &type))) return 1;
@@ -2031,7 +2035,7 @@ static int test_cio_array() {
 
   memset(data, 0, sizeof(data));
 
-  sprintf(path, "%s/../data/CIO_RA.TXT", workPath);
+  sprintf(path, "%s/CIO_RA.TXT", dataPath);
 
   if(!is_ok("cio_array:ascii:set_cio_locator_file", set_cio_locator_file(path))) return 1;
   if(!is_ok("cio_array:ascii", cio_array(NOVAS_JD_J2000, 10, data))) return 1;
@@ -2039,7 +2043,7 @@ static int test_cio_array() {
   if(!is_ok("cio_array:ascii:check:first", data[0].ra_cio == 0.0)) return 1;
   if(!is_ok("cio_array:ascii:check:last", data[9].ra_cio == 0.0)) return 1;
 
-  sprintf(path, "%s/../cio_ra.bin", workPath);
+  sprintf(path, "%s/cio_ra.bin", dataPath);
 
   if(!is_ok("cio_array:bin:set_cio_locator_file", set_cio_locator_file(path))) return 1;
   if(!is_ok("cio_array:bin", cio_array(NOVAS_JD_J2000, 10, data))) return 1;
@@ -4441,8 +4445,8 @@ static int test_clock_skew() {
 int main(int argc, char *argv[]) {
   int n = 0;
 
-  (void) argc;
-  workPath = dirname(argv[0]);
+  if(argc > 1)
+  dataPath = argv[1];
 
   novas_debug(NOVAS_DEBUG_ON);
   enable_earth_sun_hp(1);


### PR DESCRIPTION
- Fixes to CMake config (e.g. no `RPATH`)
- Added `BUILD_TESTING=ON|OFF` (default: ON)
- Added `BUILD_BENCHMARK=ON|OFF` (default: OFF)
- Added `BUILD_DOC=ON|OFF` (default: OFF)
- Added `ENABLE_CSPICE=ON|OFF` (default: OFF) -- needs `cspice` library installed.
- Examples are added to the testing suite if `BUILD_EXAMPLES` is ON
- Remove requirement on `Threads` -- nothing in SuperNOVAS should need thread libs.