### PR TITLE
Non-UNIX builds / functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [1.5.0-rc2] - 2025-09-03
+## [Unrelease]
 
 Upcoming feature release, expected around 1 November 2025.
 
@@ -35,8 +35,8 @@ Upcoming feature release, expected around 1 November 2025.
  - #221: Now supporting Mac OS X builds, which are different from standard UNIX build, via GNU `make` also (by 
    kiranshila and attipaci).
    
- - #222: CMake build support, including Mac OS and Windows builds (by kiranshila), with further tweaks in #228 (
-   (by attipaci).
+ - #222: CMake build support, including Mac OS and Windows builds (by kiranshila), with further tweaks in #228, 
+   #229, #230 (by attipaci).
 
  - #223: New functions `novas_clock_skew_tt()`, `novas_clock_skew_tcg()`, and `novas_clock_skew_tcb()` to calculate
    the incremental rate at which an observer's clock ticks faster than a TT, TCG, or TCB clock respectively would. 
@@ -67,6 +67,12 @@ Upcoming feature release, expected around 1 November 2025.
  - #222: GitHub Actions CI now checks CMake build, also for Linux, Mac OS X, FreeBSD, and Windows. (by kiranshila)
  
  - #225: GNU `Makefile` fixes for non-Linux builds, and FreeBSD build check in GitHub Actions CI.
+ 
+ - #231: source code (including tests and examples) to use platform-dependent file separator for improved portability
+   to Windows.
+ 
+ - #231: Changed documentation build to wean off the likes of `sed` or `tail`, thus allowing to build documentation in 
+   a more platform-independent way.
  
  - Various API documentation edits.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,12 +146,15 @@ set_target_properties(supernovas PROPERTIES
     CLEAN_DIRECT_OUTPUT ON
 )
 
-target_include_directories(supernovas
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/src
+target_include_directories(supernovas PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/eop
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/nutation
+)
+
+target_include_directories(supernovas PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 target_compile_definitions(supernovas PRIVATE ${SUPERNOVAS_COMPILE_DEFINITIONS})
@@ -248,35 +251,24 @@ endif()
 if(BUILD_DOC) 
     find_package(Doxygen)
 
-    set(README ${PROJECT_SOURCE_DIR}/README.md)
-    set(DOXYFILE ${PROJECT_SOURCE_DIR}/Doxyfile)
-
     if(Doxygen_FOUND)
-        # Strip head from README.md, and from generate html docs
-        # This is a bit ugly as it requires UNIX shell, sed, tail...
-        add_custom_target(prep_docs
-            VERBATIM
-            COMMAND echo "LINE=`sed -n '/\# /{=;q;}' ${README}` && tail -n +$((LINE+2)) ${README}" > tmp.sh
-            COMMAND bash tmp.sh > ${PROJECT_SOURCE_DIR}/README-orig.md && rm -f tmp.sh
-            COMMAND sed s:resources/header.html::g ${DOXYFILE} > Doxyfile.headless
-            COMMAND sed s:apidoc:${CMAKE_CURRENT_BINARY_DIR}:g Doxyfile.headless > Doxyfile.local && rm -f Doxyfile.headless
-        )
-
+        add_executable(docedit EXCLUDE_FROM_ALL src/docedit.c)
+   
         # Run Doxygen
         add_custom_target(project_docs 
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-            COMMAND Doxygen::doxygen ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile.local
+            COMMAND docedit
+            COMMAND Doxygen::doxygen Doxyfile.local
         )
+        
+        add_custom_target(clean_docs)
+        
+        if(TARGET clean_docs)
+           file(REMOVE Doxyfile.local README-orig.md)
+        endif()
 
-        # Clean up temporary generated files in source directory
-        add_custom_target(cleanup_docs
-            VERBATIM
-            COMMAND rm -f ${PROJECT_SOURCE_DIR}/README-orig.md
-        )
-    
-        add_dependencies(cleanup_docs project_docs)
-        add_dependencies(project_docs prep_docs)
-        add_dependencies(supernovas cleanup_docs)
+        add_dependencies(supernovas clean_docs)
+        add_dependencies(clean_docs project_docs)
     endif()
 endif()
 
@@ -307,7 +299,6 @@ install(TARGETS ${INSTALL_TARGETS}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 # ------------------------------------------------------------------------
@@ -320,11 +311,24 @@ install(FILES data/CIO_RA.TXT
 # ------------------------------------------------------------------------
 # Install files for the Development component
 
-install(DIRECTORY include/
+install(FILES include/novas.h include/nutation.h include/solarsystem.h
     COMPONENT Development
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    FILES_MATCHING PATTERN "*.h"
 )
+
+if(ENABLE_CALCEPH)
+   install(FILES include/novas-calceph.h
+       COMPONENT Development
+       DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+   )
+endif()
+
+if(ENABLE_CSPICE)
+   install(FILES include/novas-cspice.h
+       COMPONENT Development
+       DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+   )
+endif()
 
 install(EXPORT SuperNOVASTargets
     COMPONENT Development

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -24,7 +24,7 @@ foreach(EXAMPLE ${EXAMPLE_PROGRAMS})
     set(EXAMPLE_SOURCE ${EXAMPLE}.c)
 
     if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${EXAMPLE_SOURCE})
-        add_executable(${EXAMPLE} ${EXAMPLE_SOURCE})
+        add_executable(${EXAMPLE} EXCLUDE_FROM_ALL ${EXAMPLE_SOURCE})
 
         # Link against the supernovas library
         target_link_libraries(${EXAMPLE} PRIVATE

--- a/src/docedit.c
+++ b/src/docedit.c
@@ -1,0 +1,100 @@
+/**
+ * @date Created  on Sep 5, 2025
+ * @author Attila Kovacs
+ *
+ *   Creates headless Doxyfile.local and README-orig.md variants
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#define DOXYGEN_STRING    "resources/header.html"
+
+#if defined _WIN32 || defined __CYGWIN__
+#  define PATH_SEP  "\\"
+#else
+#  define PATH_SEP  "/"
+#endif
+
+static const char *path = ".";
+
+static FILE *openfile(const char *name, const char *mode) {
+  char filename[1024] = {'\0'};
+  FILE *fp;
+
+  snprintf(filename, sizeof(filename), "%s" PATH_SEP "%s", path, name);
+  fp = fopen(filename, mode);
+  if(!fp) fprintf(stderr, "ERROR! opening %s: %s", filename, strerror(errno));
+  return fp;
+}
+
+static int make_local_doxyfile() {
+  FILE *in, *out;
+  char line[16384] = {'\0'};
+
+  in = openfile("Doxyfile", "r");
+  if(!in) return -1;
+
+  out = openfile("Doxyfile.local", "w");
+  if(!out) {
+    fclose(in);
+    return -1;
+  }
+
+  while(fgets(line, sizeof(line) - 1, in) != NULL) {
+    char *match = strstr(line, DOXYGEN_STRING);
+    if(match) {
+      memset(match, ' ', sizeof(DOXYGEN_STRING) - 1);
+    }
+
+    fwrite(line, strlen(line), 1, out);
+  }
+
+  fclose(out);
+  fclose(in);
+
+  return 0;
+}
+
+static int make_headless_readme() {
+  FILE *in, *out;
+  char line[16384] = {'\0'};
+  int head = 1;
+
+  in = openfile("README.md", "r");
+  if(!in) return -1;
+
+  out = openfile("README-orig.md", "w");
+  if(!out) {
+    fclose(in);
+    return -1;
+  }
+
+  while(fgets(line, sizeof(line) - 1, in) != NULL) {
+    if(head) {
+      if(line[0] != '#') continue;
+      head = 0;
+    }
+    fwrite(line, strlen(line), 1, out);
+  }
+
+  fclose(out);
+  fclose(in);
+
+  return 0;
+}
+
+// Syntax: docedit [path]
+int main(int argc, const char *argv[]) {
+  int nerr = 0;
+
+  if(argc > 1)
+    path = argv[1];
+
+  if(make_local_doxyfile() != 0) nerr++;
+  if(make_headless_readme() != 0) nerr++;
+
+  return nerr;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,7 +34,7 @@ foreach(TEST ${TEST_PROGRAMS})
     set(TEST_SOURCE src/${TEST}.c)
 
     if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${TEST_SOURCE})
-        add_executable(${TEST} ${TEST_SOURCE})
+        add_executable(${TEST} EXCLUDE_FROM_ALL ${TEST_SOURCE})
         add_dependencies(${TEST} cio_bin_data)
               
         target_include_directories(${TEST} PRIVATE

--- a/test/src/test-calceph.c
+++ b/test/src/test-calceph.c
@@ -20,6 +20,12 @@
 #define PLANET_EPH                  "de440s-j2000.bsp"
 #define MARS_EPH                    "mar097-j2000.bsp"
 
+#if defined _WIN32 || defined __CYGWIN__
+#  define PATH_SEP  "\\"
+#else
+#  define PATH_SEP  "/"
+#endif
+
 static const char *prefix;
 
 static int usage() {
@@ -68,7 +74,7 @@ static int test_calceph() {
   object earth = NOVAS_EARTH_INIT, mars = NOVAS_MARS_INIT;
   t_calcephbin *eph;
 
-  sprintf(filename, "%s/" PLANET_EPH, prefix);
+  sprintf(filename, "%s" PATH_SEP PLANET_EPH, prefix);
   eph = calceph_open(filename);
 
   if(check("calceph:use", 0, novas_use_calceph(eph))) return 1;
@@ -100,11 +106,11 @@ static int test_calceph_planet() {
   make_planet(NOVAS_MARS, &mars);
   make_ephem_object("Phobos", 401, &phobos);
 
-  sprintf(filename, "%s/" MARS_EPH, prefix);
+  sprintf(filename, "%s" PATH_SEP MARS_EPH, prefix);
   eph = calceph_open(filename);
   if(check("calceph_planet:use", 0, novas_use_calceph(eph))) return 1;
 
-  sprintf(filename, "%s/" PLANET_EPH, prefix);
+  sprintf(filename, "%s" PATH_SEP PLANET_EPH, prefix);
   eph = calceph_open(filename);
   if(check("calceph_planet:use_planets", 0, novas_use_calceph_planets(eph))) return 1;
 
@@ -224,7 +230,7 @@ static int test_calceph_use_ids() {
   t_calcephbin *eph;
   enum novas_origin origin = NOVAS_BARYCENTER;
 
-  sprintf(filename, "%s/" PLANET_EPH, prefix);
+  sprintf(filename, "%s" PATH_SEP PLANET_EPH, prefix);
   eph = calceph_open(filename);
   if(novas_use_calceph(eph)) return 1;
 

--- a/test/src/test-cio_file.c
+++ b/test/src/test-cio_file.c
@@ -11,6 +11,12 @@
 
 #include "novas.h"
 
+#if defined _WIN32 || defined __CYGWIN__
+#  define PATH_SEP  "\\"
+#else
+#  define PATH_SEP  "/"
+#endif
+
 #define J2000   2451545.0
 
 static double tdb = J2000;
@@ -21,7 +27,7 @@ static void openfile(const char *name) {
   char filename[100] = {'\0'};
 
   //if(idx >= 0) sprintf(filename, "data/%02d-%s.out", idx++, name);
-  sprintf(filename, "data/%s.out", name);
+  sprintf(filename, "data" PATH_SEP "%s.out", name);
 
   if(fp) {
     fprintf(fp, "\n");

--- a/test/src/test-compat.c
+++ b/test/src/test-compat.c
@@ -11,6 +11,12 @@
 
 #include "novas.h"
 
+#if defined _WIN32 || defined __CYGWIN__
+#  define PATH_SEP  "\\"
+#else
+#  define PATH_SEP  "/"
+#endif
+
 #define DEGREE  (M_PI / 180.0)
 #define ARCSEC  (DEGREE / 3600.0)
 #define HOURANGLE (M_PI / 12.0)
@@ -54,7 +60,7 @@ static void openfile(const char *name) {
   char filename[100] = {'\0'};
 
   //if(idx >= 0) sprintf(filename, "data/%02d-%s.out", idx++, name);
-  sprintf(filename, "data/%s.out", name);
+  sprintf(filename, "data" PATH_SEP "%s.out", name);
 
   if(fp) {
     fprintf(fp, "\n");

--- a/test/src/test-cspice.c
+++ b/test/src/test-cspice.c
@@ -16,8 +16,15 @@
 #include "novas.h"
 #include "novas-cspice.h"
 
+#if defined _WIN32 || defined __CYGWIN__
+#  define PATH_SEP  "\\"
+#else
+#  define PATH_SEP  "/"
+#endif
+
 #define PLANET_EPH                  "de440s-j2000.bsp"
 #define MARS_EPH                    "mar097-j2000.bsp"
+
 
 static const char *prefix;
 
@@ -168,14 +175,14 @@ static int test_errors() {
 static int load_eph(const char *name) {
   char filename[1024];
 
-  sprintf(filename, "%s/%s", prefix, name);
+  sprintf(filename, "%s" PATH_SEP "%s", prefix, name);
   return cspice_add_kernel(filename);
 }
 
 static int unload_eph(const char *name) {
   char filename[1024];
 
-  sprintf(filename, "%s/%s", prefix, name);
+  sprintf(filename, "%s" PATH_SEP "%s", prefix, name);
   return cspice_remove_kernel(filename);
 }
 

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -13,6 +13,12 @@
 #define __NOVAS_INTERNAL_API__      ///< Use definitions meant for internal use by SuperNOVAS only
 #include "novas.h"
 
+#if defined _WIN32 || defined __CYGWIN__
+#  define PATH_SEP  "\\"
+#else
+#  define PATH_SEP  "/"
+#endif
+
 static char *dataPath = "../data";
 
 static int dummy_ephem(const char *name, long id, double jd_tdb_high, double jd_tdb_low, enum novas_origin *origin, double *pos, double *vel) {
@@ -885,7 +891,7 @@ static int test_cio_array() {
   if(check("cio_array:blah", -1, set_cio_locator_file("blah"))) n++;
   if(check("cio_array:file", 1, cio_array(0.0, 5, x))) n++;
 
-  sprintf(path, "%s/CIO_RA.TXT", dataPath);
+  sprintf(path, "%s" PATH_SEP "CIO_RA.TXT", dataPath);
   if(check("cio_array:bin", 0, set_cio_locator_file(path))) n++;
   if(check("cio_array:bin:reopen", 0, set_cio_locator_file(path))) n++; // Test reopen also...
 

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -19,6 +19,11 @@
 
 #define J2000   NOVAS_JD_J2000
 
+#if defined _WIN32 || defined __CYGWIN__
+#  define PATH_SEP  "\\"
+#else
+#  define PATH_SEP  "/"
+#endif
 
 static char *dataPath;
 
@@ -2010,7 +2015,7 @@ static int test_cio_location() {
   short type;
   char path[1024] = {'\0'};
 
-  sprintf(path, "%s/CIO_RA.TXT", dataPath);
+  sprintf(path, "%s" PATH_SEP "CIO_RA.TXT", dataPath);
   if(!is_ok("cio_location:set_path", set_cio_locator_file(path))) return 1;
 
   if(!is_ok("cio_location", cio_location(NOVAS_JD_J2000, NOVAS_FULL_ACCURACY, &loc, &type))) return 1;
@@ -2035,7 +2040,7 @@ static int test_cio_array() {
 
   memset(data, 0, sizeof(data));
 
-  sprintf(path, "%s/CIO_RA.TXT", dataPath);
+  sprintf(path, "%s" PATH_SEP "CIO_RA.TXT", dataPath);
 
   if(!is_ok("cio_array:ascii:set_cio_locator_file", set_cio_locator_file(path))) return 1;
   if(!is_ok("cio_array:ascii", cio_array(NOVAS_JD_J2000, 10, data))) return 1;
@@ -2043,7 +2048,7 @@ static int test_cio_array() {
   if(!is_ok("cio_array:ascii:check:first", data[0].ra_cio == 0.0)) return 1;
   if(!is_ok("cio_array:ascii:check:last", data[9].ra_cio == 0.0)) return 1;
 
-  sprintf(path, "%s/cio_ra.bin", dataPath);
+  sprintf(path, "%s" PATH_SEP "cio_ra.bin", dataPath);
 
   if(!is_ok("cio_array:bin:set_cio_locator_file", set_cio_locator_file(path))) return 1;
   if(!is_ok("cio_array:bin", cio_array(NOVAS_JD_J2000, 10, data))) return 1;


### PR DESCRIPTION
- Build without `sed`, `bash`, or `tail`...
- Source with platform-dependent path separator (`\` on Windows vs '/' on everything else). 

Also:
- select install of include files, depending on build options (not whole directory)