### PR TITLE
Consolidate `novas_clock_skew()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,8 @@ Upcoming feature release, expected around 1 November 2025.
  - #222: CMake build support, including Mac OS and Windows builds (by kiranshila), with further tweaks in #228, 
    #229, #230 (by attipaci).
 
- - #223: New functions `novas_clock_skew_tt()`, `novas_clock_skew_tcg()`, and `novas_clock_skew_tcb()` to calculate
-   the incremental rate at which an observer's clock ticks faster than a TT, TCG, or TCB clock respectively would. 
+ - #223: New function `novas_clock_skew()` to calculate the incremental rate at which an observer's clock ticks faster 
+   than an astronomical timescale. All timescales, except UT1, are supported (see also #232). 
 
 ### Changed
 

--- a/include/novas.h
+++ b/include/novas.h
@@ -2232,11 +2232,8 @@ int novas_geodetic_to_cartesian(double lon, double lat, double alt, enum novas_r
 
 int novas_cartesian_to_geodetic(const double *restrict x, enum novas_reference_ellipsoid ellipsoid, double *restrict lon, double *restrict lat, double *restrict alt);
 
-double novas_clock_skew_tt(const novas_frame *frame);
+double novas_clock_skew(const novas_frame *frame, enum novas_timescale timescale);
 
-double novas_clock_skew_tcg(const novas_frame *frame);
-
-double novas_clock_skew_tcb(const novas_frame *frame);
 
 
 // <================= END of SuperNOVAS API =====================>

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -2379,20 +2379,19 @@ static int test_clock_skew() {
   novas_timespec time = {};
   novas_frame frame = {};
 
-  if(check_nan("clock_skew_tcg:frame", novas_clock_skew_tcg(NULL))) n++;
-  if(check_nan("clock_skew_tcb:frame", novas_clock_skew_tcb(NULL))) n++;
-  if(check_nan("clock_skew_tt:frame", novas_clock_skew_tt(NULL))) n++;
-
-  if(check_nan("clock_skew_tcg:frame:init", novas_clock_skew_tcg(&frame))) n++;
-  if(check_nan("clock_skew_tcb:frame:init", novas_clock_skew_tcb(&frame))) n++;
-  if(check_nan("clock_skew_tt:frame:init", novas_clock_skew_tt(&frame))) n++;
+  if(check_nan("clock_skew:frame", novas_clock_skew(NULL, NOVAS_TCG))) n++;
+  if(check_nan("clock_skew:frame:init", novas_clock_skew(&frame, NOVAS_TCG))) n++;
 
   make_observer_at_geocenter(&obs);
   novas_set_time(NOVAS_TT, NOVAS_JD_J2000, 32.0, 0.0, &time);
 
   enable_earth_sun_hp(1);
   novas_make_frame(NOVAS_FULL_ACCURACY, &obs, &time, 0.0, 0.0, &frame);
-  if(check_nan("clock_skew_tcb:frame", novas_clock_skew_tcb(&frame))) n++;
+
+  if(check_nan("clock_skew:timescale:-1", novas_clock_skew(&frame, -1))) n++;
+  if(check_nan("clock_skew:timescale:UT1", novas_clock_skew(&frame, NOVAS_UT1))) n++;
+
+  if(check_nan("clock_skew:hp:no_planets", novas_clock_skew(&frame, NOVAS_TCG))) n++;
   enable_earth_sun_hp(0);
 
   return n;

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -4416,6 +4416,7 @@ static int test_clock_skew() {
   novas_timespec time = {};
   novas_frame frame = {};
   double pos[3] = { 10000.0, 0.0, 0.0 }, vel[3] = {0.0};
+  double dt1;
 
   const double LB = 1.550519768e-8;
   const double LG = 6.969290134e-10;
@@ -4423,26 +4424,31 @@ static int test_clock_skew() {
   make_observer_at_geocenter(&obs);
   novas_set_time(NOVAS_TT, NOVAS_JD_J2000, 32.0, 0.0, &time);
   if(!is_ok("clock_skew:frame:gc", novas_make_frame(NOVAS_REDUCED_ACCURACY, &obs, &time, 0.0, 0.0, &frame))) n++;
-  if(!is_equal("clock_skew:gc:tcg", 0.0, novas_clock_skew_tcg(&frame), 1e-16)) n++;
-  if(!is_equal("clock_skew:gc:tt", LG, novas_clock_skew_tt(&frame), 1e-16)) n++;
-  if(!is_equal("clock_skew:gc:tcb", LG - LB, novas_clock_skew_tcb(&frame), 3e-2 * LB)) n++;
+  if(!is_equal("clock_skew:gc:tcg", 0.0, novas_clock_skew(&frame, NOVAS_TCG), 1e-16)) n++;
+  if(!is_equal("clock_skew:gc:tt", LG, novas_clock_skew(&frame, NOVAS_TT), 1e-16)) n++;
+  if(!is_equal("clock_skew:gc:tcb", LG - LB, novas_clock_skew(&frame, NOVAS_TCB), 3e-2 * LB)) n++;
+
+  dt1 = (tt2tdb(NOVAS_JD_J2000 + 0.1) - tt2tdb(NOVAS_JD_J2000 - 0.1)) / 0.2;
+  if(!is_equal("clock_skew:gc:tdb", dt1, novas_clock_skew(&frame, NOVAS_TDB) - novas_clock_skew(&frame, NOVAS_TT), 1e-12)) n++;
 
   make_observer_on_surface(0.0, 0.0, 0.0, 0.0, 0.0, &obs);
   if(!is_ok("clock_skew:frame:earth", novas_make_frame(NOVAS_REDUCED_ACCURACY, &obs, &time, 0.0, 0.0, &frame))) n++;
-  if(!is_equal("clock_skew:earth:tcg", -LG, novas_clock_skew_tcg(&frame), 1e-12)) n++;
-  if(!is_equal("clock_skew:earth:tt", 0.0, novas_clock_skew_tt(&frame), 1e-12)) n++;
-  if(!is_equal("clock_skew:earth:tcb", -LB, novas_clock_skew_tcb(&frame), 3e-2 * LB)) n++;
+  if(!is_equal("clock_skew:earth:tcg", -LG, novas_clock_skew(&frame, NOVAS_TCG), 1e-12)) n++;
+  if(!is_equal("clock_skew:earth:tt", 0.0, novas_clock_skew(&frame, NOVAS_TT), 1e-12)) n++;
+  if(!is_equal("clock_skew:earth:tcb", -LB, novas_clock_skew(&frame, NOVAS_TCB), 3e-2 * LB)) n++;
 
   if(!is_ok("clock_skew:obs:far", make_solar_system_observer(pos, vel, &obs))) n++;
   if(!is_ok("clock_skew:frame:far", novas_make_frame(NOVAS_REDUCED_ACCURACY, &obs, &time, 0.0, 0.0, &frame))) n++;
-  if(!is_equal("clock_skew:far:tcb", 0.0, novas_clock_skew_tcb(&frame), 1e-12)) n++;
+  if(!is_equal("clock_skew:far:tcb", 0.0, novas_clock_skew(&frame, NOVAS_TCB), 1e-12)) n++;
 
   vel[0] = 0.9999999 * NOVAS_C;
   make_observer_in_space(pos, vel, &obs);
   if(!is_ok("clock_skew:frame:c", novas_make_frame(NOVAS_REDUCED_ACCURACY, &obs, &time, 0.0, 0.0, &frame))) n++;
-  if(!is_equal("clock_skew:c:tcb", -1.0, novas_clock_skew_tcb(&frame), 1e-3)) n++;
-  if(!is_equal("clock_skew:c:tcg", -1.0, novas_clock_skew_tcg(&frame), 1e-3)) n++;
-  if(!is_equal("clock_skew:c:tt", -1.0, novas_clock_skew_tt(&frame), 1e-3)) n++;
+  if(!is_equal("clock_skew:c:tcb", -1.0, novas_clock_skew(&frame, NOVAS_TCB), 1e-3)) n++;
+  if(!is_equal("clock_skew:c:tcg", -1.0, novas_clock_skew(&frame, NOVAS_TCG), 1e-3)) n++;
+  if(!is_equal("clock_skew:c:tt", -1.0, novas_clock_skew(&frame, NOVAS_TT), 1e-3)) n++;
+
+
 
   return n;
 }


### PR DESCRIPTION
One `novas_clock_skew()` function to rule them all. (It takes a reference timescale argument, hence replacing multiple variants from before.)