### PR TITLE
Mean vs instantaneous clock skews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@ Upcoming feature release, expected around 1 November 2025.
    Sidereal Times for a given UT1 date. The new functions are meant to replace the old NOVAS C `sidereal_time()` with
    a simpler, cleaner interface.
    
- - #215: New functions (e.g. `novas_diurnal_eop()`) to calculate corrections to the Earth orientation parameters 
-   published by IERS, to include the effect of libration and ocean tides. Such corrections are necessary to include 
-   if needing or using ITRS / TIRS coordinates with accuracy below the milli-arcsecond (mas) level.
+ - #215: New functions (`novas_diurnal_eop()`, `novas_duirnal_ocean_tides()` and `novas_diurnal_libration()`) to 
+   calculate corrections to the Earth orientation parameters published by IERS, to include the effect of libration and 
+   ocean tides. Such corrections are necessary to include if needing or using ITRS / TIRS coordinates with accuracy 
+   below the milli-arcsecond (mas) level.
 
  - #217: New functions `novas_itrf_transform()` and `novas_itrf_transform_eop()` to enable transforming gecocentric
    _xyz_ station coordinates, or Earth orientation parameters (EOP), between different ITRF realizations (e.g. 
@@ -35,8 +36,8 @@ Upcoming feature release, expected around 1 November 2025.
  - #221: Now supporting Mac OS X builds, which are different from standard UNIX build, via GNU `make` also (by 
    kiranshila and attipaci).
    
- - #222: CMake build support, including Mac OS and Windows builds (by kiranshila), with further tweaks in #228, 
-   #229, #230 (by attipaci).
+ - #222: CMake build support, supporting e.g for Mac OS X or Windows builds also (by kiranshila), with further tweaks 
+   in #228, #229, #230 (by attipaci).
 
  - #223: New function `novas_clock_skew()` / `novas_mean_clock_skew()` to calculate the instantaneous or averaged
    (for Earth-bound observers) incremental rate, respectively, at which an observer's clock ticks faster than an 
@@ -69,8 +70,8 @@ Upcoming feature release, expected around 1 November 2025.
  
  - #225: GNU `Makefile` fixes for non-Linux builds, and FreeBSD build check in GitHub Actions CI.
  
- - #231: source code (including tests and examples) to use platform-dependent file separator for improved portability
-   to Windows.
+ - #231: The source code (including tests and examples) now uses platform-dependent file separator for improved 
+   portability to Windows.
  
  - #231: Changed documentation build to wean off the likes of `sed` or `tail`, thus allowing to build documentation in 
    a more platform-independent way.
@@ -79,16 +80,16 @@ Upcoming feature release, expected around 1 November 2025.
 
 ### Deprecated
 
- - #208: Deprecated `cio_location()`. Going forward, SuperNOVAS no longer uses the CIO locator data files (`CIO_RA.TXT`
-   or `cio_ra.bin`) internally, and so `cio_location()` becomes redundant with `cio_ra()` and also `ira_equinox()` (which
-   returns the negative of the same value).
+ - #208: Deprecated `cio_location()`. Going forward, SuperNOVAS no longer uses the CIO locator data files 
+   (`CIO_RA.TXT` or `cio_ra.bin`) internally, and so `cio_location()` becomes redundant with `cio_ra()` and also 
+   `ira_equinox()` (which returns the negative of the same value).
 
- - #209: Deprecated `sidereal_time()`. It is messy and one of its arguments (`erot`) is now a dud. Instead, you should
-   use `novas_gmst()` or `novas_gast()` to get the same results simpler.
+ - #209: Deprecated `sidereal_time()`. It is messy and one of its arguments (`erot`) is now unused. Instead, you 
+   should use `novas_gmst()` or `novas_gast()` to get the same results simpler.
 
  - #214: Deprecated `cio_basis()`. It is no longer used internally by the library, and users are recommended against 
-   using it themselves, since SuperNOVAS provides cleaner ways to convert between GCRS and CIRS using frames and transforms, 
-   or else via the `gcrs_to_cirs()` / `cirs_to_gcrs()` functions.
+   using it themselves, since SuperNOVAS provides cleaner ways to convert between GCRS and CIRS using frames and 
+   transforms, or else via the `gcrs_to_cirs()` / `cirs_to_gcrs()` functions.
    
    
 ## [1.4.2] - 2025-08-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,9 @@ Upcoming feature release, expected around 1 November 2025.
  - #222: CMake build support, including Mac OS and Windows builds (by kiranshila), with further tweaks in #228, 
    #229, #230 (by attipaci).
 
- - #223: New function `novas_clock_skew()` to calculate the incremental rate at which an observer's clock ticks faster 
-   than an astronomical timescale. All timescales, except UT1, are supported (see also #232). 
+ - #223: New function `novas_clock_skew()` / `novas_mean_clock_skew()` to calculate the instantaneous or averaged
+   (for Earth-bound observers) incremental rate, respectively, at which an observer's clock ticks faster than an 
+   astronomical timescale. All timescales, except UT1, are supported (see also #232 and #233). 
 
 ### Changed
 

--- a/include/novas.h
+++ b/include/novas.h
@@ -2234,6 +2234,7 @@ int novas_cartesian_to_geodetic(const double *restrict x, enum novas_reference_e
 
 double novas_clock_skew(const novas_frame *frame, enum novas_timescale timescale);
 
+double novas_mean_clock_skew(const novas_frame *frame, enum novas_timescale timescale);
 
 
 // <================= END of SuperNOVAS API =====================>

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -2379,8 +2379,8 @@ static int test_clock_skew() {
   novas_timespec time = {};
   novas_frame frame = {};
 
-  if(check_nan("clock_skew:frame", novas_clock_skew(NULL, NOVAS_TCG))) n++;
-  if(check_nan("clock_skew:frame:init", novas_clock_skew(&frame, NOVAS_TCG))) n++;
+  if(check_nan("clock_skew:frame", novas_mean_clock_skew(NULL, NOVAS_TCG))) n++;
+  if(check_nan("clock_skew:frame:init", novas_mean_clock_skew(&frame, NOVAS_TCG))) n++;
 
   make_observer_at_geocenter(&obs);
   novas_set_time(NOVAS_TT, NOVAS_JD_J2000, 32.0, 0.0, &time);
@@ -2388,10 +2388,10 @@ static int test_clock_skew() {
   enable_earth_sun_hp(1);
   novas_make_frame(NOVAS_FULL_ACCURACY, &obs, &time, 0.0, 0.0, &frame);
 
-  if(check_nan("clock_skew:timescale:-1", novas_clock_skew(&frame, -1))) n++;
-  if(check_nan("clock_skew:timescale:UT1", novas_clock_skew(&frame, NOVAS_UT1))) n++;
+  if(check_nan("clock_skew:timescale:-1", novas_mean_clock_skew(&frame, -1))) n++;
+  if(check_nan("clock_skew:timescale:UT1", novas_mean_clock_skew(&frame, NOVAS_UT1))) n++;
 
-  if(check_nan("clock_skew:hp:no_planets", novas_clock_skew(&frame, NOVAS_TCG))) n++;
+  if(check_nan("clock_skew:hp:no_planets", novas_mean_clock_skew(&frame, NOVAS_TCG))) n++;
   enable_earth_sun_hp(0);
 
   return n;

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -4424,31 +4424,29 @@ static int test_clock_skew() {
   make_observer_at_geocenter(&obs);
   novas_set_time(NOVAS_TT, NOVAS_JD_J2000, 32.0, 0.0, &time);
   if(!is_ok("clock_skew:frame:gc", novas_make_frame(NOVAS_REDUCED_ACCURACY, &obs, &time, 0.0, 0.0, &frame))) n++;
-  if(!is_equal("clock_skew:gc:tcg", 0.0, novas_clock_skew(&frame, NOVAS_TCG), 1e-16)) n++;
-  if(!is_equal("clock_skew:gc:tt", LG, novas_clock_skew(&frame, NOVAS_TT), 1e-16)) n++;
-  if(!is_equal("clock_skew:gc:tcb", LG - LB, novas_clock_skew(&frame, NOVAS_TCB), 3e-2 * LB)) n++;
+  if(!is_equal("clock_skew:gc:tcg", 0.0, novas_mean_clock_skew(&frame, NOVAS_TCG), 1e-16)) n++;
+  if(!is_equal("clock_skew:gc:tt", LG, novas_mean_clock_skew(&frame, NOVAS_TT), 1e-16)) n++;
+  if(!is_equal("clock_skew:gc:tcb", LG - LB, novas_mean_clock_skew(&frame, NOVAS_TCB), 3e-2 * LB)) n++;
 
   dt1 = (tt2tdb(NOVAS_JD_J2000 + 0.1) - tt2tdb(NOVAS_JD_J2000 - 0.1)) / 0.2;
-  if(!is_equal("clock_skew:gc:tdb", -dt1, novas_clock_skew(&frame, NOVAS_TDB) - novas_clock_skew(&frame, NOVAS_TT), 1e-12)) n++;
+  if(!is_equal("clock_skew:gc:tdb", -dt1, novas_mean_clock_skew(&frame, NOVAS_TDB) - novas_mean_clock_skew(&frame, NOVAS_TT), 1e-12)) n++;
 
   make_observer_on_surface(0.0, 0.0, 0.0, 0.0, 0.0, &obs);
   if(!is_ok("clock_skew:frame:earth", novas_make_frame(NOVAS_REDUCED_ACCURACY, &obs, &time, 0.0, 0.0, &frame))) n++;
-  if(!is_equal("clock_skew:earth:tcg", -LG, novas_clock_skew(&frame, NOVAS_TCG), 1e-12)) n++;
-  if(!is_equal("clock_skew:earth:tt", 0.0, novas_clock_skew(&frame, NOVAS_TT), 1e-12)) n++;
-  if(!is_equal("clock_skew:earth:tcb", -LB, novas_clock_skew(&frame, NOVAS_TCB), 3e-2 * LB)) n++;
+  if(!is_equal("clock_skew:earth:tcg", -LG, novas_mean_clock_skew(&frame, NOVAS_TCG), 1e-12)) n++;
+  if(!is_equal("clock_skew:earth:tt", 0.0, novas_mean_clock_skew(&frame, NOVAS_TT), 1e-12)) n++;
+  if(!is_equal("clock_skew:earth:tcb", -LB, novas_mean_clock_skew(&frame, NOVAS_TCB), 3e-2 * LB)) n++;
 
   if(!is_ok("clock_skew:obs:far", make_solar_system_observer(pos, vel, &obs))) n++;
   if(!is_ok("clock_skew:frame:far", novas_make_frame(NOVAS_REDUCED_ACCURACY, &obs, &time, 0.0, 0.0, &frame))) n++;
-  if(!is_equal("clock_skew:far:tcb", 0.0, novas_clock_skew(&frame, NOVAS_TCB), 1e-12)) n++;
+  if(!is_equal("clock_skew:far:tcb", 0.0, novas_mean_clock_skew(&frame, NOVAS_TCB), 1e-12)) n++;
 
   vel[0] = 0.9999999 * NOVAS_C;
   make_observer_in_space(pos, vel, &obs);
   if(!is_ok("clock_skew:frame:c", novas_make_frame(NOVAS_REDUCED_ACCURACY, &obs, &time, 0.0, 0.0, &frame))) n++;
-  if(!is_equal("clock_skew:c:tcb", -1.0, novas_clock_skew(&frame, NOVAS_TCB), 1e-3)) n++;
-  if(!is_equal("clock_skew:c:tcg", -1.0, novas_clock_skew(&frame, NOVAS_TCG), 1e-3)) n++;
-  if(!is_equal("clock_skew:c:tt", -1.0, novas_clock_skew(&frame, NOVAS_TT), 1e-3)) n++;
-
-
+  if(!is_equal("clock_skew:c:tcb", -1.0, novas_mean_clock_skew(&frame, NOVAS_TCB), 1e-3)) n++;
+  if(!is_equal("clock_skew:c:tcg", -1.0, novas_mean_clock_skew(&frame, NOVAS_TCG), 1e-3)) n++;
+  if(!is_equal("clock_skew:c:tt", -1.0, novas_mean_clock_skew(&frame, NOVAS_TT), 1e-3)) n++;
 
   return n;
 }


### PR DESCRIPTION
Added

```c
double novas_mean_clock_skew(const novas_frame *frame, enum novas_timescale timescale);
```

which discounts tidal variations for Earth-bound observers as they rotate around the geocenter.