### PR TITLE
Don't install CIO locator data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Upcoming feature release, expected around 1 November 2025.
  - #222: CMake build support, e.g for Mac OS X or Windows builds also (by kiranshila), with further tweaks in #228, 
    #229, #230, #234, 235 (by attipaci).
 
- - #223: New function `novas_clock_skew()` / `novas_mean_clock_skew()` to calculate the instantaneous or averaged
+ - #223: New functions `novas_clock_skew()` / `novas_mean_clock_skew()` to calculate the instantaneous or averaged 
    (for Earth-bound observers) incremental rate, respectively, at which an observer's clock ticks faster than an 
    astronomical timescale. All timescales, except UT1, are supported (see also #232 and #233). 
 
@@ -73,12 +73,21 @@ Upcoming feature release, expected around 1 November 2025.
  - #231: Changed documentation build to wean off the likes of `sed` or `tail`, thus allowing to build documentation in 
    a more platform-independent way.
  
+ - #236: No longer installing `CIO_RA.TXT` (e.g. to `/usr/share/supernovas`). Not only it is no longer needed by the 
+   library, it is also not precise as the data was generated with the original, now obsoleted, IAU2000 nutation model. 
+   Those who really want it, nevertheless, can install it themselves, to the location of choice, from the SuperNOVAS 
+   GitHub repo (in any location), and call `set_cio_locator_file()` before using it with `cio_array()` or 
+   `cio_location()`.
+   
+ - Both CMake and GNU make now install only the headers for the components that were included in the build. E.g. 
+   `novas-calceph.h` is installed only if the library is built with the CALCEPH support option enabled.
+ 
  - Various API documentation edits.
 
 ### Deprecated
 
- - #208: Deprecated `cio_location()`. Going forward, SuperNOVAS no longer uses the CIO locator data files 
-   (`CIO_RA.TXT` or `cio_ra.bin`) internally, and so `cio_location()` becomes redundant with `cio_ra()` and also 
+ - #208: Deprecated `cio_array()` and `cio_location()`. Going forward, SuperNOVAS no longer uses the CIO locator data 
+   files (`CIO_RA.TXT` or `cio_ra.bin`) internally, and so `cio_location()` becomes redundant with `cio_ra()` and also 
    `ira_equinox()` (which returns the negative of the same value).
 
  - #209: Deprecated `sidereal_time()`. It is messy and one of its arguments (`erot`) is now unused. Instead, you 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 #    $ [sudo ] cmake --install --prefix=/usr/local
 #
 #  You may install just a specific component via the --component option, such
-#  as 'Runtime', 'Development', or 'Data'.
+#  as 'Runtime' or 'Development'.
 #
 
 
@@ -308,14 +308,6 @@ install(TARGETS ${INSTALL_TARGETS}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
-
-# ------------------------------------------------------------------------
-# Install Data component
-
-install(FILES data/CIO_RA.TXT
-    COMPONENT Data
-    DESTINATION ${CMAKE_INSTALL_DATADIR}/supernovas
 )
 
 # ------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ INSTALL_PROGRAM ?= install
 INSTALL_DATA ?= install -m 644
 
 .PHONY: install
-install: install-libs install-cio-data install-headers install-html
+install: install-libs install-headers install-html
 
 .PHONY: install-libs
 install-libs:
@@ -261,18 +261,6 @@ ifneq ($(wildcard $(LIB)/*),)
 	cp -a $(LIB)/* $(DESTDIR)$(libdir)/
 else
 	@echo "WARNING! Skipping libs install: needs 'shared' and/or 'static'"
-endif
-
-.PHONY: install-cio-data
-install-cio-data:
-	@echo "installing CIO locator data to $(DESTDIR)$(mydatadir)"
-	install -d $(DESTDIR)$(mydatadir)
-	$(INSTALL_DATA) data/CIO_RA.TXT $(DESTDIR)$(mydatadir)/CIO_RA.TXT
-
-.PHONY: install-compat-headers
-install-compat-headers:
-ifeq ($(COMPAT),1)
-	$(INSTALL_DATA) include/novascon.h $(DESTDIR)$(includedir)/
 endif
 
 .PHONY: install-calceph-headers
@@ -292,7 +280,6 @@ install-headers:
 	@echo "installing headers to $(DESTDIR)$(includedir)"
 	install -d $(DESTDIR)$(includedir)
 	$(INSTALL_DATA) include/novas.h include/nutation.h include/solarsystem.h $(DESTDIR)$(includedir)/
-	@$(MAKE) install-compat-headers
 	@$(MAKE) install-calceph-headers
 	@$(MAKE) install-cspice-headers
 

--- a/README.md
+++ b/README.md
@@ -230,12 +230,6 @@ the necessary variables in the shell prior to invoking `make`. For example:
    thread local via `-DTHREAD_LOCAL=...` added to `CFLAGS`. (Don't forget to enclose the string value in escaped
    quotes in `config.mk`, or unescaped if defining the `THREAD_LOCAL` shell variable prior to invoking `make`.)
 
- - If you insist on using a CIO locator file for `cio_location()`, you can specify the path to the CIO locator file 
-   (e.g. `/usr/local/share/supernovas/CIO_RA.TXT`) on your system e.g. by setting the `CIO_LOCATOR_FILE` shell 
-   variable prior to calling `make`. (The CIO locator file is not necessary for the functioning of the library, unless 
-   you specifically require CIO positions relative to GCRS -- which is not something that anyone should really need
-   or want, in general).
-
 Additionally, you may set number of environment variables to futher customize the build, such as:
 
  - `CC`: The C compiler to use (default: `gcc`).
@@ -305,10 +299,10 @@ NOTES:
 <a name="cmake-build"></a>
 ### Build SuperNOVAS using CMake 
 
-As of v1.5, __SuperNOVAS__ can be built using [CMake](https://cmake.org/) (thanks to Kiran Shila). CMake allows for 
-greater portability than the regular GNU `Makefile`. Note, however, that the CMake configuration does not support all 
-of the build options of the GNU `Makefile`, such as automatic CALCEPH/CSPICE integration on Linux, supporting legacy 
-NOVAS C style builds, and code coverage tracking. 
+As of v1.5, __SuperNOVAS__ can be built using [CMake](https://cmake.org/) (many thanks to Kiran Shila). CMake allows 
+for greater portability than the regular GNU `Makefile`. Note, however, that the CMake configuration does not support 
+all of the build options of the GNU `Makefile`, such as automatic CALCEPH/CSPICE integration on Linux, supporting 
+legacy NOVAS C style builds, and code coverage tracking. 
 
 The basic build recipe for CMake is:
 
@@ -345,8 +339,8 @@ This is ideal for those who want to have full control of the compiler flags used
 `Release` or `Debug` will append a particular set of appropriate compiler options which are suited for the given 
 build type.
 
-After a successful build, you can install the `Runtime` (libraries), `Development` (headers, CMake config, and 
-`pkg-config`), and `Data` (CIO locator data) components, e.g. under `/usr/local`, as:
+After a successful build, you can install the `Runtime` (libraries), and `Development` (headers, CMake config, and 
+`pkg-config`) components, e.g. under `/usr/local`, as:
 
 ```bash
   $ cmake --build build

--- a/include/novas.h
+++ b/include/novas.h
@@ -738,7 +738,7 @@ enum novas_cio_location_type {
 /// Path / name of file to use for interpolating the CIO location relative to GCRS
 /// This file can be generated with the <code>cio_file.c</code> tool using the
 /// <code>CIO_RA.TXT</code> data (both are included in the distribution)
-#    define DEFAULT_CIO_LOCATOR_FILE      "/usr/share/supernovas/CIO_RA.TXT"
+#    define DEFAULT_CIO_LOCATOR_FILE      NULL
 #  endif
 #endif
 

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -2015,6 +2015,8 @@ static int test_cio_location() {
   short type;
   char path[1024] = {'\0'};
 
+  if(!is_ok("cio_location:set_path:NULL", set_cio_locator_file(NULL))) return 1;
+
   sprintf(path, "%s" PATH_SEP "CIO_RA.TXT", dataPath);
   if(!is_ok("cio_location:set_path", set_cio_locator_file(path))) return 1;
 


### PR DESCRIPTION
And, also no default CIO data location set unless in `COMPAT` mode (in which case the NOVAS C `./cio_array.bin` is used.

Follows #208. 