### PR TITLE
Install more documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,9 @@ Upcoming feature release, expected around 1 November 2025.
    GitHub repo (in any location), and call `set_cio_locator_file()` before using it with `cio_array()` or 
    `cio_location()`.
    
+ - #237: Both CMake and GNU make now install more developer docs into `$(docdir)/supernovas`, such as `examples/`
+   `legacy/` source code, and markdown files.
+   
  - Both CMake and GNU make now install only the headers for the components that were included in the build. E.g. 
    `novas-calceph.h` is installed only if the library is built with the CALCEPH support option enabled.
  

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,16 +339,37 @@ if(ENABLE_SOLSYS1)
    )
 endif()
 
+install(FILES README.md LEGACY.md CHANGELOG.md CONTRIBUTING.md
+    COMPONENT Development
+    DESTINATION ${CMAKE_INSTALL_DOCDIR}
+)
+
+# For examples/ dir, list just the directory, not the individual files installed.
+install(CODE "message(STATUS \"Installing: ${CMAKE_INSTALL_DOCDIR}/supernovas/examples\")")
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/examples
+   DESTINATION ${CMAKE_INSTALL_DOCDIR}/supernovas
+   MESSAGE_NEVER
+   COMPONENT Development
+)
+
+# For legacy/ dir, list just the directory, not the individual files installed.
+install(CODE "message(STATUS \"Installing: ${CMAKE_INSTALL_DOCDIR}/supernovas/legacy\")")
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/legacy
+   DESTINATION ${CMAKE_INSTALL_DOCDIR}/supernovas
+   MESSAGE_NEVER
+   COMPONENT Development
+)
+
 if(BUILD_DOC AND TARGET project_docs)
     # For html/ dir, list just the directory, not the individual files installed.
-    install(CODE "message(STATUS \"Installing: ${CMAKE_CURRENT_BINARY_DIR}/html\")")
+    install(CODE "message(STATUS \"Installing: ${CMAKE_INSTALL_DOCDIR}/supernovas/html\")")
     install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html
         DESTINATION ${CMAKE_INSTALL_DOCDIR}/supernovas
         MESSAGE_NEVER
         COMPONENT Development
     )
     # For resources/ dir, list just the directory, not the individual files installed.
-    install(CODE "message(STATUS \"Installing: ${CMAKE_CURRENT_BINARY_DIR}/html/resources\")")
+    install(CODE "message(STATUS \"Installing: ${CMAKE_INSTALL_DOCDIR}/supernovas/html/resources\")")
     install(DIRECTORY ${PROJECT_SOURCE_DIR}/resources
         DESTINATION ${CMAKE_INSTALL_DOCDIR}/supernovas/html
         MESSAGE_NEVER

--- a/Doxyfile
+++ b/Doxyfile
@@ -993,7 +993,8 @@ WARN_LOGFILE           =
 
 INPUT                  = src \
                          include \
-                         .
+                         . \
+                         resources/supernovas_vs_astropy.md
 
 # This tag can be used to specify the character encoding of the source files
 # that Doxygen parses. Internally Doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1098,7 +1099,8 @@ RECURSIVE              = NO
 
 EXCLUDE                = README.md \
                          CODE_OF_CONDUCT.md \
-                         CMakeLists.txt
+                         CMakeLists.txt \
+                         RELEASE-HOWTO.md
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ INSTALL_PROGRAM ?= install
 INSTALL_DATA ?= install -m 644
 
 .PHONY: install
-install: install-libs install-headers install-html
+install: install-libs install-headers install-docs
 
 .PHONY: install-libs
 install-libs:
@@ -283,6 +283,18 @@ install-headers:
 	@$(MAKE) install-calceph-headers
 	@$(MAKE) install-cspice-headers
 
+.PHONY: install-docs
+install-docs: install-markdown install-html install-examples install-legacy
+
+.PHONY: install-markdown
+install-markdown:
+	@echo "installing documentation to $(DESTDIR)$(docdir)"
+	install -d $(DESTDIR)$(docdir)
+	$(INSTALL_DATA) README.md $(DESTDIR)$(docdir)/
+	$(INSTALL_DATA) LEGACY.md $(DESTDIR)$(docdir)/
+	$(INSTALL_DATA) CHANGELOG.md $(DESTDIR)$(docdir)/
+	$(INSTALL_DATA) CONTRIBUTING.md $(DESTDIR)$(docdir)/
+
 .PHONY: install-html
 install-html:
 ifneq ($(wildcard apidoc/html/search/*),)
@@ -299,6 +311,18 @@ ifneq ($(wildcard apidoc/html/search/*),)
 else
 	@echo "WARNING! Skipping apidoc install: needs doxygen and 'local-dox'"
 endif
+
+.PHONY: install-examples
+install-examples:
+	@echo "installing examples to $(DESTDIR)$(docdir)/examples"
+	install -d $(DESTDIR)$(docdir)/examples
+	$(INSTALL_DATA) examples/* $(DESTDIR)$(docdir)/examples/
+
+.PHONY: install-legacy
+install-legacy:
+	@echo "installing legacy source code to $(DESTDIR)$(docdir)/legacy"
+	install -d $(DESTDIR)$(docdir)/legacy
+	$(INSTALL_DATA) legacy/* $(DESTDIR)$(docdir)/legacy/
 
 # Some standard GNU targets, that should always exist...
 .PHONY: html


### PR DESCRIPTION
Both CMake and GNU make to install the following in `$(docdir)/supernovas/`:

- `README.md`
- `LEGACY.md`
- `CHANGELOG.md`
- `CONTRIBUTING.md`
- `examples/`
- `legacy/`

Also compile `resources/supernovas_vs_astropy.md` into HTML.