### PR TITLE
Doxygen to use README.md as is.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,13 +74,17 @@ Upcoming feature release, expected around 1 November 2025.
    a more platform-independent way.
  
  - #236: No longer installing `CIO_RA.TXT` (e.g. to `/usr/share/supernovas`). Not only it is no longer needed by the 
-   library, it is also not precise as the data was generated with the original, now obsoleted, IAU2000 nutation model. 
-   Those who really want it, nevertheless, can install it themselves, to the location of choice, from the SuperNOVAS 
-   GitHub repo (in any location), and call `set_cio_locator_file()` before using it with `cio_array()` or 
-   `cio_location()`.
+   library, it is also not precise at the tens of microarcsecond (&mu;as) level as the data was generated with the 
+   original, now obsoleted, IAU2000 nutation model. Those who really want it, nevertheless, can install it themselves, 
+   to the location of choice, from the SuperNOVAS GitHub repo (in any location), and call `set_cio_locator_file()` 
+   before using it with `cio_array()` or `cio_location()`.
    
  - #237: Both CMake and GNU make now install more developer docs into `$(docdir)/supernovas`, such as `examples/`
    `legacy/` source code, and markdown files.
+   
+ - #238: Added doxygen commands to `README.md` inside HTML comments to exclude rendering the README header (badges
+   and logo) with doxygen, while not rendering the commands in Github (or other viewers) either. The change allows
+   using the README as is, without editing, as input to Doxygen. 
    
  - Both CMake and GNU make now install only the headers for the components that were included in the build. E.g. 
    `novas-calceph.h` is installed only if the library is built with the CALCEPH support option enabled.

--- a/Doxyfile
+++ b/Doxyfile
@@ -1097,10 +1097,11 @@ RECURSIVE              = NO
 # Note that relative paths are relative to the directory from which Doxygen is
 # run.
 
-EXCLUDE                = README.md \
-                         CODE_OF_CONDUCT.md \
+EXCLUDE                = CODE_OF_CONDUCT.md \
                          CMakeLists.txt \
-                         RELEASE-HOWTO.md
+                         RELEASE-HOWTO.md \
+                         LEGACY.md \
+                         README-orig.md
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -1220,7 +1221,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the Doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = README-orig.md
+USE_MDFILE_AS_MAINPAGE = README.md
 
 # If the IMPLICIT_DIR_DOCS tag is set to YES, any README.md file found in sub-
 # directories of the project's root, is used as the documentation for that sub-

--- a/LEGACY.md
+++ b/LEGACY.md
@@ -1,7 +1,8 @@
-# Astrometric Positions the Old Way
+# Old example usage
 
 As of version 1.1, the SuperNOVAS library offers a new, more versatile, more intuitive, and more efficient way to 
-calculate the astrometric positions (and velocities) of celestial sources, via observing frames (see `README.md`). 
+calculate the astrometric positions (and velocities) of celestial sources, via observing frames (see the 
+_Example Usage_ section of the main `README.md`). 
 However the old approach of the NOVAS C library remain viable also. This document demonstrates calculating the 
 astrometric places of sources the old way, without using the observing frames approach that is now preferred in 
 SuperNOVAS.
@@ -45,7 +46,7 @@ adjustment to convert from J2000 to ICRS coordinates.
 (Naturally, you can skip the transformation steps above if you have defined your source in ICRS coordinates from the 
 start.)
 
-### Spefify the observer location
+### Specify the observer location
 
 Next, we define the location where we observe from. Here we can (but don't have to) specify local weather parameters
 (temperature and pressure) also for refraction correction later (in this example, we'll skip the weather):

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ coverage:
 # Remove intermediates
 .PHONY: clean
 clean:
-	rm -f $(OBJECTS) README-orig.md Doxyfile.local $(BIN)/cio_file gmon.out
+	rm -f $(OBJECTS) Doxyfile.local $(BIN)/cio_file gmon.out
 	$(MAKE) -C test clean
 	$(MAKE) -C benchmark clean
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<!--! 
+\cond MD_HEADER
+-->
+
 ![Build Status](https://github.com/Smithsonian/SuperNOVAS/actions/workflows/build.yml/badge.svg)
 ![Test](https://github.com/Smithsonian/SuperNOVAS/actions/workflows/test.yml/badge.svg)
 <a href="https://smithsonian.github.io/SuperNOVAS/apidoc/html/files.html">
@@ -14,7 +18,13 @@
 </picture>
 <br clear="all">
 
-# SuperNOVAS 
+# SuperNOVAS
+ 
+<!--!
+\endcond 
+
+## User's guide
+-->
 
 [![DOI](resources/748170057.svg)](https://doi.org/10.5281/zenodo.14584983)
 
@@ -532,7 +542,7 @@ implementation.
 
 __SuperNOVAS v1.1__ has introduced a new, more intuitive, more elegant, and more efficient approach for calculating
 astrometric positions of celestial objects. The guide below is geared towards this new method. However, the original
-NOVAS C approach remains viable also (albeit often less efficient). You may find an equivalent example usage 
+NOVAS C approach remains viable also (albeit often less efficient). You may find an equivalent legacy example 
 showcasing the original NOVAS method in [LEGACY.md](LEGACY.html).
 
 <a name="sidereal-example"></a>

--- a/resources/header.html
+++ b/resources/header.html
@@ -1,4 +1,4 @@
-<!-- HTML header for doxygen 1.9.7-->
+<!-- HTML header for doxygen -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="$langISO">
 <head>
@@ -8,7 +8,7 @@
 <meta name="description" content="SuperNOVAS C/C++ astrometry library"/>
 <meta name="keywords" content="astronomy, astrometry, C, C++, C99, software library, open source, NOVAS"/>
 <meta name="author" content="Attila Kovacs"/>
-<meta name="copyright" content="(C)2024 Attila Kovacs" />
+<meta name="copyright" content="(C)2025 Attila Kovacs" />
 <meta name="robots" content="index,follow"/>
 <meta name="generator" content="Doxygen $doxygenversion"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>

--- a/src/docedit.c
+++ b/src/docedit.c
@@ -70,34 +70,6 @@ static int make_local_doxyfile() {
   return 0;
 }
 
-static int make_headless_readme() {
-  FILE *in, *out;
-  char line[16384] = {'\0'};
-  int head = 1;
-
-  in = openfile("README.md", "r");
-  if(!in) return -1;
-
-  out = openfile("README-orig.md", "w");
-  if(!out) {
-    fclose(in);
-    return -1;
-  }
-
-  while(fgets(line, sizeof(line) - 1, in) != NULL) {
-    if(head) {
-      if(line[0] != '#') continue;
-      head = 0;
-    }
-    fwrite(line, strlen(line), 1, out);
-  }
-
-  fclose(out);
-  fclose(in);
-
-  return 0;
-}
-
 // Syntax: docedit [input-path] [output-path]
 int main(int argc, const char *argv[]) {
   int nerr = 0;
@@ -109,7 +81,6 @@ int main(int argc, const char *argv[]) {
     outpath = argv[2];
 
   if(make_local_doxyfile() != 0) nerr++;
-  if(make_headless_readme() != 0) nerr++;
 
   return nerr;
 }


### PR DESCRIPTION
Add HTML comments with doxygen command to skip badges and logo, so we no longer need to create a headless `README-orig.md`