### PR TITLE
Define catalog sources step-by-step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CC: gcc
-      FORTIFY: 3
+      CFLAGS: -O0
     steps:
 
     - uses: actions/checkout@v5

--- a/.settings/language.settings.xml
+++ b/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="([^/\\\\]*)((g?cc)|([gc]\+\+)|(clang))" prefer-non-shared="true"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-1708501093666589092" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="1827449319562938263" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Upcoming feature release, expected around 1 November 2025.
    (for Earth-bound observers) incremental rate, respectively, at which an observer's clock ticks faster than an 
    astronomical timescale. All timescales, except UT1, are supported (see also #232 and #233). 
 
+ - #239: New step-by-step approach to populate astormetric data for catalog sources, complementing the one-step
+   `make_cat_entry()`. Start with `novas_init_cat_entry()` specifying the name and the R.A. / Dec coordinates, and 
+   then add more information as needed: set radial velocities with `novas_set_ssb_vel()` / `novas_set_lsr_vel()` / 
+   `novas_set_redshift()`; set parallax or distance (if any) with `novas_set_parallax()` or `novas_set_distance()`; 
+   set proper motion (if any) with `novas_set_proper_motion()`; or add catalog information with `novas_set_catalog()`.
+
 ### Changed
 
  - #208: `cio_location()` now always returns the CIO's right ascension relative to the true equinox of date (on the 

--- a/examples/example-rise-set.c
+++ b/examples/example-rise-set.c
@@ -78,10 +78,24 @@ int main(int argc, const char *argv[]) {
   // NOTE, that make_cat_entry() expects radial velocities defined relative to the
   // Solar-System Barycenter (SSB). But you can convert LSR-based velocities to
   // the required SSB-based radial velocities using novas_lsr_to_ssb_vel() if needed.
-  if(make_cat_entry("Antares", "FK4", 1, 16.43894213, -26.323094, -12.11, -23.30, 5.89, -3.4, &star) != 0) {
+
+  // E.g. initialize with string coordinates to hours/degrees...
+  if(novas_init_cat_entry(&star, "Antares", novas_str_hours("16h26m20.1918s"), novas_str_degrees("-26d19m23.138s")) != 0) {
     fprintf(stderr, "ERROR! defining cat_entry.\n");
     return 1;
   }
+
+  // Optionally, we might store the catalog information: catalog name (5-chars max) and number.
+  novas_set_catalog(&star, "FK4", 1);
+
+  // Set the proper motion
+  novas_set_proper_motion(&star, -12.11, -23.30);
+
+  // Set the parallax. Alternatively we could set distance with `novas_set_distance()` instead.
+  novas_set_parallax(&star, 5.89);
+
+  // Set radial velocity. Or we could set LSR velocity with 'novas_set_lsr_vel()' instead
+  novas_set_ssb_vel(&star, -3.4);
 
   // -------------------------------------------------------------------------
   // Convert to ICRS coordinates and wrap in a generic object structure.

--- a/examples/example-star.c
+++ b/examples/example-star.c
@@ -64,14 +64,24 @@ int main() {
   // Solar-System Barycenter (SSB). But you can convert LSR-based velocities to
   // the required SSB-based radial velocities using novas_lsr_to_ssb_vel() if needed.
 
-  // Convert string coordinates to hours/degrees...
-  double ra0 = novas_str_hours("16h26m20.1918s");
-  double dec0 = novas_str_degrees("-26d19m23.138s");
-
-  if(make_cat_entry("Antares", "FK4", 1, ra0, dec0, -12.11, -23.30, 5.89, -3.4, &star) != 0) {
+  // E.g. initialize with string coordinates to hours/degrees...
+  if(novas_init_cat_entry(&star, "Antares", novas_str_hours("16h26m20.1918s"), novas_str_degrees("-26d19m23.138s")) != 0) {
     fprintf(stderr, "ERROR! defining cat_entry.\n");
     return 1;
   }
+
+  // Optionally, we might store the catalog information: catalog name (5-chars max) and number.
+  novas_set_catalog(&star, "FK4", 1);
+
+  // Set the proper motion
+  novas_set_proper_motion(&star, -12.11, -23.30);
+
+  // Set the parallax. Alternatively we could set distance with `novas_set_distance()` instead.
+  novas_set_parallax(&star, 5.89);
+
+  // Set radial velocity. Or we could set LSR velocity with 'novas_set_lsr_vel()' instead
+  novas_set_ssb_vel(&star, -3.4);
+
 
   // -------------------------------------------------------------------------
   // Convert to ICRS coordinates and wrap in a generic object structure.

--- a/include/novas.h
+++ b/include/novas.h
@@ -1798,8 +1798,8 @@ double julian_date(short year, short month, short day, double hour);
 int cal_date(double tjd, short *restrict year, short *restrict month, short *restrict day, double *restrict hour);
 
 // in target.c
-short make_cat_entry(const char *restrict star_name, const char *restrict catalog, long cat_num, double ra, double dec,
-        double pm_ra, double pm_dec, double parallax, double rad_vel, cat_entry *star);
+short make_cat_entry(const char *restrict name, const char *restrict catalog, long cat_num, double ra, double dec,
+        double pm_ra, double pm_dec, double parallax, double rad_vel, cat_entry *source);
 
 short transform_cat(enum novas_transform_type, double jd_tt_in, const cat_entry *in, double jd_tt_out, const char *out_id,
         cat_entry *out);
@@ -2074,7 +2074,6 @@ int gcrs_to_mod(double jd_tdb, const double *in, double *out);
 int mod_to_gcrs(double jd_tdb, const double *in, double *out);
 
 
-
 // ---------------------- Added in 1.3.0 -------------------------
 
 // in calendar.c
@@ -2207,6 +2206,7 @@ int novas_day_of_year(double tjd, enum novas_calendar_type calendar, int *restri
 
 // ---------------------- Added in 1.5.0 -------------------------
 
+// in earth.c
 double novas_gmst(double jd_ut1, double ut1_to_tt);
 
 double novas_gast(double jd_ut1, double ut1_to_tt, enum novas_accuracy accuracy);
@@ -2222,6 +2222,7 @@ int novas_diurnal_libration(double gmst, const novas_delaunay_args *restrict del
 int novas_diurnal_ocean_tides(double gmst, const novas_delaunay_args *restrict delaunay, double *restrict xp, double *restrict yp,
         double *restrict dut1);
 
+// in itrf.c
 int novas_itrf_transform(int from_year, const double *restrict from_coords, const double *restrict from_rates,
         int to_year, double *to_coords, double *to_rates);
 
@@ -2232,9 +2233,28 @@ int novas_geodetic_to_cartesian(double lon, double lat, double alt, enum novas_r
 
 int novas_cartesian_to_geodetic(const double *restrict x, enum novas_reference_ellipsoid ellipsoid, double *restrict lon, double *restrict lat, double *restrict alt);
 
+// in timescale.c
 double novas_clock_skew(const novas_frame *frame, enum novas_timescale timescale);
 
 double novas_mean_clock_skew(const novas_frame *frame, enum novas_timescale timescale);
+
+
+// in target.c
+int novas_init_cat_entry(cat_entry *restrict source, const char *restrict name, double ra, double dec);
+
+int novas_set_catalog(cat_entry *restrict source, const char *restrict catalog, long num);
+
+int novas_set_ssb_vel(cat_entry *source, double v_kms);
+
+int novas_set_lsr_vel(cat_entry *source, double epoch, double v_kms);
+
+int novas_set_redshift(cat_entry *source, double z);
+
+int novas_set_proper_motion(cat_entry *source, double pm_ra, double pm_dec);
+
+int novas_set_parallax(cat_entry *source, double mas);
+
+int novas_set_distance(cat_entry *source, double parsecs);
 
 
 // <================= END of SuperNOVAS API =====================>

--- a/src/calendar.c
+++ b/src/calendar.c
@@ -68,12 +68,12 @@ double novas_jd_from_date(enum novas_calendar_type calendar, int year, int month
     return novas_error(-1, EINVAL, fn, "invalid calendar type: %d\n", calendar);
 
   if(month < 1 || month > 12) {
-    novas_error(0, EINVAL, fn, "invalid month: %d, expected 1-12", month);
+    novas_set_errno(EINVAL, fn, "invalid month: %d, expected 1-12", month);
     return NAN;
   }
 
   if(day < 1 || day > md[month]) {
-    novas_error(0, EINVAL, fn, "invalid day-of-month: %d, expected 1-%d", day, md[month]);
+    novas_set_errno(EINVAL, fn, "invalid day-of-month: %d, expected 1-%d", day, md[month]);
     return NAN;
   }
 

--- a/src/frames.c
+++ b/src/frames.c
@@ -1417,17 +1417,17 @@ double novas_frame_lst(const novas_frame *restrict frame) {
   double lst;
 
   if(!frame) {
-    novas_error(0, EINVAL, fn, "input frame is NULL");
+    novas_set_errno(EINVAL, fn, "input frame is NULL");
     return NAN;
   }
 
   if(!novas_frame_is_initialized(frame)) {
-    novas_error(0, EINVAL, fn, "input frame is not initialized");
+    novas_set_errno(EINVAL, fn, "input frame is not initialized");
     return NAN;
   }
 
   if(frame->observer.where != NOVAS_OBSERVER_ON_EARTH && frame->observer.where != NOVAS_AIRBORNE_OBSERVER) {
-    novas_error(0, EINVAL, fn, "Not an Earth-bound observer: where=%d", frame->observer.where);
+    novas_set_errno(EINVAL, fn, "Not an Earth-bound observer: where=%d", frame->observer.where);
     return NAN;
   }
 
@@ -1495,7 +1495,7 @@ static double novas_cross_el_date(double el, int sign, const object *source, con
   int i;
 
   if(!source) {
-    novas_error(0, EINVAL, fn, "input source is NULL");
+    novas_set_errno(EINVAL, fn, "input source is NULL");
     return NAN;
   }
 
@@ -1545,7 +1545,7 @@ static double novas_cross_el_date(double el, int sign, const object *source, con
     novas_make_frame(frame->accuracy, &frame->observer, &t, frame->dx, frame->dy, &frame1);
   }
 
-  novas_error(0, ECANCELED, fn, "failed to converge");
+  novas_set_errno(ECANCELED, fn, "failed to converge");
   return NAN;
 }
 
@@ -1682,17 +1682,17 @@ double novas_solar_illum(const object *restrict source, const novas_frame *restr
   int i;
 
   if(!source) {
-    novas_error(0, EINVAL, fn, "input source is NULL");
+    novas_set_errno(EINVAL, fn, "input source is NULL");
     return NAN;
   }
 
   if(!frame) {
-    novas_error(0, EINVAL, fn, "input frame is NULL");
+    novas_set_errno(EINVAL, fn, "input frame is NULL");
     return NAN;
   }
 
   if(!novas_frame_is_initialized(frame)) {
-    novas_error(0, EINVAL, fn, "input frame is not initialized");
+    novas_set_errno(EINVAL, fn, "input frame is not initialized");
     return NAN;
   }
 
@@ -1739,12 +1739,12 @@ double novas_object_sep(const object *source1, const object *source2, const nova
   sky_pos p1 = SKY_POS_INIT, p2 = SKY_POS_INIT;
 
   if(!source1) {
-    novas_error(0, EINVAL, fn, "input source1 is NULL");
+    novas_set_errno(EINVAL, fn, "input source1 is NULL");
     return NAN;
   }
 
   if(!source2) {
-    novas_error(0, EINVAL, fn, "input source2 is NULL");
+    novas_set_errno(EINVAL, fn, "input source2 is NULL");
     return NAN;
   }
 
@@ -1755,7 +1755,7 @@ double novas_object_sep(const object *source1, const object *source2, const nova
     return novas_trace_nan(fn);
 
   if(p1.dis < 1e-11 || p2.dis < 1e-11) {
-    novas_error(0, EINVAL, fn, "source is at observer location");
+    novas_set_errno(EINVAL, fn, "source is at observer location");
     return NAN;
   }
 

--- a/src/frames.c
+++ b/src/frames.c
@@ -863,7 +863,7 @@ int novas_geom_to_app(const novas_frame *restrict frame, const double *restrict 
   if(!novas_frame_is_initialized(frame))
     return novas_error(-1, EINVAL, fn, "frame at %p not initialized", frame);
 
-  if(frame->accuracy != NOVAS_FULL_ACCURACY && frame->accuracy != NOVAS_REDUCED_ACCURACY)
+  if(frame->accuracy < NOVAS_FULL_ACCURACY || frame->accuracy > NOVAS_REDUCED_ACCURACY)
     return novas_error(-1, EINVAL, fn, "invalid accuracy: %d", frame->accuracy);
 
   // Compute gravitational deflection and aberration.

--- a/src/parse.c
+++ b/src/parse.c
@@ -61,12 +61,12 @@ double novas_epoch(const char *restrict system) {
   char type = 0, *tail = NULL;
 
   if(!system) {
-    novas_error(0, EINVAL, fn, "epoch is NULL");
+    novas_set_errno(EINVAL, fn, "epoch is NULL");
     return NAN;
   }
 
   if(!system[0]) {
-    novas_error(0, EINVAL, fn, "epoch is empty");
+    novas_set_errno(EINVAL, fn, "epoch is empty");
     return NAN;
   }
 
@@ -95,7 +95,7 @@ double novas_epoch(const char *restrict system) {
 
   year = strtod(system, &tail);
   if(tail <= system) {
-    novas_error(0, EINVAL, fn, "Invalid epoch: %s", system);
+    novas_set_errno(EINVAL, fn, "Invalid epoch: %s", system);
     return NAN;
   }
 
@@ -158,26 +158,26 @@ double novas_parse_hms(const char *restrict hms, char **restrict tail) {
     *tail = (char *) hms;
 
   if(!hms) {
-    novas_error(0, EINVAL, fn, "input string is NULL");
+    novas_set_errno(EINVAL, fn, "input string is NULL");
     return NAN;
   }
   if(!hms[0]) {
-    novas_error(0, EINVAL, fn, "input string is empty");
+    novas_set_errno(EINVAL, fn, "input string is empty");
     return NAN;
   }
 
   if(sscanf(hms, "%d%*[:hH _\t]%d%n%*[:mM'’ _\t]%lf%n", &h, &m, &n, &s, &n) < 2) {
-    novas_error(0, EINVAL, fn, "not in HMS format: '%s'", hms);
+    novas_set_errno(EINVAL, fn, "not in HMS format: '%s'", hms);
     return NAN;
   }
 
   if(m < 0 || m >= 60) {
-    novas_error(0, EINVAL, fn, "invalid minutes: got %d, expected 0-59", m);
+    novas_set_errno(EINVAL, fn, "invalid minutes: got %d, expected 0-59", m);
     return NAN;
   }
 
   if(s < 0.0 || s >= 60.0) {
-    novas_error(0, EINVAL, fn, "invalid seconds: got %f, expected [0.0:60.0)", s);
+    novas_set_errno(EINVAL, fn, "invalid seconds: got %f, expected [0.0:60.0)", s);
     return NAN;
   }
 
@@ -351,11 +351,11 @@ double novas_parse_dms(const char *restrict dms, char **restrict tail) {
     *tail = (char *) dms;
 
   if(!dms) {
-    novas_error(0, EINVAL, fn, "input string is NULL");
+    novas_set_errno(EINVAL, fn, "input string is NULL");
     return NAN;
   }
   if(!dms[0]) {
-    novas_error(0, EINVAL, fn, "input string is empty");
+    novas_set_errno(EINVAL, fn, "input string is empty");
     return NAN;
   }
 
@@ -363,12 +363,12 @@ double novas_parse_dms(const char *restrict dms, char **restrict tail) {
   str = (char *) dms + nc;
 
   if(sscanf(str, "%d%*[:d _\t]%d%n%*[:m' _\t]%n%39[-+0-9.]", &d, &m, &nv, &nv, ss) < 2) {
-    novas_error(0, EINVAL, fn, "not in DMS format: '%s'", dms);
+    novas_set_errno(EINVAL, fn, "not in DMS format: '%s'", dms);
     return NAN;
   }
 
   if(m < 0 || m >= 60) {
-    novas_error(0, EINVAL, fn, "invalid minutes: got %d, expected 0-59", m);
+    novas_set_errno(EINVAL, fn, "invalid minutes: got %d, expected 0-59", m);
     return NAN;
   }
 
@@ -379,7 +379,7 @@ double novas_parse_dms(const char *restrict dms, char **restrict tail) {
   }
 
   if(s < 0.0 || s >= 60.0) {
-    novas_error(0, EINVAL, fn, "invalid seconds: got %f, expected [0.0:60.0)", s);
+    novas_set_errno(EINVAL, fn, "invalid seconds: got %f, expected [0.0:60.0)", s);
     return NAN;
   }
 
@@ -535,7 +535,7 @@ double novas_parse_degrees(const char *restrict str, char **restrict tail) {
     *tail = (char *) str;
 
   if(!str) {
-    novas_error(0, EINVAL, fn, "input string is NULL");
+    novas_set_errno(EINVAL, fn, "input string is NULL");
     return NAN;
   }
 
@@ -608,7 +608,7 @@ double novas_parse_degrees(const char *restrict str, char **restrict tail) {
     }
   }
 
-  novas_error(0, EINVAL, fn, "invalid angle specification: '%s'", str);
+  novas_set_errno(EINVAL, fn, "invalid angle specification: '%s'", str);
   return NAN;
 }
 
@@ -663,7 +663,7 @@ double novas_parse_hours(const char *restrict str, char **restrict tail) {
     *tail = (char *) str;
 
   if(!str) {
-    novas_error(0, EINVAL, fn, "input string is NULL");
+    novas_set_errno(EINVAL, fn, "input string is NULL");
     return NAN;
   }
 
@@ -704,7 +704,7 @@ double novas_parse_hours(const char *restrict str, char **restrict tail) {
       *tail += n;
   }
   else {
-    novas_error(0, EINVAL, fn, "invalid time specification: '%s'", str);
+    novas_set_errno(EINVAL, fn, "invalid time specification: '%s'", str);
     return NAN;
   }
 

--- a/src/spectral.c
+++ b/src/spectral.c
@@ -58,7 +58,7 @@ double novas_add_vel(double v1, double v2) {
  */
 double novas_z2v(double z) {
   if(z <= -1.0) {
-    novas_error(-1, EINVAL, "novas_z2v", "invalid redshift value z=%g", z);
+    novas_error(-1, ERANGE, "novas_z2v", "invalid redshift value z=%g", z);
     return NAN;
   }
   z += 1.0;

--- a/src/target.c
+++ b/src/target.c
@@ -1102,12 +1102,12 @@ double novas_helio_dist(double jd_tdb, const object *restrict source, double *re
     *rate = NAN;
 
   if(!source) {
-    novas_error(0, EINVAL, fn, "input source is NULL");
+    novas_set_errno(EINVAL, fn, "input source is NULL");
     return NAN;
   }
 
   if(source->type == NOVAS_CATALOG_OBJECT) {
-    novas_error(0, EINVAL, fn, "input source is not a Solar-system body: type %d", source->type);
+    novas_set_errno(EINVAL, fn, "input source is not a Solar-system body: type %d", source->type);
     return NAN;
   }
 

--- a/src/timescale.c
+++ b/src/timescale.c
@@ -1027,11 +1027,11 @@ double novas_parse_date_format(enum novas_calendar_type calendar, enum novas_dat
     *tail = (char *) date;
 
   if(!date) {
-    novas_error(0, EINVAL, fn, "input string is NULL");
+    novas_set_errno(EINVAL, fn, "input string is NULL");
     return NAN;
   }
   if(!date[0]) {
-    novas_error(0, EINVAL, fn, "input string is empty");
+    novas_set_errno(EINVAL, fn, "input string is empty");
     return NAN;
   }
 
@@ -1046,19 +1046,19 @@ double novas_parse_date_format(enum novas_calendar_type calendar, enum novas_dat
       N = sscanf(date, MONTH_SPEC DATE_SEP "%d" DATE_SEP "%d%n", month, &d, &y, &n);
       break;
     default:
-      novas_error(0, EINVAL, fn, "invalid date format: %d", format);
+      novas_set_errno(EINVAL, fn, "invalid date format: %d", format);
       return NAN;
   }
 
   if(N < 3) {
-    novas_error(0, EINVAL, fn, "invalid date: '%s'", date);
+    novas_set_errno(EINVAL, fn, "invalid date: '%s'", date);
     return NAN;
   }
 
   if(sscanf(month, "%d", &m) == 1) {
     // Month as integer, check if in expected range
     if(m < 1 || m > 12) {
-      novas_error(0, EINVAL, fn, "invalid month: got %d, expected 1-12", m);
+      novas_set_errno(EINVAL, fn, "invalid month: got %d, expected 1-12", m);
       return NAN;
     }
   }
@@ -1074,14 +1074,14 @@ double novas_parse_date_format(enum novas_calendar_type calendar, enum novas_dat
     }
     if(m > 12) {
       // No match to month names...
-      novas_error(0, EINVAL, fn, "invalid month: %s", month);
+      novas_set_errno(EINVAL, fn, "invalid month: %s", month);
       return NAN;
     }
   }
 
   // Check that day is valid in principle (for leap years)
   if(d < 1 || d > md[m]) {
-    novas_error(0, EINVAL, fn, "invalid day-of-month: got %d, expected 1-%d", d, md[m]);
+    novas_set_errno(EINVAL, fn, "invalid day-of-month: got %d, expected 1-%d", d, md[m]);
     return NAN;
   }
 
@@ -1286,7 +1286,7 @@ double novas_date_scale(const char *restrict date, enum novas_timescale *restric
   double jd = novas_parse_date(date, &tail);
 
   if(!scale) {
-    novas_error(0, EINVAL, fn, "output scale is NULL");
+    novas_set_errno(EINVAL, fn, "output scale is NULL");
     return NAN;
   }
 
@@ -1712,7 +1712,7 @@ static double solar_system_potential(const novas_frame *frame, const double *pos
       d = novas_vdist(pos, frame->earth_pos) * AU;
     }
     else if(frame->accuracy != NOVAS_REDUCED_ACCURACY) {
-      novas_error(0, EAGAIN, "solar_system_potential", "Missing position data for planet %d", i);
+      novas_set_errno(EAGAIN, "solar_system_potential", "Missing position data for planet %d", i);
       return NAN;
     }
 
@@ -1893,12 +1893,12 @@ double novas_clock_skew(const novas_frame *frame, enum novas_timescale timescale
   double D = 0.0;
 
   if(!frame) {
-    novas_error(0, EINVAL, fn, "input frame is NULL");
+    novas_set_errno(EINVAL, fn, "input frame is NULL");
     return NAN;
   }
 
   if(!novas_frame_is_initialized(frame)) {
-    novas_error(0, EINVAL, fn, "input frame is not initialized");
+    novas_set_errno(EINVAL, fn, "input frame is not initialized");
     return NAN;
   }
 
@@ -1936,7 +1936,7 @@ double novas_clock_skew(const novas_frame *frame, enum novas_timescale timescale
     }
 
     default:
-      novas_error(0, EINVAL, fn, "timescale %d not supported.", timescale);
+      novas_set_errno(EINVAL, fn, "timescale %d not supported.", timescale);
       return NAN;
   }
 

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -980,7 +980,7 @@ static int test_planet_lon() {
   int n = 0;
 
   if(check_nan("planet_lon:-1", planet_lon(0.0, -1))) n++;
-  if(check_nan("planet_lon:hi", planet_lon(0.0, NOVAS_PLUTO + 1))) n++;
+  if(check_nan("planet_lon:pluto", planet_lon(0.0, NOVAS_PLUTO))) n++;
 
   return n;
 }

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -2397,6 +2397,32 @@ static int test_clock_skew() {
   return n;
 }
 
+static int test_cat_entry() {
+  int n = 0;
+  char *name = "blah", longname[SIZE_OF_OBJ_NAME + 2] = {};
+  cat_entry star = {};
+
+  if(check("cat_entry:init", -1, novas_init_cat_entry(NULL, name, 0.0, 0.0))) n++;
+
+  memset(longname, 'x', SIZE_OF_OBJ_NAME);
+  if(check("cat_entry:init:long", -1, novas_init_cat_entry(NULL, longname, 0.0, 0.0))) n++;
+
+  longname[SIZE_OF_OBJ_NAME + 1] = 'x';
+  if(check("cat_entry:init:verylong", -1, novas_init_cat_entry(NULL, longname, 0.0, 0.0))) n++;
+
+  if(check("cat_entry:set_catalog", -1, novas_set_catalog(NULL, name, 0))) n++;
+  if(check("cat_entry:set_proper_motion", -1, novas_set_proper_motion(NULL, 0.0, 0.0))) n++;
+  if(check("cat_entry:set_parallax", -1, novas_set_parallax(NULL, 0.0))) n++;
+  if(check("cat_entry:set_distance", -1, novas_set_distance(NULL, 0.0))) n++;
+  if(check("cat_entry:set_ssb_vel", -1, novas_set_ssb_vel(NULL, 0.0))) n++;
+  if(check("cat_entry:set_ssb_vel:hi", -1, novas_set_ssb_vel(&star, NOVAS_C + 1.0))) n++;
+  if(check("cat_entry:set_ssb_vel:lo", -1, novas_set_ssb_vel(&star, -(NOVAS_C + 1.0)))) n++;
+  if(check("cat_entry:set_lsr_vel", -1, novas_set_lsr_vel(NULL, 2000.0, 0.0))) n++;
+  if(check("cat_entry:set_redshift", -1, novas_set_redshift(NULL, 0.0))) n++;
+
+  return n;
+}
+
 int main(int argc, const char *argv[]) {
   int n = 0;
 
@@ -2599,6 +2625,7 @@ int main(int argc, const char *argv[]) {
   if(test_itrf_transform()) n++;
 
   if(test_clock_skew()) n++;
+  if(test_cat_entry()) n++;
 
   if(n) fprintf(stderr, " -- FAILED %d tests\n", n);
   else fprintf(stderr, " -- OK\n");

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -979,7 +979,8 @@ static int test_vector2radec() {
 static int test_planet_lon() {
   int n = 0;
 
-  if(check_nan("planet_lon", planet_lon(0.0, -1))) n++;
+  if(check_nan("planet_lon:-1", planet_lon(0.0, -1))) n++;
+  if(check_nan("planet_lon:hi", planet_lon(0.0, NOVAS_PLUTO + 1))) n++;
 
   return n;
 }
@@ -1478,6 +1479,7 @@ static int test_geom_to_app() {
   if(check("geom_to_app:frame:ok", 0, novas_geom_to_app(&frame, pos, NOVAS_ICRS, &out))) n++;
 
   if(check("geom_to_app:pos", -1, novas_geom_to_app(&frame, NULL, NOVAS_ICRS, &out))) n++;
+  if(check("geom_to_app:out", -1, novas_geom_to_app(&frame, pos, NOVAS_ICRS, NULL))) n++;
   if(check("geom_to_app:sys:-1", -1, novas_geom_to_app(&frame, pos, -1, &out))) n++;
   if(check("geom_to_app:sys:hi", -1, novas_geom_to_app(&frame, pos, NOVAS_REFERENCE_SYSTEMS, &out))) n++;
 

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -3946,6 +3946,11 @@ static int test_approx_heliocentric() {
   if(!is_ok("approx_heliocentric:neptune:2050:pos", check_equal_pos(pos, pos0, 2e-2))) n++;
   if(!is_ok("approx_heliocentric:neptune:2050:vel", check_equal_pos(vel, vel0, 1e-2))) n++;
 
+
+  // Check that both Pluto and its barycenter process
+  if(!is_ok("approx_heliocentric:neptune:2050", novas_approx_heliocentric(NOVAS_PLUTO, 2469936.0, pos, vel))) n++;
+  if(!is_ok("approx_heliocentric:neptune:2050", novas_approx_heliocentric(NOVAS_PLUTO_BARYCENTER, 2469936.0, pos0, vel0))) n++;
+
   return n;
 }
 
@@ -4453,6 +4458,47 @@ static int test_clock_skew() {
   return n;
 }
 
+static int test_init_cat_entry() {
+  int n = 0;
+
+  cat_entry star = {};
+
+  if(!is_ok("init_cat_entry", novas_init_cat_entry(&star, "TEST", 2.0, 3.0))) n++;
+  if(!is_ok("init_cat_entry:check:name", strcmp(star.starname, "TEST"))) n++;
+  if(!is_equal("init_cat_entry:check:ra", star.ra, 2.0, 1e-16)) n++;
+  if(!is_equal("init_cat_entry:check:dec", star.dec, 3.0, 1e-16)) n++;
+
+  if(!is_ok("init_cat_entry:no_name", novas_init_cat_entry(&star, NULL, -2.0, -3.0))) n++;
+  if(!is_ok("init_cat_entry:no_name:check:name", strcmp(star.starname, ""))) n++;
+  if(!is_equal("init_cat_entry:no_name:check:ra", star.ra, -2.0, 1e-16)) n++;
+  if(!is_equal("init_cat_entry:no_name:check:dec", star.dec, -3.0, 1e-16)) n++;
+
+  return n;
+}
+
+static int test_set_lsr_vel() {
+  int n = 0;
+
+  cat_entry star = {};
+  if(!is_ok("set_lsr_vel:init", novas_init_cat_entry(&star, "TEST", 0.0, 0.0))) n++;
+  if(!is_ok("set_lsr_vel", novas_set_lsr_vel(&star, 2000.0, 0.0))) n++;
+  if(!is_equal("set_lsr_vel:check", star.radialvelocity, novas_lsr_to_ssb_vel(2000, star.ra, star.dec, 0.0), 1e-12)) n++;
+
+  return n;
+}
+
+static int test_set_distance() {
+  int n = 0;
+
+  cat_entry star = {};
+  if(!is_ok("set_distance:init", novas_init_cat_entry(&star, "TEST", 0.0, 0.0))) n++;
+  if(!is_ok("set_distance", novas_set_distance(&star, 10000.0))) n++;
+  if(!is_equal("set_distance:check", star.parallax, 0.1, 1e-12)) n++;
+
+  return n;
+}
+
+
 int main(int argc, char *argv[]) {
   int n = 0;
 
@@ -4581,6 +4627,7 @@ int main(int argc, char *argv[]) {
 
   if(test_tt2tdb_hp()) n++;
 
+  // v 1.5
   if(test_libration()) n++;
   if(test_ocean_tides()) n++;
   if(test_diurnal_eop_at_time()) n++;
@@ -4590,6 +4637,10 @@ int main(int argc, char *argv[]) {
   if(test_itrf_transform()) n++;
   if(test_itrf_transform_eop()) n++;
   if(test_clock_skew()) n++;
+
+  if(test_init_cat_entry()) n++;
+  if(test_set_lsr_vel()) n++;
+  if(test_set_distance()) n++;
 
   n += test_dates();
 


### PR DESCRIPTION
New functions to define `cat_entry`data step-by-step, and with more flexibility than the NOVAS C `make_cat_entry()`...

1. Initialize the `cat_entry` with source name and RA/Dec coordinates using `novas_init_cat_entry()`.
2. (optional) Set radial velocity, as needed, via either:
   (a) radial velocity w.r.t SSB using `novas_set_ssb_vel()`, or
   (b) LSR velocity using `novas_set_lsr_vel()`, or
   (c) redshift using `novas_set_redshift()`.
3. (optional) Set proper motions (mas/yr), as needed, using `novas_set_proper_motion()`.
4. (optional) Set parallax, as needed, via either:
   (a) parallax (mas) using `novas_set_parallax()`, or
   (b) distance (parcsec) using `novas_set_distance()`.
5. (optional) Assign catalog info if desired via `novas_set_catalog()`.
 