### PR TITLE
Option to exclude deprecated definitions from novas.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ Upcoming feature release, expected around 1 November 2025.
  - #246: New `novas_geodetic_transform_site()` and `novas_itrf_transform_site()` convenience functions to make it 
    simpler to change the reference ellipsoid or the ITRF realization of an `on_surface` data structure, respectively.
 
+ - #249: Option to exclude deprecated API from `novas.h` defitions for your application. Simplt compile your 
+   application with `-D_EXCLUDE_DEPRECATED` or else define `EXCLUDE_DEPRECATED` in your source __before_ including
+   `novas.h`. 
+
 ### Changed
 
  - #208: `cio_location()` now always returns the CIO's right ascension relative to the true equinox of date (on the 

--- a/README.md
+++ b/README.md
@@ -381,8 +381,10 @@ needs best:
 
  - [Using a GNU `Makefile`](#makefile-application)
  - [Using CMake](#cmake-application)
+ - [Deprecated API](#deprecations)
  - [Legacy linking `solarsystem()` and `readeph()` modules](#legacy-application)
  - [Legacy modules: a better way](#preferred-legacy-application)
+
 
 <a name="makefile-application"></a>
 ### Using a GNU `Makefile`
@@ -437,6 +439,30 @@ Add the appropriate bits from below to the `CMakeLists.txt` file of your applica
 ```
 
 </details>
+
+<a name="deprecations"></a>
+### Deprecated API
+
+__SuperNOVAS__ began deprecating some NOVAS C functions, either because they are no longer needed; or are not easy to 
+use with better alternatives around; or are internals that should never have been exposed to end-users. The 
+deprecations are marked in the inline and HTML API documentations, providing also alternatives. 
+
+That said, the deprecated parts of the API are NOT removed, nor we plan on removing them for the foreseeable future. 
+Instead, they serve as a gentle reminder to users that perhaps they should stay away from these features for their own 
+good.
+
+However, you have the option to force yourself to avoid using the deprecated API if you choose to do so, by compiling
+your application with `-D_EXCLUDE_DEPRECATED`, or equivalently, by defining `_EXCLUDE_DEPRECATED` in your source code 
+_before_ including `novas.h`. E.g.:
+
+```c
+// Include novas.h without the deprecated definitions
+#define _EXCLUDE_DEPRECATED
+#include <novas.h>
+```
+
+After that, your compiler will complain if your source code references any of the deprecated entities, so you may 
+change that part of your code to use the recommended alternatives instead.
 
 <a name="legacy-application"></a>
 ### Legacy linking `solarsystem()` and `readeph()` modules

--- a/include/novas.h
+++ b/include/novas.h
@@ -685,11 +685,15 @@ enum novas_origin {
  */
 #define NOVAS_ORIGIN_TYPES        (NOVAS_HELIOCENTER + 1)
 
+#ifndef _EXCLUDE_DEPRECATED
+
 /** @deprecated Old definition of the Barycenter origin. NOVAS_BARYCENTER is preferred. */
-#define BARYC                     NOVAS_BARYCENTER
+#  define BARYC                     NOVAS_BARYCENTER
 
 /** @deprecated Old definition of the Center of Sun as the origin. NOVAS_HELIOCENTER is preferred. */
-#define HELIOC                    NOVAS_HELIOCENTER
+#  define HELIOC                    NOVAS_HELIOCENTER
+
+#endif // _EXCLUDE_DEPRECATED
 
 /**
  * The types of coordinate transformations available for tranform_cat().
@@ -1652,17 +1656,25 @@ short virtual_planet(double jd_tt, const object *restrict ss_body, enum novas_ac
 short astro_planet(double jd_tt, const object *restrict ss_body, enum novas_accuracy accuracy,
         double *restrict ra, double *restrict dec, double *restrict dis);
 
+#ifndef _EXCLUDE_DEPRECATED
 short topo_star(double jd_tt, double ut1_to_tt, const cat_entry *restrict star, const on_surface *restrict position,
         enum novas_accuracy accuracy, double *restrict ra, double *restrict dec);
+#endif
 
+#ifndef _EXCLUDE_DEPRECATED
 short local_star(double jd_tt, double ut1_to_tt, const cat_entry *restrict star, const on_surface *restrict position,
         enum novas_accuracy accuracy, double *restrict ra, double *restrict dec);
+#endif
 
+#ifndef _EXCLUDE_DEPRECATED
 short topo_planet(double jd_tt, const object *restrict ss_body, double ut1_to_tt, const on_surface *restrict position,
         enum novas_accuracy accuracy, double *restrict ra, double *restrict dec, double *restrict dis);
+#endif
 
+#ifndef _EXCLUDE_DEPRECATED
 short local_planet(double jd_tt, const object *restrict ss_body, double ut1_to_tt, const on_surface *restrict position,
         enum novas_accuracy accuracy, double *restrict ra, double *restrict dec, double *restrict dis);
+#endif
 
 short mean_star(double jd_tt, double tra, double tdec, enum novas_accuracy accuracy,
         double *restrict ira, double *restrict idec);
@@ -1685,9 +1697,11 @@ short equ2ecl_vec(double jd_tt, enum novas_equator_type coord_sys, enum novas_ac
 short ecl2equ_vec(double jd_tt, enum novas_equator_type coord_sys, enum novas_accuracy accuracy,
         const double *in, double *out);
 
+#ifndef _EXCLUDE_DEPRECATED
 int equ2hor(double jd_ut1, double ut1_to_tt, enum novas_accuracy accuracy, double xp, double yp,
         const on_surface *restrict location, double ra, double dec, enum novas_refraction_model ref_option,
         double *restrict zd, double *restrict az, double *restrict rar, double *restrict decr);
+#endif
 
 // in system.c
 int frame_tie(const double *in, enum novas_frametie_direction direction, double *out);
@@ -1695,16 +1709,22 @@ int frame_tie(const double *in, enum novas_frametie_direction direction, double 
 short gcrs2equ(double jd_tt, enum novas_dynamical_type sys, enum novas_accuracy accuracy, double rag, double decg,
         double *restrict ra, double *restrict dec);
 
+#ifndef _EXCLUDE_DEPRECATED
 short sidereal_time(double jd_ut1_high, double jd_ut1_low, double ut1_to_tt, enum novas_equinox_type gst_type,
         enum novas_earth_rotation_measure erot, enum novas_accuracy accuracy, double *restrict gst);
+#endif
 
+#ifndef _EXCLUDE_DEPRECATED
 short ter2cel(double jd_ut1_high, double jd_ut1_low, double ut1_to_tt, enum novas_earth_rotation_measure erot,
         enum novas_accuracy accuracy, enum novas_equatorial_class coordType, double xp, double yp, const double *in,
         double *out);
+#endif
 
+#ifndef _EXCLUDE_DEPRECATED
 short cel2ter(double jd_ut1_high, double jd_ut1_low, double ut1_to_tt, enum novas_earth_rotation_measure erot,
         enum novas_accuracy accuracy, enum novas_equatorial_class coordType, double xp, double yp, const double *in,
         double *out);
+#endif
 
 // in util.c
 int spin(double angle, const double *in, double *out);
@@ -1714,8 +1734,6 @@ double d_light(const double *pos_src, const double *pos_body);
 short vector2radec(const double *restrict pos, double *restrict ra, double *restrict dec);
 
 int radec2vector(double ra, double dec, double dist, double *restrict pos);
-
-double novas_norm_ang(double angle);
 
 // in earth.c
 double era(double jd_ut1_high, double jd_ut1_low);
@@ -1727,10 +1745,14 @@ int terra(const on_surface *restrict location, double lst, double *restrict pos,
 int e_tilt(double jd_tdb, enum novas_accuracy accuracy, double *restrict mobl, double *restrict tobl,
         double *restrict ee, double *restrict dpsi, double *restrict deps);
 
+#ifndef _EXCLUDE_DEPRECATED
 short cel_pole(double jd_tt, enum novas_pole_offset_type type, double dpole1, double dpole2);
+#endif
 
 // in equinox.c
+#ifndef _EXCLUDE_DEPRECATED
 double ee_ct(double jd_tt_high, double jd_tt_low, enum novas_accuracy accuracy);
+#endif
 
 int fund_args(double t, novas_delaunay_args *restrict a);
 
@@ -1774,12 +1796,18 @@ int tdb2tt(double jd_tdb, double *restrict jd_tt, double *restrict secdiff);
 // in  cio.c
 short cio_ra(double jd_tt, enum novas_accuracy accuracy, double *restrict ra_cio);
 
+#ifndef _EXCLUDE_DEPRECATED
 short cio_location(double jd_tdb, enum novas_accuracy accuracy, double *restrict ra_cio, short *restrict loc_type);
+#endif
 
+#ifndef _EXCLUDE_DEPRECATED
 short cio_basis(double jd_tdb, double ra_cio, enum novas_cio_location_type loc_type, enum novas_accuracy accuracy,
         double *restrict x, double *restrict y, double *restrict z);
+#endif
 
+#ifndef _EXCLUDE_DEPRECATED
 short cio_array(double jd_tdb, long n_pts, ra_of_cio *restrict cio);
+#endif
 
 // in refract.c
 double refract(const on_surface *restrict location, enum novas_refraction_model model, double zd_obs);
@@ -1800,13 +1828,17 @@ int transform_hip(const cat_entry *hipparcos, cat_entry *hip_2000);
 
 int starvectors(const cat_entry *restrict star, double *restrict pos, double *restrict motion);
 
+#ifndef _EXCLUDE_DEPRECATED
 short make_object(enum novas_object_type, long number, const char *name, const cat_entry *star, object *source);
+#endif
 
 int proper_motion(double jd_tdb_in, const double *pos, const double *restrict vel, double jd_tdb_out, double *out);
 
 // in observer.c
+#ifndef _EXCLUDE_DEPRECATED
 short make_observer(enum novas_observer_place, const on_surface *loc_surface, const in_space *loc_space,
         observer *obs);
+#endif
 
 int make_observer_at_geocenter(observer *restrict obs);
 
@@ -1815,8 +1847,10 @@ int make_observer_on_surface(double latitude, double longitude, double height, d
 
 int make_observer_in_space(const double *sc_pos, const double *sc_vel, observer *obs);
 
+#ifndef _EXCLUDE_DEPRECATED
 int make_on_surface(double latitude, double longitude, double height, double temperature, double pressure,
         on_surface *restrict loc);
+#endif
 
 int make_in_space(const double *sc_pos, const double *sc_vel, in_space *loc);
 
@@ -1836,6 +1870,8 @@ void novas_debug(enum novas_debug_mode mode);
 
 enum novas_debug_mode novas_get_debug_mode();
 
+double novas_norm_ang(double angle);
+
 // in target.c
 void novas_case_sensitive(int value);
 
@@ -1844,7 +1880,9 @@ int make_planet(enum novas_planet num, object *restrict planet);
 int make_ephem_object(const char *name, long num, object *body);
 
 // in cio.c
+#ifndef _EXCLUDE_DEPRECATED
 int set_cio_locator_file(const char *restrict filename);
+#endif
 
 // in plugin.c
 int set_nutation_lp_provider(novas_nutation_provider func);

--- a/include/solarsystem.h
+++ b/include/solarsystem.h
@@ -200,7 +200,7 @@ typedef int (*novas_ephem_provider)(const char *name, long id, double jd_tdb_hig
         enum novas_origin *restrict origin, double *restrict pos, double *restrict vel);
 
 
-
+#ifndef _EXCLUDE_DEPRECATED
 /**
  * @deprecated This old ephemeris reader is prone to memory leaks, and lacks some useful
  *             functionality. Users are strongly encouraged to use the new
@@ -243,7 +243,7 @@ typedef int (*novas_ephem_provider)(const char *name, long id, double jd_tdb_hig
  * @sa NOVAS_EPHEM_OBJECT
  */
 double *readeph(int mp, const char *restrict name, double jd_tdb, int *restrict error);
-
+#endif
 
 int set_planet_provider(novas_planet_provider func);
 
@@ -253,7 +253,7 @@ int set_ephem_provider(novas_ephem_provider func);
 
 novas_ephem_provider get_ephem_provider();
 
-
+#ifndef _EXCLUDE_DEPRECATED
 /**
  * @deprecated (<i>legacy function</i>) Use `set_planet_provider()` instead to specify what
  *             function should be used to calculate ephemeris positions for major planets. This
@@ -296,8 +296,9 @@ novas_ephem_provider get_ephem_provider();
  * @sa ephemeris()
  */
 short solarsystem(double jd_tdb, short body, short origin, double *restrict position, double *restrict velocity);
+#endif
 
-
+#ifndef _EXCLUDE_DEPRECATED
 /**
  * @deprecated (<i>legacy function</i>) Use `set_planet_provider_hp()` instead to specify what
  *             function should be used to calculate high-precision ephemeris positions for major
@@ -341,7 +342,7 @@ short solarsystem(double jd_tdb, short body, short origin, double *restrict posi
  * @sa ephemeris()
  */
 short solarsystem_hp(const double jd_tdb[restrict 2], short body, short origin, double *restrict position, double *restrict velocity);
-
+#endif
 
 short earth_sun_calc(double jd_tdb, enum novas_planet body, enum novas_origin origin, double *restrict position,
         double *restrict velocity);

--- a/src/equinox.c
+++ b/src/equinox.c
@@ -337,9 +337,6 @@ double novas_gmst_prec(double jd_tdb) {
 /// \endcond
 
 /**
- * @deprecated      (<i>for internal use</i>) There is no good reason why this function should
- *                  be exposed to users. It is intended only for `cio_location()` internally.
- *
  * Compute the intermediate right ascension of the equinox at the input Julian date, using an
  * analytical expression for the accumulated precession in right ascension.  For the true
  * equinox, the result is the equation of the origins.

--- a/src/grav.c
+++ b/src/grav.c
@@ -34,9 +34,10 @@ int grav_bodies_full_accuracy = DEFAULT_GRAV_BODIES_FULL_ACCURACY;
  *
  * NOTES:
  * <ol>
- * <li>This function is called by place() to calculate gravitational deflections as
- * appropriate for positioning sources precisely. The gravitational deflection due to
- * planets requires a planet calculator function to be configured, e.g. via set_planet_provider().
+ * <li>This function is called by place() and `novas_sky_pos()` to calculate gravitational
+ * deflections as appropriate for positioning sources precisely. The gravitational deflection due
+ * to planets requires a planet calculator function to be configured, e.g.
+ * via set_planet_provider().
  * </li>
  * </ol>
  *

--- a/src/observer.c
+++ b/src/observer.c
@@ -33,7 +33,7 @@
  *                will be available for the foreseeable future also.
  *
  * Populates an 'observer' data structure given the parameters. The output data structure may
- * be used an the the inputs to NOVAS-C function 'place()'.
+ * be used an the the inputs to NOVAS-C functions, such as `make_frame()` or `place()`.
  *
  * @param where         The location type of the observer
  * @param loc_surface   Pointer to data structure that defines a location on Earth's surface.
@@ -95,8 +95,8 @@ short make_observer(enum novas_observer_place where, const on_surface *loc_surfa
 
 /**
  * Populates an 'observer' data structure for a hypothetical observer located at Earth's
- * geocenter. The output data structure may be used an the the inputs to NOVAS-C function
- * 'place()'.
+ * geocenter. The output data structure may be used an the the inputs to NOVAS-C functions,
+ * such as `make_frame()` or `place()`.
  *
  * @param[out] obs    Pointer to data structure to populate.
  * @return          0 if successful, or -1 if the output argument is NULL.
@@ -135,11 +135,11 @@ int make_observer_at_geocenter(observer *restrict obs) {
  * to use make_gps_observer() intead</li>
  * </ol>
  *
- * @param latitude      [deg] Geodetic (ITRF / GRS80) latitude in degrees; north positive.
- * @param longitude     [deg] Geodetic (ITRF / GRS80) longitude in degrees; east positive.
+ * @param latitude      [deg] Geodetic (ITRF / GRS80) latitude; north positive.
+ * @param longitude     [deg] Geodetic (ITRF / GRS80) longitude; east positive.
  * @param height        [m] Geodetic (ITRF / GRS80) altitude above sea level of the observer.
  * @param temperature   [C] Temperature (degrees Celsius).
- * @param pressure      [mbar] Atmospheric pressure (millibars).
+ * @param pressure      [mbar] Atmospheric pressure.
  * @param[out] obs      Pointer to the data structure to populate.
  *
  * @return              0 if successful, or -1 if the output argument is NULL, or if the latitude
@@ -202,8 +202,8 @@ int make_observer_at_site(const on_surface *restrict site, observer *restrict ob
  * `novas_itrf_transform_eop()` to change the ITRF realization for the EOP values,
  * if necessary.
  *
- * @param latitude      [deg] Geodetic (ITRF / GRS80) latitude in degrees; north positive.
- * @param longitude     [deg] Geodetic (ITRF / GRS80) longitude in degrees; east positive.
+ * @param latitude      [deg] Geodetic (ITRF / GRS80) latitude; north positive.
+ * @param longitude     [deg] Geodetic (ITRF / GRS80) longitude; east positive.
  * @param height        [m] Geodetic (ITRF / GRS80) altitude above sea level of the observer.
  * @param[out] obs      Pointer to the data structure to populate.
  *
@@ -233,8 +233,8 @@ int make_itrf_observer(double latitude, double longitude, double height, observe
  * For the highest (&mu;as / mm level) precision, you probably should use an ITRF location
  * instead of a GPS based location.
  *
- * @param latitude      [deg] Geodetic (GPS / WGS84) latitude in degrees; north positive.
- * @param longitude     [deg] Geodetic (GPS / WGS84) longitude in degrees; east positive.
+ * @param latitude      [deg] Geodetic (GPS / WGS84) latitude north positive.
+ * @param longitude     [deg] Geodetic (GPS / WGS84) longitude east positive.
  * @param height        [m] Geodetic (GPS / WGS84) altitude above sea level of the observer.
  * @param[out] obs      Pointer to the data structure to populate.
  *
@@ -261,10 +261,10 @@ int make_gps_observer(double latitude, double longitude, double height, observer
  * Populates an 'observer' data structure, for an observer situated on a near-Earth spacecraft,
  * with the specified geocentric position and velocity vectors. Both input vectors are with
  * respect to true equator and equinox of date. The output data structure may be used an the
- * the inputs to NOVAS-C function 'place()'.
+ * the inputs to NOVAS-C functions, such as `make_frame()` or `place()`.
  *
- * @param sc_pos        [km] Geocentric (x, y, z) position vector in km.
- * @param sc_vel        [km/s] Geocentric (x, y, z) velocity vector in km/s.
+ * @param sc_pos        [km] Geocentric (x, y, z) position vector.
+ * @param sc_vel        [km/s] Geocentric (x, y, z) velocity vector.
  * @param[out] obs      Pointer to the data structure to populate
  * @return          0 if successful, or -1 if the output argument is NULL.
  *
@@ -313,11 +313,11 @@ int make_observer_in_space(const double *sc_pos, const double *sc_vel, observer 
  * </li>
  * </ol>
  *
- * @param latitude      [deg] Geodetic (ITRF / GRS80) latitude in degrees; north positive.
- * @param longitude     [deg] Geodetic (ITRF / GRS80) longitude in degrees; east positive.
+ * @param latitude      [deg] Geodetic (ITRF / GRS80) latitude; north positive.
+ * @param longitude     [deg] Geodetic (ITRF / GRS80) longitude; east positive.
  * @param height        [m] Geodetic (ITRF / GSR80) altitude above sea level of the observer.
  * @param temperature   [C] Temperature (degrees Celsius) [-120:70].
- * @param pressure      [mbar] Atmospheric pressure (millibars) [0:1200].
+ * @param pressure      [mbar] Atmospheric pressure [0:1200].
  * @param[out] loc      Pointer to Earth location data structure to populate.
  *
  * @return          0 if successful, or -1 if the output argument is NULL (errno set to EINVAL),
@@ -359,8 +359,8 @@ int make_on_surface(double latitude, double longitude, double height, double tem
  * `novas_itrf_transform_eop()` to change the ITRF realization for the EOP values,
  * if necessary.
  *
- * @param latitude      [deg] Geodetic (ITRF / GRS80) latitude in degrees; north positive.
- * @param longitude     [deg] Geodetic (ITRF / GRS80) longitude in degrees; east positive.
+ * @param latitude      [deg] Geodetic (ITRF / GRS80) latitude; north positive.
+ * @param longitude     [deg] Geodetic (ITRF / GRS80) longitude; east positive.
  * @param height        [m] Geodetic (ITRF / GRS80) altitude above sea level of the observer.
  * @param[out] site     Pointer to the data structure to populate.
  *
@@ -399,8 +399,8 @@ int make_itrf_site(double latitude, double longitude, double height, on_surface 
  * For the highest (&mu;as / mm level) precision, you probably should use an ITRF location
  * instead of a GPS based location.
  *
- * @param latitude      [deg] Geodetic (GPS / WGS84) latitude in degrees; north positive.
- * @param longitude     [deg] Geodetic (GPS / WGS84) longitude in degrees; east positive.
+ * @param latitude      [deg] Geodetic (GPS / WGS84) latitude; north positive.
+ * @param longitude     [deg] Geodetic (GPS / WGS84) longitude; east positive.
  * @param height        [m] Geodetic (GPS / WGS84) altitude above sea level of the observer.
  * @param[out] site     Pointer to the data structure to populate.
  *
@@ -465,9 +465,8 @@ int make_xyz_site(const double *restrict xyz, on_surface *restrict site) {
  * with the provided position and velocity components. Both input vectors are assumed with respect
  * to true equator and equinox of date.
  *
- * @param sc_pos    [km] Geocentric (x, y, z) position vector in km. NULL defaults to the origin
- * @param sc_vel    [km/s] Geocentric (x, y, z) velocity vector in km/s. NULL defaults to zero
- *                  speed.
+ * @param sc_pos    [km] Geocentric (x, y, z) position vector. NULL defaults to the origin
+ * @param sc_vel    [km/s] Geocentric (x, y, z) velocity vector. NULL defaults to zero speed.
  * @param[out] loc  Pointer to earth-orbit location data structure to populate.
  * @return          0 if successful, or -1 if the output argument is NULL.
  *
@@ -553,8 +552,8 @@ int make_solar_system_observer(const double *sc_pos, const double *sc_vel, obser
  *
  * NOTES:
  * <ol>
- * <li>This function is called by place() to account for aberration when calculating the position
- * of the source.</li>
+ * <li>This function is called by `place()` to account for aberration when calculating the
+ * position of the source.</li>
  * </ol>
  *
  * REFERENCES:
@@ -566,14 +565,14 @@ int make_solar_system_observer(const double *sc_pos, const double *sc_vel, obser
  * @param pos         [AU]  Position vector of source relative to observer
  * @param vobs        [AU/day]  Velocity vector of observer, relative to the solar system
  *                    barycenter.
- * @param lighttime   [day] Light time from object to Earth in days (if known). Or set to 0, and
- *                    this function will compute it.
+ * @param lighttime   [day] Light time from object to Earth (if known). Or set to 0, and this
+ *                    function will compute it as needed.
  * @param[out] out    [AU] Position vector, referred to origin at center of mass of the Earth,
  *                    corrected for aberration. It can be the same vector as one of the inputs.
  *
  * @return            0 if successful, or -1 if any of the vector arguments are NULL.
  *
- * @sa novas_make_frame()
+ * @sa frame_aberration()
  */
 int aberration(const double *pos, const double *vobs, double lighttime, double *out) {
   double p1mag, vemag, beta, cosd, gammai, p, q, r;
@@ -719,15 +718,13 @@ int obs_posvel(double jd_tdb, double ut1_to_tt, enum novas_accuracy accuracy, co
  * <li>Kaplan, G. H. et. al. (1989). Astron. Journ. 97, 1197-1210.</li>
  * </ol>
  *
- * @param pos             [AU] Position vector, referred to origin at solar system barycenter,
- *                        components in AU.
+ * @param pos             [AU] Position vector, referred to origin at solar system barycenter.
  * @param pos_obs         [AU] Position vector of observer (or the geocenter), with respect to
- *                        origin at solar system barycenter, components in AU.
- * @param[out] out        [AU] Position vector, referred to origin at center of mass of the Earth,
- *                        components in AU. It may be NULL if not required, or be the same vector
- *                        as either of the inputs.
- * @param[out] lighttime  [day] Light time from object to Earth in days. It may be NULL if not
- *                        required.
+ *                        origin at solar system barycenter.
+ * @param[out] out        [AU] Position vector, referred to origin at center of mass of the Earth.
+ *                        It may be NULL if not required, or be the same vector as either of the
+ *                        inputs.
+ * @param[out] lighttime  [day] Light time from object to Earth. It may be NULL if not required.
  * @return                0 if successful, or -1 if any of the essential pointer arguments is
  *                        NULL.
  *
@@ -854,23 +851,23 @@ int obs_planets(double jd_tdb, enum novas_accuracy accuracy, const double *restr
  *
  * NOTES:
  * <ol>
- * <li>This function is called by place() to calculate observed positions, radial velocity,
- * and distance for the time when the observed light originated from the source.</li>
+ * <li>This function is called by `novas_geom_posvel()` or `place()` to calculate observed
+ * positions, radial velocity, and distance for the time when the observed light originated
+ * from the source.</li>
  * </ol>
  *
  * @param jd_tdb          [day] Barycentric Dynamical Time (TDB) based Julian date
  * @param body            Pointer to structure containing the designation for the solar system
  *                        body
  * @param pos_obs         [AU] Position 3-vector of observer (or the geocenter), with respect
- *                        to origin at solar system barycenter, referred to ICRS axes,
- *                        components in AU.
- * @param tlight0         [day] First approximation to light-time, in days (can be set to 0.0
- *                        if unknown).
+ *                        to origin at solar system barycenter, referred to ICRS axes.
+ * @param tlight0         [day] First approximation to light-time (can be set to 0.0 if not
+ *                        readily avasilable -- so it will be calculated as needed).
  * @param accuracy        NOVAS_FULL_ACCURACY (0) or NOVAS_REDUCED_ACCURACY (1)
  * @param[out] p_src_obs  [AU] Position 3-vector of body, relative to observer, referred to ICRS
  *                        axes, components in AU.
  * @param[out] v_ssb      [AU/day] Velocity 3-vector of body, with respect to the Solar-system
- *                        barycenter, referred to ICRS axes, components in AU/day.
+ *                        barycenter, referred to ICRS axes.
  * @param[out] tlight     [day] Calculated light time, or NAN when returning with an error code.
  *
  * @return            0 if successful, -1 if any of the pointer arguments is NULL or if the
@@ -878,7 +875,8 @@ int obs_planets(double jd_tdb, enum novas_accuracy accuracy, const double *restr
  *                    the algorithm failed to converge after 10 iterations, or 10 + the error
  *                    from ephemeris().
  *
- * @sa light_time(), novas_make_frame()
+ * @sa light_time()
+ * @sa novas_sky_pos()
  *
  * @since 1.0
  * @author Attila Kovacs
@@ -942,8 +940,8 @@ int light_time2(double jd_tdb, const object *restrict body, const double *restri
  * @param body        Pointer to structure containing the designation for the solar system body
  * @param pos_obs     [AU] Position 3-vector of observer (or the geocenter), with respect to
  *                    origin at solar system barycenter, referred to ICRS axes.
- * @param tlight0     [day] First approximation to light-time, in days (can be set to 0.0 if
- *                    unknown).
+ * @param tlight0     [day] First approximation to light-time (can be set to 0.0 if not readily
+ *                    available -- it will then be computed as needed).
  * @param accuracy    NOVAS_FULL_ACCURACY (0) or NOVAS_REDUCED_ACCURACY (1)
  * @param[out] pos_src_obs    [AU] Position 3-vector of body, with respect to origin at observer
  *                            (or the geocenter), referred to ICRS axes. It can be the same vector

--- a/src/spectral.c
+++ b/src/spectral.c
@@ -427,8 +427,8 @@ int rad_vel(const object *restrict source, const double *restrict pos_src, const
  *
  * NOTES:
  * <ol>
- * <li>This function is called by place() and novas_sky_pos() to calculate radial velocities along
- * with the apparent position of the source.</li>
+ * <li>This function is called by `novas_sky_pos()` and `place()` to calculate radial velocities
+ * along with the apparent position of the source.</li>
  * <li>For major planets (and Sun and Moon), the radial velocity includes gravitational redshift
  * corrections for light originating at the surface, assuming it's observed from near Earth or
  * else from a large distance away.</li>
@@ -469,7 +469,7 @@ int rad_vel(const object *restrict source, const double *restrict pos_src, const
  * @author Attila Kovacs
  *
  * @sa rad_vel()
- * @sa novas_make_frame(), novas_sky_pos(), novas_v2z()
+ * @sa novas_sky_pos(), novas_v2z()
  */
 double rad_vel2(const object *restrict source, const double *pos_emit, const double *vel_src, const double *pos_det, const double *vel_obs,
         double d_obs_geo, double d_obs_sun, double d_src_sun) {

--- a/src/util.c
+++ b/src/util.c
@@ -481,7 +481,7 @@ int radec2vector(double ra, double dec, double dist, double *restrict pos) {
  *
  * NOTES:
  * <ol>
- * <li>This function is called by place()</li>
+ * <li>This function is called by `novas_geom_posvel()`, novas_sky_pos(), or `place()`</li>
  * </ol>
  *
  * @param pos_src   Position vector towards observed object, with respect to the SSB
@@ -493,7 +493,7 @@ int radec2vector(double ra, double dec, double dist, double *restrict pos) {
  *                  (<i>Usage A</i>) or relative intermediate solar-system body
  *                  (<i>Usage B</i>); or else NAN if either of the input arguments is NULL.
  *
- * @sa novas_make_frame()
+ * @sa novas_sky_pos(), novas_geom_posvel()
  */
 double d_light(const double *pos_src, const double *pos_body) {
   double d_src;


### PR DESCRIPTION
You can define `_EXCLUDE_DEPRECATED`, either as a compiler option `-D_EXCLUDE_DEPRECATED`, or else in your source code by defining `_EXCLUDE_DEPRECATED` __before__ including `novas.h`, to exclude deprecated definitions. E.g.,

```c
// Include novas.h without the deprecated API
#define _EXCLUDE_DEPRECATED
#include <novas.h>
```
