### PR TITLE
Tweak build configs

### DIFF
--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -32,22 +32,19 @@ jobs:
         include:
           - os: ubuntu-latest
             cc: gcc
-            cxx: g++
-            cmopt:
+            opt:
           - os: macos-latest
             cc: clang
-            cxx: clang++
-            cmopt:
+            opt:
           - os: windows-latest
             cc: gcc
-            cxx: g++
-            cmopt: -G "MinGW Makefiles"
+            opt: -G "MinGW Makefiles"
 
     steps:
       - uses: actions/checkout@v5
 
       - name: Configure CMake (Unix)
-        run: cmake -B build ${{ matrix.cmopt }} -DBUILD_SHARED_LIBS=ON -DBUILD_EXAMPLES=ON -DBUILD_BENCHMARK=ON -DENABLE_SOLSYS1=ON  -DCMAKE_C_COMPILER=${{ matrix.cc }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
+        run: cmake -B build -DCMAKE_C_COMPILER=${{ matrix.cc }} ${{ matrix.opt }} -DBUILD_SHARED_LIBS=ON -DBUILD_EXAMPLES=ON -DBUILD_BENCHMARK=ON
 
       - name: Build
         run: cmake --build build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,11 +53,8 @@ jobs:
       - name: Build shared library
         run: make shared
 
-      - name: Compile solsys variants
+      - name: Compile solsys plugins
         run: make solsys
-
-      - name: Generate legacy CIO locator data
-        run: make legacy
 
       - name: Build examples
         run: make examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,10 +77,6 @@ Upcoming feature release, expected around 1 November 2025.
 
  - #250: No longer including `CIO_RA.TXT` (now unused) in the distribution.
  
- - #252: Removed the option to build `libsolsys1` / `libsolsys2`, `libsolsys3`, and `libsolsys-ephem` as separate 
-   libraries. The source codes for the former two are available in the `legacy/` folder for those who need it, while 
-   the latter two are always integral to the `libsupernovas` library.
- 
  - #252: Some build configuration options have been removed, such as the GNU make `BUILTIN_SOLSYS1`, `BUILTIN_SOLSYS2`,
    `BUILTIN_SOLSYS3`, `BUILTIN_SOLSYS_EPHEM`, `DEFAULT_SOLSYS`, and `DEFAULT_READEPH` configuration options, or the
    CMake `BUILD_SOLSYS1` / `BUILD_SOLSYS2` options.
@@ -132,7 +128,7 @@ Upcoming feature release, expected around 1 November 2025.
    
  - #251: Added further CI checks via Github Actions.
 
- - #252: Overhauled how legacy `solarsystem()` / `solarsystem_hp()` and `readeph()` functions can be added to the
+ - #252: Overhauled how legacy `solarsystem()` / `solarsystem_hp()` and `readeph()` functions can be added to the 
    build if needed, e.g. via externally provided sources at build time. If a `solarsystem()` / `solarsystem_hp()` 
    module is not explicitly defined for the build, `solsys3.c` will provide a default implementation for these.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,9 @@ add_library(novas ALIAS supernovas)
 # Plugins
 
 # plugins via external libraries (e.g. calceph or cspice). 
-function(solsys_plugin PLUGIN)
+function(solsys_plugin EPHEM_LIB)
+    set(PLUGIN solsys-${EPHEM_LIB})
+    
     add_library(${PLUGIN} src/${PLUGIN}.c)
     add_library(supernovas::${PLUGIN} ALIAS ${PLUGIN})
 

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,6 @@ include config.mk
 # Specific build targets and recipes below...
 # ===============================================================================
 
-# The version of the shared .so libraries
-SO_VERSION := 1
-
 # We'll need math functions to link
 LDFLAGS += -lm
 
@@ -113,6 +110,7 @@ dox:
 local-dox:
 	$(MAKE) -C doc
 
+
 # ----------------------------------------------------------------------------
 # The nitty-gritty stuff below
 # ----------------------------------------------------------------------------
@@ -152,7 +150,7 @@ INSTALL_PROGRAM ?= install
 INSTALL_DATA ?= install -m 644
 
 .PHONY: install
-install: install-libs install-headers install-docs
+install: install-libs install-headers install-docs install-legacy
 
 .PHONY: install-libs
 install-libs:
@@ -217,10 +215,9 @@ install-examples:
 
 .PHONY: install-legacy
 install-legacy:
-	@echo "installing legacy source code to $(DESTDIR)$(docdir)/legacy"
+	@echo "installing legacy files to $(DESTDIR)$(docdir)/legacy"
 	install -d $(DESTDIR)$(docdir)/legacy
 	$(INSTALL_DATA) legacy/* $(DESTDIR)$(docdir)/legacy/
-
 
 # Some standard GNU targets, that should always exist...
 .PHONY: html

--- a/README.md
+++ b/README.md
@@ -331,8 +331,8 @@ The __SuperNOVAS__ CMake build supports the following options (in addition to th
  - `BUILD_EXAMPLES=ON|OFF` (default: ON) - Build the included examples
  - `BUILD_TESTING=ON|OFF` (default: ON - Build regression tests
  - `BUILD_BENCHMARK=ON|OFF` (default: OFF - Build benchmarking programs 
- - `ENABLE_CALCEPH=ON|OFF` (default: OFF) - Enable CALCEPH ephemeris plugin support. Requires CALCEPH package.
- - `ENABLE_CSPICE=ON|OFF` (default: OFF) - Enable CSPICE ephemeris plugin support. Requires `cspice` library 
+ - `ENABLE_CALCEPH=ON|OFF` (default: OFF) - Optional CALCEPH ephemeris plugin support. Requires CALCEPH package.
+ - `ENABLE_CSPICE=ON|OFF` (default: OFF) - Optional CSPICE ephemeris plugin support. Requires `cspice` library 
    installed.
 
 For example, to build __SuperNOVAS__ as shared libraries with 
@@ -465,18 +465,18 @@ change that part of your code to use the recommended alternatives instead.
 The NOVAS C way to handle planet or other ephemeris functions was to link particular modules to provide the
 `solarsystem()` / `solarsystem_hp()` and `readeph()` functions. This approach is discouraged in __SuperNOVAS__, with
 preference for selecting implementations at runtime. The old, deprecated way, of incorporating Solar-system data is 
-supported, nevertheless, for legacy applications.
+supported, nevertheless, for legacy applications with some caveats.
 
 <details>
 
-To use your own existing default `solarsystem()` implementation in this way, you will have to build __SuperNOVAS__
-with `SOLSYS_SOURCE` set to the source file(s) of the implementation (`config.mk` or the environment).
+To use your own existing default `solarsystem()` implementation in the NOVAS Cway, you will have to build 
+__SuperNOVAS__with `SOLSYS_SOURCE` set to the source file(s) of the implementation (`config.mk` or the environment).
 
 The same principle applies to using your specific legacy `readeph()` implementation, except that you must set 
 `READEPH_SOURCE` to the source file(s) of the chosen implementation when building __SuperNOVAS__). 
 
 (You might have to also add additional include directories to `CPPFLAGS`, e.g. `-I/my-path/include` for you custom 
-sources).
+sources for their associated headers).
 
 </details>
 

--- a/build.mk
+++ b/build.mk
@@ -10,14 +10,14 @@
 $(OBJ)/%.o: $(SRC)/%.c $(OBJ) Makefile
 	$(CC) -o $@ -c $(CPPFLAGS) $(CFLAGS) $<
 
-# Share library recipe
+# Shared library recipe
 $(LIB)/%.$(SOEXT).$(SO_VERSION): | $(LIB)
 	$(CC) -o $@ $(CPPFLAGS) $(CFLAGS) $^ $(SHARED_FLAGS) $(SONAME_FLAG)$(notdir $@) $(LDFLAGS)
 
 # Unversioned shared libs (for linking against)
 $(LIB)/lib%.$(SOEXT):
 	@rm -f $@
-	( cd $(LIB); ln -s $(notdir $<) $(notdir $@) )
+	( cd $(dir $@); ln -s $(notdir $<) $(notdir $@) )
 
 # Static library recipe
 $(LIB)/%.a:

--- a/config.mk
+++ b/config.mk
@@ -5,6 +5,11 @@
 # You can include this snipplet in your Makefile also.
 # ============================================================================
 
+# Folders for compiled objects, libraries, and binaries, respectively 
+OBJ ?= obj
+LIB ?= lib
+BIN ?= bin
+
 # Default compiler to use (if not defined externally)
 CC ?= gcc
 
@@ -80,14 +85,15 @@ CHECKOPTS += --inline-suppr $(CHECKEXTRA)
 # Below are some generated constants based on the one that were set above
 # ============================================================================
 
+SUPERNOVAS_BUILD := 1
+export SUPERNOVAS_BUILD
+
+# The version of the shared .so libraries
+SO_VERSION := 1
+
 # Folders in which sources and headers are located, respectively
 SRC := src
 INC := include
-
-# Folders for compiled objects, libraries, and binaries, respectively 
-OBJ := obj
-LIB := lib
-BIN ?= bin
 
 # Add include directory
 CPPFLAGS += -I$(INC)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,6 +7,23 @@
 #
 # Author: Attila Kovacs
 
+cmake_minimum_required(VERSION 3.20)
+
+# Configuration in case this is a standalone project....
+if(NOT PROJECT_NAME)
+    project(supernovas-examples 
+        VERSION 1.5.0
+        DESCRIPTION "SuperNOVAS example programs"
+        HOMEPAGE_URL "https://smithsonian.github.io/SuperNOVAS/"
+        LANGUAGES C
+    )
+    
+    include(GNUInstallDirs)
+    
+    # Check for math library
+    check_library_exists(m sin "" HAVE_LIBM)
+endif()
+
 # List of example programs to build
 set(EXAMPLE_PROGRAMS
     example-star

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,6 +1,6 @@
 # Part of SuperNOVAS
 #
-# Generates headless README.md and HTML documentation 
+# Build exammple programs
 #
 # Author: Attila Kovacs
 
@@ -25,6 +25,12 @@ endif
 .PHONY: all
 all: $(EXAMPLES)
 
+# Static code analysis using 'cppcheck'
+.PHONY: analyze
+analyze:
+	@echo "   [analyze]"
+	@cppcheck $(CPPFLAGS) $(CHECKOPTS) .
+
 .PHONY: clean
 clean:
 
@@ -34,3 +40,16 @@ distclean:
 
 example-%: example-%.c
 	$(CC) -o $@ $(CPPFLAGS) $(CFLAGS) $< $(LDFLAGS)
+
+.PHONY: help
+help:
+	@echo
+	@echo "Syntax: make [target]"
+	@echo
+	@echo "The following targets are available:"
+	@echo
+	@echo "  all           (default) Build all example programs."
+	@echo "  analyze       Runs 'cppcheck' static analysis tool on sources."
+	@echo "  clean         Removes intermediate products."
+	@echo "  distclean     Deletes all generated files."
+	@echo

--- a/examples/example-cspice.c
+++ b/examples/example-cspice.c
@@ -45,7 +45,7 @@
 
 int main(int argc, char *argv[]) {
   // Program Options -------------------------------------------------------->
-   char *datafile = "/path/to/de440s.bsp";  // // Ephemeris file to use
+  const char *datafile = "/path/to/de440s.bsp";  // // Ephemeris file to use
 
   // SuperNOVAS variables used for the calculations ------------------------->
   object source;                    // observed source

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,12 @@
+# Part of SuperNOVAS
+#
+# Builds and runs regression tests, measures test coverage
+#
+# Author: Attila Kovacs
+
 include ../config.mk
 
+# Flags for measuring test coverage
 CFLAGS += -I../include -pg -Wall -fprofile-arcs -ftest-coverage
 LDFLAGS += -fprofile-arcs -ftest-coverage -lm
 
@@ -75,7 +82,6 @@ test-%.o: src/test-%.c | Makefile
 
 %.o: ../src/%.c | Makefile
 	$(CC) -c -o $@ $(CPPFLAGS) $(CFLAGS) $<
-
 
 test-calceph: LDFLAGS += -lcalceph
 


### PR DESCRIPTION
- Fixes to CALCEPH / CSPICE build with CMake
- Standalone `CMakeLists.txt` for examples.
- Self contained `make help`  for examples.
- Various other tweaks