### PR TITLE
Improved portability beyond UNIX (e.g. MSVC)

### DIFF
--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -29,25 +29,20 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        include:
-          - os: ubuntu-latest
-            cc: gcc
-            opt:
-          - os: macos-latest
-            cc: clang
-            opt:
-          - os: windows-latest
-            cc: gcc
-            opt: -G "MinGW Makefiles"
 
     steps:
       - uses: actions/checkout@v5
 
       - name: Configure CMake (Unix)
-        run: cmake -B build -DCMAKE_C_COMPILER=${{ matrix.cc }} ${{ matrix.opt }} -DBUILD_SHARED_LIBS=ON -DBUILD_EXAMPLES=ON -DBUILD_BENCHMARK=ON
+        run: cmake -B build -DBUILD_SHARED_LIBS=ON -DBUILD_EXAMPLES=ON -DBUILD_BENCHMARK=ON
 
-      - name: Build
-        run: cmake --build build
+      - name: Build (Unix)
+        if: runner.os != 'Windows'
+        run: cmake --build build 
+
+      - name: Build (Windows)
+        if: runner.os == 'Windows'
+        run: cmake --build build --config Release 
 
       - name: Install
         run: cmake --install build --prefix install
@@ -63,6 +58,7 @@ jobs:
         run: |
           echo Installation contents:
           dir install
+    
 
   build-freebsd:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,10 +136,18 @@ Upcoming feature release, expected around 1 November 2025.
  - Both CMake and GNU make now install only the headers for the components that were built. E.g. `novas-calceph.h` is 
    installed only if the library is built with the CALCEPH support option enabled.
  
- - Reanmed `equinox.c` to `equator.c`, since the functions therein concern the equator of date more than the equinox 
+ - Renamed `equinox.c` to `equator.c`, since the functions therein concern the equator of date more than the equinox 
    of date specifically.
+   
+ - Moved `nutation.h` to `legacy/`. Its functions are now integral to `novas.h` instead. It is unlikely that any one 
+   would use it as a separate header, and not via `novas.h`. But, in case someone does want it, they can find it it 
+   the installation folder of the `supernovas` documentation, under the `legacy/` folder.
+   
+ - Moved a few functions around among the source modules to make the organization more consistent. It also helps when
+   browsing the HTML documentation topically by source modules.
  
- - Fully revised API and user documentation.
+ - Fully revised API and user documentation. The HTML API docs now have automatic brief descriptions when listed
+   (except for the deprecated entitites, which do not).
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ Upcoming feature release, expected around 1 November 2025.
  - #249: Option to exclude deprecated API from `novas.h` definitions for your application. Simply compile your 
    application with `-D_EXCLUDE_DEPRECATED` or else define `EXCLUDE_DEPRECATED` in your source _before_ including
    `novas.h`. 
+   
+ - #255: More platform-independent code, by eliminating some UNIX specific calls. Windows builds with the Microsoft 
+   Visual C compiler are now possible also (with CMake). 
 
 ### Removed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,12 +68,10 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Windows-specific settings
 if(WIN32)
+    message("Configuring for Windows...")
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 endif()
-
-# Preprocessor definitions
-set(SUPERNOVAS_COMPILE_DEFINITIONS "")
 
 # Check for math library
 check_library_exists(m sin "" HAVE_LIBM)
@@ -155,8 +153,6 @@ target_include_directories(supernovas PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-
-target_compile_definitions(supernovas PRIVATE ${SUPERNOVAS_COMPILE_DEFINITIONS})
 
 # Link with math libs as necessary
 target_link_libraries(supernovas PRIVATE $<$<BOOL:${HAVE_LIBM}>:m>)

--- a/README.md
+++ b/README.md
@@ -346,13 +346,25 @@ For example, to build __SuperNOVAS__ as shared libraries with
 If a `CMAKE_BUILD_TYPE` is not set, the build will only use the `CFLAGS` (if any) that were set in the environment.
 This is ideal for those who want to have full control of the compiler flags used in the build. Specifying
 `Release` or `Debug` will append a particular set of appropriate compiler options which are suited for the given 
-build type.
+build type. (If you want to use the MinGW compiler on Windows, you'll want to set 
+`-DCMAKE_C_COMPILER=gcc -G "MinGW Makefiles"` options also.)
 
 After a successful build, you can install the `Runtime` (libraries), and `Development` (headers, CMake config, and 
 `pkg-config`) components, e.g. under `/usr/local`, as:
 
 ```bash
   $ cmake --build build
+```
+
+Or, on Windows (Microsoft Visual C) you will want:
+
+```bash
+  $ cmake --build build --config Release
+```
+
+After the build, you can install the __SuperNOVAS__ files in the location of choice (e.g. `/usr/local`): 
+
+```bash
   $ cmake --install build --prefix /usr/local 
 ```
 
@@ -363,10 +375,6 @@ the `Runtime` component:
   $ cmake --install build --component Runtime --prefix /usr/local
 ```
 </details>
-
-> [!TIP]
-> On Windows, you probably want to add the `-DCMAKE_C_COMPILER=gcc -G "MinGW Makefiles"` options to `cmake`, to build
-> with MinGW.
 
 -----------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -362,8 +362,11 @@ the `Runtime` component:
 ```bash
   $ cmake --install build --component Runtime --prefix /usr/local
 ```
-
 </details>
+
+> [!TIP]
+> On Windows, you probably want to add the `-DCMAKE_C_COMPILER=gcc -G "MinGW Makefiles"` options to `cmake`, to build
+> with MinGW.
 
 -----------------------------------------------------------------------------
 

--- a/benchmark/benchmark-nutation.c
+++ b/benchmark/benchmark-nutation.c
@@ -26,12 +26,16 @@
 #define  LEAP_SECONDS     37        ///< [s] current leap seconds from IERS Bulletin C
 #define  DUT1             0.114     ///< [s] current UT1 - UTC time difference from IERS Bulletin A
 
+static void timestamp(novas_timespec *t) {
+  novas_set_current_time(LEAP_SECONDS, DUT1, t);
+}
+
 
 int main() {              // observer location
   // Other variables we need ----------------------------------------------->
   int i, N = 30000;
   double tjd = 2460683.132905, dx, dy;
-  struct timespec unix_time, end;
+  novas_timespec start, end;
 
   // -------------------------------------------------------------------------
   // Start benchmarks...
@@ -39,27 +43,24 @@ int main() {              // observer location
 
   // -------------------------------------------------------------------------
   // Benchmark reduced accuracy, place(), same time
-  clock_gettime(CLOCK_REALTIME, &unix_time);
+  timestamp(&start);
   for(i = 0; i < N; i++) iau2000a(tjd + i * 0.01, 0.0, &dx, &dy);
-  clock_gettime(CLOCK_REALTIME, &end);
-  printf(" - iau2000a:   %12.1f nutations/sec\n",
-          N / (end.tv_sec - unix_time.tv_sec + 1e-9 * (end.tv_nsec - unix_time.tv_nsec)));
+  timestamp(&end);
+  printf(" - iau2000a:   %12.1f nutations/sec\n", N / novas_diff_time(&end, &start));
 
   // -------------------------------------------------------------------------
   // Benchmark reduced accuracy, place(), different times()
-  clock_gettime(CLOCK_REALTIME, &unix_time);
+  timestamp(&start);
   for(i = 0; i < N; i++)   for(i = 0; i < N; i++) iau2000b(tjd + i * 0.01, 0.0, &dx, &dy);
-  clock_gettime(CLOCK_REALTIME, &end);
-  printf(" - iau2000b:   %12.1f positions/sec\n",
-          N / (end.tv_sec - unix_time.tv_sec + 1e-9 * (end.tv_nsec - unix_time.tv_nsec)));
+  timestamp(&end);
+  printf(" - iau2000b:   %12.1f positions/sec\n", N / novas_diff_time(&end, &start));
 
   // -------------------------------------------------------------------------
   // Benchmark reduced accuracy, place(), different times()
-  clock_gettime(CLOCK_REALTIME, &unix_time);
+  timestamp(&start);
   for(i = 0; i < N; i++)   for(i = 0; i < N; i++) nu2000k(tjd + i * 0.01, 0.0, &dx, &dy);
-  clock_gettime(CLOCK_REALTIME, &end);
-  printf(" - nu2000k:    %12.1f positions/sec\n",
-          N / (end.tv_sec - unix_time.tv_sec + 1e-9 * (end.tv_nsec - unix_time.tv_nsec)));
+  timestamp(&end);
+  printf(" - nu2000k:    %12.1f positions/sec\n", N / novas_diff_time(&end, &start));
 
   return 0;
 }

--- a/examples/example-time.c
+++ b/examples/example-time.c
@@ -13,7 +13,9 @@
  *  ```
  */
 
-#define _POSIX_C_SOURCE 199309L   ///< for clock_gettime()
+#if __STDC_VERSION__ < 201112L
+#  define _POSIX_C_SOURCE 199309      ///< struct timespec
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -95,7 +97,12 @@ int main() {
   // 1.d. UNIX time
 
   // We'll set unix_time to current time, but it could be a UNIX timestamp...
+
+#if __STDC_VERSION__ >= 201112L || defined(_MSC_VER)
+  timespec_get(&unix_time, TIME_UTC);
+#else
   clock_gettime(CLOCK_REALTIME, &unix_time);
+#endif
 
   // Use the UNIX time (seconds + nanoseconds) to define astrometric time
   novas_set_unix_time(unix_time.tv_sec, unix_time.tv_nsec, LEAP_SECONDS, DUT1, &time3);

--- a/include/novas.h
+++ b/include/novas.h
@@ -2348,6 +2348,13 @@ int novas_set_default_weather(on_surface *site);
 
 #endif /* _CONSTS_ */
 
+/**
+ * Default value for the maximum number of iterations allowed for inverse calculations.
+ * @since 1.5
+ * @sa novas_set_max_iter()
+ */
+#define NOVAS_DEFAULT_MAX_ITER    100
+
 // On some older platform NAN may not be defined, so define it here if need be
 #  ifndef NAN
 #    define NAN               (0.0/0.0)
@@ -2422,7 +2429,14 @@ int polar_dxdy_to_dpsideps(double jd_tt, double dx, double dy, double *restrict 
 int novas_frame_is_initialized(const novas_frame *frame);
 double novas_gmst_prec(double jd_tdb);
 double novas_cio_gcrs_ra(double jd_tdb);
+void novas_set_max_iter(int n);
 
+
+/**
+ * Deprecated.
+ * @deprecated Use novas_set_max_iter() instead
+ * @sa novas_set_max_iter()
+ */
 extern int novas_inv_max_iter;
 
 #endif /* __NOVAS_INTERNAL_API__ */

--- a/src/frames.c
+++ b/src/frames.c
@@ -239,7 +239,8 @@ static int set_frame_tie(novas_frame *frame) {
   static const double ax = ETA0;
   static const double ay = -XI0;
   static const double az = -DA0;
-  static const double X = ax * ax, Y = ay * ay, Z = az * az;
+
+  static const double X = ETA0 * ETA0, Y = XI0 * XI0, Z = DA0 * DA0;
 
   novas_matrix *T = &frame->icrs_to_j2000;
 

--- a/src/frames.c
+++ b/src/frames.c
@@ -99,7 +99,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <string.h>
 #include <errno.h>
 #include <math.h>

--- a/src/refract.c
+++ b/src/refract.c
@@ -12,7 +12,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <string.h>
 #include <errno.h>
 

--- a/src/target.c
+++ b/src/target.c
@@ -55,6 +55,8 @@
 #if __Lynx__ && __powerpc__
 // strcasecmp() / strncasecmp() are not defined on PowerPC / LynxOS 3.1
 extern int strcasecmp(const char *s1, const char *s2);
+#elif defined(_MSC_VER)
+#  define strcasecmp _stricmp                       /// MSVC equivalent
 #endif
 
 static int is_case_sensitive = 0; ///< (boolean) whether object names are case-sensitive.

--- a/src/timescale.c
+++ b/src/timescale.c
@@ -11,7 +11,9 @@
  */
 
 /// \cond PRIVATE
-#define _GNU_SOURCE                 ///< for strcasecmp()
+#if __STDC_VERSION__ < 201112L
+#  define _POSIX_C_SOURCE 199309    ///< struct timespec
+#endif
 #define __NOVAS_INTERNAL_API__      ///< Use definitions meant for internal use by SuperNOVAS only
 /// \endcond
 
@@ -20,7 +22,7 @@
 #include <string.h>
 #include <errno.h>
 #include <math.h>
-
+#include <time.h>
 
 #include "novas.h"
 
@@ -76,11 +78,6 @@ static const double iM[] = NOVAS_RMASS_INIT;       ///< [1/M<sub>sun</sub>]
 static const double R[] = NOVAS_PLANET_RADII_INIT; ///< [m]
 
 /// \endcond
-
-#if __Lynx__ && __powerpc__
-// strcasecmp() / strncasecmp() are not defined on PowerPC / LynxOS 3.1
-extern int strcasecmp(const char *s1, const char *s2);
-#endif
 
 
 /**
@@ -818,7 +815,7 @@ double novas_diff_tcg(const novas_timespec *t1, const novas_timespec *t2) {
  * since 0 UTC, 1 Jan 1970 (the start of the UNIX era). Specifying time this way supports
  * precisions to the nanoseconds level by construct. Specifying UNIX time in split seconds and
  * nanoseconds is a common way CLIB handles precision time, e.g. with `struct timespec` and
- * functions like `clock_gettime()` (see `time.h`).
+ * functions like `clock_gettime()` or the C11 `timespec_get` (see `time.h`).
  *
  * @param unix_time   [s] UNIX time (UTC) seconds
  * @param nanos       [ns] UTC sub-second component
@@ -861,6 +858,13 @@ int novas_set_unix_time(time_t unix_time, long nanos, int leap, double dut1, nov
  * system clock is. You should generally make sure the sytem clock is synchronized to a time reference
  * e.g. via ntp, preferably to a local time reference.
  *
+ * NOTE:
+ *
+ * <ol>
+ * <li>For C11 or later, this function uses the C11 standard `timespec_get()` function, which is
+ * portable. For older C standard, the POSIX only `clock_gettime()` function is used.</li>
+ * </ol>
+ *
  * @param leap        [s] Leap seconds, e.g. as published by IERS Bulletin C.
  * @param dut1        [s] UT1-UTC time difference, e.g. as published in IERS Bulletin A, and
  *                    possibly corrected for diurnal and semi-diurnal variations, e.g.
@@ -879,7 +883,13 @@ int novas_set_unix_time(time_t unix_time, long nanos, int leap, double dut1, nov
  */
 int novas_set_current_time(int leap, double dut1, novas_timespec *restrict time) {
   struct timespec t = {};
+
+#if __STDC_VERSION__ >= 201112L || defined(_MSC_VER)
+  timespec_get(&t, TIME_UTC);
+#else
   clock_gettime(CLOCK_REALTIME, &t);
+#endif
+
   prop_error("novas_set_current_time", novas_set_unix_time(t.tv_sec, t.tv_nsec, leap, dut1, time), 0);
   return 0;
 }
@@ -1202,57 +1212,6 @@ int novas_print_timescale(enum novas_timescale scale, char *restrict buf) {
   *buf = '\0';
 
   return novas_error(-1, EINVAL, fn, "invalid timescale: %d", scale);
-}
-
-/**
- * Returns the timescale constant for a string that denotes the timescale in with a standard
- * abbreviation (case insensitive). The following values are recognised: "UTC", "UT", "UT0",
- * "UT1", "GMT", "TAI", "GPS", "TT", "ET", "TCG", "TCB", and "TDB".
- *
- * @param str     String specifying an astronomical timescale
- * @return        The SuperNOVAS timescale constant (&lt;=0), or else -1 if the string was NULL,
- *                empty, or could not be matched to a timescale value (errno will be set to EINVAL
- *                also).
- *
- * @since 1.3
- * @author Attila Kovacs
- *
- * @sa novas_parse_timescale(), novas_set_str_time(), novas_print_timescale()
- */
-enum novas_timescale novas_timescale_for_string(const char *restrict str) {
-  static const char *fn = "novas_str_timescale";
-
-  if(!str)
-    return novas_error(-1, EINVAL, fn, "input string is NULL");
-
-  if(!str[0])
-    return novas_error(-1, EINVAL, fn, "input string is empty");
-
-  if(strcasecmp("UTC", str) == 0 || strcasecmp("UT", str) == 0 || strcasecmp("UT0", str) == 0 || strcasecmp("GMT", str) == 0)
-    return NOVAS_UTC;
-
-  if(strcasecmp("UT1", str) == 0)
-    return NOVAS_UT1;
-
-  if(strcasecmp("TAI", str) == 0)
-    return NOVAS_TAI;
-
-  if(strcasecmp("GPS", str) == 0)
-    return NOVAS_GPS;
-
-  if(strcasecmp("TT", str) == 0 || strcasecmp("ET", str) == 0)
-    return NOVAS_TT;
-
-  if(strcasecmp("TCG", str) == 0)
-    return NOVAS_TCG;
-
-  if(strcasecmp("TCB", str) == 0)
-    return NOVAS_TCB;
-
-  if(strcasecmp("TDB", str) == 0)
-    return NOVAS_TDB;
-
-  return novas_error(-1, EINVAL, fn, "unknown timescale: %s", str);
 }
 
 /**

--- a/src/timescale.c
+++ b/src/timescale.c
@@ -17,7 +17,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <string.h>
 #include <errno.h>
 #include <math.h>

--- a/src/util.c
+++ b/src/util.c
@@ -259,6 +259,18 @@ void novas_tiny_rotate(const double *in, double ax, double ay, double az, double
   out[2] = z - 0.5 * (A[0] + A[1]) * z - ay * x + ax * y;
 }
 
+/**
+ * Sets the maximum number of iterations allowed for convergent inverese calculations.
+ *
+ * @param n   Maximum number of iterations allowed.
+ *
+ * @since 1.5
+ * @author Attila Kovacs
+ */
+void novas_set_max_iter(int n) {
+  novas_inv_max_iter = n;
+}
+
 /// \endcond PROTECTED
 
 // ===========================================================================
@@ -770,3 +782,5 @@ int novas_print_dms(double degrees, enum novas_separator_type sep, int decimals,
 
   return strlen(buf);
 }
+
+

--- a/src/util.c
+++ b/src/util.c
@@ -10,7 +10,6 @@
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>
-#include <unistd.h>
 
 /// \cond PRIVATE
 #define __NOVAS_INTERNAL_API__    ///< Use definitions meant for internal use by SuperNOVAS only

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -244,7 +244,6 @@ static int test_refract() {
 }
 
 static int test_refract_astro() {
-  extern int novas_inv_max_iter;
   on_surface surf = ON_SURFACE_INIT;
   int n = 0;
 
@@ -252,26 +251,25 @@ static int test_refract_astro() {
   if(check_nan("refract_astro:model:-1", refract_astro(&surf, -1, 30.0))) n++;
   if(check_nan("refract_astro:model:hi", refract_astro(&surf, NOVAS_REFRACTION_MODELS, 30.0))) n++;
 
-  novas_inv_max_iter = 0;
+  novas_set_max_iter(0);
   if(check_nan("refract_astro:converge", refract_astro(&surf, NOVAS_STANDARD_ATMOSPHERE, 85.0))) n++;
   else if(check("refract_astro:converge:errno", ECANCELED, errno)) n++;
 
-  novas_inv_max_iter = 100;
+  novas_set_max_iter(NOVAS_DEFAULT_MAX_ITER);
 
   return n;
 }
 
 static int test_inv_refract() {
-  extern int novas_inv_max_iter;
   on_surface surf = ON_SURFACE_INIT;
   int n = 0;
 
   if(check_nan("inv_refract:loc", novas_inv_refract(novas_optical_refraction, NOVAS_JD_J2000, NULL, NOVAS_REFRACT_OBSERVED, 5.0))) n++;;
 
-  novas_inv_max_iter = 0;
+  novas_set_max_iter(0);
   if(check_nan("inv_refract:converge", novas_inv_refract(novas_optical_refraction, NOVAS_JD_J2000, &surf, NOVAS_REFRACT_OBSERVED, 5.0))) n++;
   else if(check("inv_refract:converge:errno", ECANCELED, errno)) n++;
-  novas_inv_max_iter = 100;
+  novas_set_max_iter(NOVAS_DEFAULT_MAX_ITER);
 
   return n;
 }
@@ -599,17 +597,16 @@ static int test_radec_planet() {
 }
 
 static int test_mean_star() {
-  extern int novas_inv_max_iter;
   double x, y;
   int n = 0;
 
   if(check("mean_star:ira", -1, mean_star(0.0, 0.0, 0.0, NOVAS_FULL_ACCURACY, NULL, &y))) n++;
   if(check("mean_star:idec", -1, mean_star(0.0, 0.0, 0.0, NOVAS_FULL_ACCURACY, &x, NULL))) n++;
 
-  novas_inv_max_iter = 0;
+  novas_set_max_iter(0);
   if(check("mean_star:converge", 1, mean_star(NOVAS_JD_J2000, 0.0, 0.0, NOVAS_REDUCED_ACCURACY, &x, &y))) n++;
   else if(check("mean_star:converge:errno", ECANCELED, errno)) n++;
-  novas_inv_max_iter = 100;
+  novas_set_max_iter(NOVAS_DEFAULT_MAX_ITER);
 
   return n;
 }
@@ -861,7 +858,6 @@ static int test_geo_posvel() {
 }
 
 static int test_light_time2() {
-  extern int novas_inv_max_iter;
   object o;
   double pos[3] = {1.0}, p[3], v[3], t;
   int n = 0;
@@ -872,10 +868,10 @@ static int test_light_time2() {
   if(check("light_time2:object", -1, light_time2(0.0, NULL, pos, 0.0, NOVAS_FULL_ACCURACY, p, v, &t))) n++;
   if(check("light_time2:pos", -1, light_time2(0.0, &o, NULL, 0.0, NOVAS_FULL_ACCURACY, p, v, &t))) n++;
 
-  novas_inv_max_iter = 0;
+  novas_set_max_iter(0);
   if(check("light_time2:converge", 1, light_time2(0.0, &o, pos, 0.0, NOVAS_FULL_ACCURACY, p, v, &t))) n++;
   else if(check("light_time2:converge:errno", ECANCELED, errno)) n++;
-  novas_inv_max_iter = 100;
+  novas_set_max_iter(NOVAS_DEFAULT_MAX_ITER);
 
   return n;
 }
@@ -1128,7 +1124,6 @@ static int test_grav_planets() {
 }
 
 static int test_grav_undo_planets() {
-  extern int novas_inv_max_iter;
   novas_planet_bundle planets = NOVAS_PLANET_BUNDLE_INIT;
   double p[3] = {2.0}, po[3] = {0.0, 1.0}, out[3] = {0.0};
   int n = 0;
@@ -1139,10 +1134,10 @@ static int test_grav_undo_planets() {
   if(check("grav_undo_planets:pos_src", -1, grav_undo_planets(p, po, &planets, NULL))) n++;
 
   planets.mask = 1 << NOVAS_SUN;
-  novas_inv_max_iter = 0;
+  novas_set_max_iter(0);
   if(check("grav_undo_planets:converge", -1, grav_undo_planets(p, po, &planets, out))) n++;
   else if(check("grav_undo_planets:converge:errno", ECANCELED, errno)) n++;
-  novas_inv_max_iter = 100;
+  novas_set_max_iter(NOVAS_DEFAULT_MAX_ITER);
 
   return n;
 }
@@ -1445,7 +1440,6 @@ static int test_sky_pos() {
 }
 
 static int test_app_to_geom() {
-  extern int novas_inv_max_iter;
   novas_timespec ts = NOVAS_TIMESPEC_INIT;
   observer obs = OBSERVER_INIT;
   novas_frame frame = NOVAS_FRAME_INIT;
@@ -1459,10 +1453,10 @@ static int test_app_to_geom() {
   if(check("app_to_geom:frame:init", -1, novas_app_to_geom(&frame, NOVAS_ICRS, 1.0, 2.0, 10.0, pos))) n++;
 
   novas_make_frame(NOVAS_REDUCED_ACCURACY, &obs, &ts, 0.0, 0.0, &frame);
-  novas_inv_max_iter = 0;
+  novas_set_max_iter(0);
   if(check("app_to_geom:frame:converge", -1, novas_app_to_geom(&frame, NOVAS_ICRS, 1.0, 2.0, 10.0, pos))) n++;
   else if(check("app_to_geom:frame:converge:errno", ECANCELED, errno)) n++;
-  novas_inv_max_iter = 100;
+  novas_set_max_iter(NOVAS_DEFAULT_MAX_ITER);
 
   if(check("app_to_geom:pos", -1, novas_app_to_geom(&frame, NOVAS_ICRS, 1.0, 2.0, 10.0, NULL))) n++;
   if(check("app_to_geom:sys:-1", -1, novas_app_to_geom(&frame, -1, 1.0, 2.0, 10.0, pos))) n++;
@@ -1704,7 +1698,7 @@ static int test_make_orbital_object() {
 static int test_orbit_posvel() {
   int n = 0;
   double pos[3] = {0.0}, vel[3] = {0.0};
-  int saved = novas_inv_max_iter;
+
   novas_orbital orbit = NOVAS_ORBIT_INIT;
 
   orbit.a = 1.0;
@@ -1716,10 +1710,10 @@ static int test_orbit_posvel() {
 
   if(check("set_obsys_pole:orbit:converge", 0, novas_orbit_posvel(0.0, &orbit, NOVAS_REDUCED_ACCURACY, pos, vel))) n++;
 
-  novas_inv_max_iter = 0;
+  novas_set_max_iter(0);
   if(check("set_obsys_pole:orbit:converge", -1, novas_orbit_posvel(0.0, &orbit, NOVAS_REDUCED_ACCURACY, pos, vel))) n++;
   else if(check("set_obsys_pole:orbit:converge:errno", ECANCELED, errno)) n++;
-  novas_inv_max_iter = saved;
+  novas_set_max_iter(NOVAS_DEFAULT_MAX_ITER);
 
   orbit.system.type = -1;
   if(check("set_obsys_pole:orbit:type:-1", -1, novas_orbit_posvel(0.0, &orbit, NOVAS_REDUCED_ACCURACY, pos, vel))) n++;
@@ -1876,7 +1870,6 @@ static int test_rise_set() {
   novas_timespec time = NOVAS_TIMESPEC_INIT;
   observer obs = OBSERVER_INIT;
   novas_frame frame = NOVAS_FRAME_INIT;
-  int save = novas_inv_max_iter;
 
   if(check_nan("rise_set:rises_above:frame:null", novas_rises_above(0.0, &sun, NULL, NULL))) n++;
   if(check_nan("rise_set:rises_above:frame:init", novas_rises_above(0.0, &sun, &frame, NULL))) n++;
@@ -1899,10 +1892,10 @@ static int test_rise_set() {
   if(check_nan("rise_set:rises_above:source:null", novas_rises_above(31.0, &sun, &frame, NULL))) n++;
   if(check_nan("rise_set:sets_below:source:null", novas_sets_below(31.0, &sun, &frame, NULL))) n++;
 
-  novas_inv_max_iter = 0;
+  novas_set_max_iter(0);
   if(check_nan("rise_set:rises_above:noconv", novas_rises_above(0.0, &sun, &frame, NULL))) n++;
   if(check_nan("rise_set:sets_below:noconv", novas_rises_above(0.0, &sun, &frame, NULL))) n++;
-  novas_inv_max_iter = save;
+  novas_set_max_iter(NOVAS_DEFAULT_MAX_ITER);
 
   return n;
 }
@@ -2298,10 +2291,9 @@ static int test_approx_sky_pos() {
 static int test_moon_phase() {
   int n = 0;
 
-  int saved = novas_inv_max_iter;
-  novas_inv_max_iter = 0;
+  novas_set_max_iter(0);
   if(check_nan("moon_phase:conv", novas_moon_phase(NOVAS_JD_J2000))) n++;
-  novas_inv_max_iter = saved;
+  novas_set_max_iter(NOVAS_DEFAULT_MAX_ITER);
   return n;
 }
 
@@ -2311,10 +2303,9 @@ static int test_next_moon_phase() {
   if(check_nan("next_moon_phase:time:lo", novas_next_moon_phase(0.0, NOVAS_JD_J2000 - 31.0 * JULIAN_CENTURY_DAYS))) n++;
   if(check_nan("next_moon_phase:time:hi", novas_next_moon_phase(0.0, NOVAS_JD_J2000 + 31.0 * JULIAN_CENTURY_DAYS))) n++;
 
-  int saved = novas_inv_max_iter;
-  novas_inv_max_iter = 0;
+  novas_set_max_iter(0);
   if(check_nan("next_moon_phase:conv", novas_next_moon_phase(0.0, NOVAS_JD_J2000))) n++;
-  novas_inv_max_iter = saved;
+  novas_set_max_iter(NOVAS_DEFAULT_MAX_ITER);
   return n;
 }
 

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -11,7 +11,6 @@
 #include <math.h>
 #include <string.h>
 #include <time.h>
-#include <unistd.h>
 #include <libgen.h>
 
 #define __NOVAS_INTERNAL_API__      ///< Use definitions meant for internal use by SuperNOVAS only


### PR DESCRIPTION
Various changes to enable non-UNIX builds, esp. with MSVC.

- No more `unistd.h` includes. It's a UNIX-specific header, and it turns out we did not need it at all.
- Use the MSVC `_stricmp()` and `_strincmp()` instead of the UNIX `strcasecmp()` and `strncasecmp()`, when compiling with MSC.
- Use the C11 `timespec_get()` instead of the UNIX-specific `clock_gettime()` when appropriate.
- Various fixes to tests of small issues, which did not trip up gcc / clang.
- New 'internal' function `novas_set_max_iter()` to set the global `novas_inv_max_iter` variable (since MSVC does not seem to export the variable).