### PR TITLE
Automatically correct for diurnal EOP variations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,10 @@ Upcoming feature release, expected around 1 November 2025.
    data. POSIX semaphores are not supported on Windows and MacOS, whereas pthread is available on all (via wrapper
    library on Windows -- something that CMake is aware of).
 
+ - #264: The likes of `novas_set_time()` and full accuracy `novas_make_frame()` will automatically apply diurnal
+   corrections for libration and ocean tides to the input EOP values. As such, users should supply mean (interpolated) 
+   UT1-UTC time differences and _x_<sub>p</sub>, _y_<sub>p</sub> pole offsets, e.g. directly from the IERS Bulletins.
+
  - Both CMake and GNU make now install only the headers for the components that were built. E.g. `novas-calceph.h` is 
    installed only if the library is built with the CALCEPH support option enabled.
  

--- a/README.md
+++ b/README.md
@@ -752,8 +752,8 @@ e.g.:
 
 Next, we set the time of observation. For a ground-based observer, you will need to provide __SuperNOVAS__ with the
 UT1 - UTC time difference (a.k.a. DUT1), and the current leap seconds. You can obtain suitable values for DUT1 from 
-IERS, and for the highest precision, interpolate for the time of observations, and add diurnal corrections obtained 
-from `novas_diurnal_eop()`. For the example, let's assume 37 leap seconds, and DUT1 = 0.042,
+IERS, and for the highest precision, interpolate for the time of observations. For the example, let's assume 37 leap 
+seconds, and DUT1 = 0.042,
 
 ```c
   int leap_seconds = 37;        // [s] UTC - TAI time difference
@@ -793,6 +793,10 @@ Or, you might use string dates, such as an ISO timestamp:
  novas_set_str_time(NOVAS_UTC, "2025-01-26T22:05:14.234+0200", leap_seconds, dut1, &obs_time);
 ```
 
+Note, that the likes of `novas_set_time()` will automatically apply diurnal corrections to the supplied UT1-UTC time 
+difference for libration and ocean tides. Thus, the supplied values should not include these. Rather you should pass
+`dut1` directly (or interpolated) from the IERS Bulletin values for the time of observation.
+
 <a name="observing-frame"></a>
 #### Set up the observing frame
 
@@ -809,11 +813,12 @@ observation:
 ```
 
 Here `xp` and `yp` are small (sub-arcsec level) corrections to Earth orientation. Values for these are are published 
-in the [IERS Bulletins](https://www.iers.org/IERS/EN/Publications/Bulletins/bulletins.html), and if accuracy below the
-milliarcsecond level is required, should be corrected for diurnal and semi-diurnal variations caused by libration and
-ocean tides (see `novas_diurnal_eop()` for calculating such corrections). These Earth orientation parameters (EOP) are 
-needed only when converting positions from the celestial CIRS (or PEF) frame to the Earth-fixed ITRS frame. You may 
-ignore these and set zeroes if sub-arcsecond precision is not required. 
+in the [IERS Bulletins](https://www.iers.org/IERS/EN/Publications/Bulletins/bulletins.html). These values should be 
+interpolated for the time of observation, but should NOT be corrected for libration and ocean tides 
+(`novas_make_frame() will apply such corrections as appropriate for full accuracy frames). The Earth orientation 
+parameters (EOP) are needed only when converting positions from the celestial CIRS (or TOD) frame to the Earth-fixed 
+ITRS (or PEF) frames. You may ignore these and set zeroes if not interested in Earth-fixed calculations or if 
+sub-arcsecond precision is not required. 
 
 The advantage of using the observing frame, is that it enables very fast position calculations for multiple objects
 in that frame (see the [benchmarks](#benchmarks)), since all sources in a frame have well-defined, fixed, topological 

--- a/src/earth.c
+++ b/src/earth.c
@@ -479,6 +479,14 @@ static int add_diurnal_eop(double gmst, const novas_delaunay_args *restrict dela
  * and sub-millisecond level in UT1. Thus, these diurnal and semi-diurnal variations are important
  * for the highest precision astrometry only, when converting between ITRS and TIRS frames.
  *
+ * NOTES:
+ * <ol>
+ * <li>These diurnal corrections are automatically added to the mean Earth Orinetation parameters
+ * used when defining astronomical times and observing frames. I.e., you should pass mean values
+ * to the likes of `novas_set_time()` and `novas_make_frame()`, which will then add the diurnal
+ * corrections as appropriate automatically.</li>
+ * </ol>
+ *
  * REFERENCES:
  * <ol>
  * <li>IERS Conventions 2010, Chapter 5, https://iers-conventions.obspm.fr/content/chapter5/icc5.pdf</li>
@@ -519,6 +527,14 @@ int novas_diurnal_eop(double gmst, const novas_delaunay_args *restrict delaunay,
  * Calculate corrections to the Earth orientation parameters (EOP) due to short term (diurnal and
  * semidiurnal) libration and the ocean tides at a given astromtric time. See Chapters 5 and 8 of
  * the IERS Conventions.
+ *
+ * NOTES:
+ * <ol>
+ * <li>These diurnal corrections are automatically added to the mean Earth Orinetation parameters
+ * used when defining astronomical times and observing frames. I.e., you should pass mean values
+ * to the likes of `novas_set_time()` and `novas_make_frame()`, which will then add the diurnal
+ * corrections as appropriate automatically.</li>
+ * </ol>
  *
  * REFERENCES:
  * <ol>

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -1289,8 +1289,8 @@ static int test_set_time() {
   if(!is_ok("set_time:set:ut1", novas_set_split_time(NOVAS_UT1, ijd, fjd, leap, dut1, &ut1))) return 1;
 
   dt = remainder(novas_get_split_time(&TDB, NOVAS_TT, NULL) - novas_get_split_time(&tt, NOVAS_TT, NULL), 1.0);
-  if(!is_equal("set_time:check:tdb-tt", dt * DAY, -tt2tdb(novas_get_time(&tt, NOVAS_TT)), 1e-9)) {
-    printf("!!! TT-TDB: %.9f (expected %.9f)\n", dt * DAY, -tt2tdb(ijd + fjd));
+  if(!is_equal("set_time:check:tdb-tt", dt * DAY, -tt2tdb_hp(novas_get_time(&tt, NOVAS_TT)), 1e-9)) {
+    printf("!!! TT-TDB: %.9f (expected %.9f)\n", dt * DAY, -tt2tdb_hp(ijd + fjd));
     return 1;
   }
 
@@ -1335,7 +1335,7 @@ static int test_get_time() {
   if(!is_equal("get_time:check:nosplit", dt * DAY, 0.0, 1e-5)) return 1;
 
   dt = remainder(novas_get_split_time(&tt, NOVAS_TDB, NULL) - novas_get_split_time(&tt, NOVAS_TT, NULL), 1.0);
-  if(!is_equal("get_time:check:tdb-tt", dt * DAY, tt2tdb(novas_get_time(&tt, NOVAS_TT)), 1e-9)) return 1;
+  if(!is_equal("get_time:check:tdb-tt", dt * DAY, tt2tdb_hp(novas_get_time(&tt, NOVAS_TT)), 1e-9)) return 1;
 
   dt = novas_get_split_time(&tt, NOVAS_TCB, NULL) - novas_get_split_time(&tt, NOVAS_TDB, NULL);
   dt -= LB * (novas_get_time(&tt, NOVAS_TDB) - CT0) - TDB0 / DAY;
@@ -1355,7 +1355,7 @@ static int test_get_time() {
   if(!is_equal("get_time:check:tai-utc", dt * DAY, leap, 1e-9)) return 1;
 
   dt = novas_get_split_time(&tt, NOVAS_UT1, NULL) - novas_get_split_time(&tt, NOVAS_UTC, NULL);
-  if(!is_equal("get_time:check:ut1-utc", dt * DAY, dut1, 1e-9)) return 1;
+  if(!is_equal("get_time:check:ut1-utc", dt * DAY, dut1, 1e-3)) return 1;
 
   tt.fjd_tt = 0.0;
   dt = novas_get_split_time(&tt, NOVAS_TAI, &ijd) - (1.0 - 32.184 / DAY);
@@ -3937,7 +3937,7 @@ static int test_time_lst() {
   if(!is_ok("time_lst:make_frame", novas_make_frame(NOVAS_REDUCED_ACCURACY, &obs, &t, 0.0, 0.0, &f))) return 1;
 
   if(!is_equal("time_lst:check", novas_time_lst(&t, obs.on_surf.longitude, f.accuracy),
-          novas_frame_lst(&f), 1e-9)) return 1;
+          novas_frame_lst(&f), 1e-8)) return 1;
 
   return 0;
 }


### PR DESCRIPTION
- The likes of `novas_set_time()` and `novas_make_frame()` (if high precision) will automatically include diurnal corrections for libration and ocean tides. As such, the input parameters should be interpolated mean values, e.g. directly from IERS Bulletin A.

- Also, `novas_timespec` now uses the full-precision TT-TDB conversion always.