### PR TITLE
Use portable mutex code in plugins.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,8 @@ Upcoming feature release, expected around 1 November 2025.
  - #264: `novas_timespec` now stores the TT-TDB conversion to the full (100 ns) precision. It's slightly slower than
    the less precise original NOVAS `tdb2tt()`, but it's worth it not having to worry about the precision.
  
+ - #265: CALCEPH and CSPICE plugins to use portable mutex code.
+ 
  - Both CMake and GNU make now install only the headers for the components that were built. E.g. `novas-calceph.h` is 
    installed only if the library is built with the CALCEPH support option enabled.
  

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ project(supernovas
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 include(FeatureSummary)
+include(FindThreads)
 
 # Build options
 option(BUILD_SHARED_LIBS "Build as shared libraries instead of static" OFF)
@@ -78,13 +79,9 @@ if(NOT LIBM)
     set(LIBM "")
 endif()
 
-# Use pthread mutexes for thread safe CALCEPH / CSPICE plugins
-if(ENABLE_CSPICE OR ENABLE_CALCEPH)
-  set(THREADS_PREFER_PTHREAD_FLAG ON)
-  find_package(Threads REQUIRED)
-  set(THREADLIB Threads::Threads)
+if(ENABLE_CALCEPH OR ENABLE_CSPICE)
+    find_package(Threads REQUIRED)
 endif()
-
 
 # ----------------------------------------------------------------------------
 # Extenal plugin configuration
@@ -98,13 +95,11 @@ if(ENABLE_CALCEPH)
         TYPE REQUIRED
         PURPOSE "Provides ephemeris support for supernovas"
     )
-    list(APPEND SUPERNOVAS_COMPILE_DEFINITIONS USE_CALCEPH=1)
 endif()
 
 # CSPICE plugin
 if(ENABLE_CSPICE)
     find_library(cspice cspice REGISTRY_VIEW TARGET REQUIRED)
-    list(APPEND SUPERNOVAS_COMPILE_DEFINITIONS USE_CSPICE=1)
 endif()
 
 # ----------------------------------------------------------------------------
@@ -186,13 +181,17 @@ function(solsys_plugin EPHEM_LIB)
         POSITION_INDEPENDENT_CODE ON
     )
     
+    if(CMAKE_USE_PTHREADS_INIT)
+        target_compile_definitions(${PLUGIN} PRIVATE _PTHREAD_)
+    endif()
+    
     target_include_directories(${PLUGIN} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
     
     target_link_libraries(solsys-${EPHEM_LIB} PRIVATE
         supernovas
         ${EPHEM_LIB}
         ${LIBM}
-        ${THREADLIB}
+        Threads::Threads
     )
 endfunction()
 

--- a/include/novas-calceph.h
+++ b/include/novas-calceph.h
@@ -11,6 +11,7 @@
 #define NOVAS_CALCEPH_H_
 
 #  include <calceph.h>
+#  include "novas.h"
 
 #if __cplusplus
 #  ifdef NOVAS_NAMESPACE
@@ -19,6 +20,9 @@ namespace novas {
 
 extern "C" {
 #endif
+
+/// @ingroup solar-system
+int novas_calceph_is_thread_safe();
 
 /// @ingroup solar-system
 int novas_use_calceph(t_calcephbin *eph);

--- a/include/novas-cspice.h
+++ b/include/novas-cspice.h
@@ -19,6 +19,9 @@ namespace novas {
 extern "C" {
 #endif
 
+/// @ingroup solar_system
+int novas_cspice_is_thread_safe();
+
 /// @ingroup solar-system
 int novas_use_cspice();
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -10,7 +10,6 @@
  */
 
 /// \cond PRIVATE
-#define _X_OPEN_SOURCE 500        ///< For strdup(), glibc >= 2.12
 #define __NOVAS_INTERNAL_API__    ///< Use definitions meant for internal use by SuperNOVAS only
 /// \endcond
 

--- a/src/solsys-calceph.c
+++ b/src/solsys-calceph.c
@@ -57,9 +57,31 @@
 
 #include <string.h>
 #include <errno.h>
-#include <pthread.h>
 
 /// \cond PRIVATE
+#if defined(_PTHREAD_) || defined(__unix__) || defined(__unix) || defined(__APPLE__)
+#  include <pthread.h>
+
+#  define mtx_init        pthread_mutex_init
+#  define mtx_lock        pthread_mutex_lock
+#  define mtx_unlock      pthread_mutex_unlock
+#  define THREAD_SAFE     1
+
+typedef pthread_mutex_t   mtx_t;
+
+#elif __STDC_VERSION__ >= 201112L
+#  include <threads.h>
+#  define THREAD_SAFE     1
+
+#else
+#  define mtx_init        (void)
+#  define mtx_lock        (void)
+#  define mtx_unlock      (void)
+#  define THREAD_SAFE     0
+
+typedef int               mtx_t;
+#endif
+
 #define __NOVAS_INTERNAL_API__      ///< Use definitions meant for internal use by SuperNOVAS only
 /// \endcond
 
@@ -77,8 +99,8 @@ namespace novas {
 #define CALCEPH_SUN                 11  ///< Sun in CALCEPH
 #define CALCEPH_SSB                 12  ///< Solar-system Barycenter in CALCEPH
 
-/// Distance and time units to use for CALCEPH (AU would be conventient, but is not available
-/// unless defined in the sphemeris file(s) themselves.
+/// Distance and time units to use for CALCEPH (AU would be convenient, but is not available
+/// unless defined in the ephemeris file(s) themselves.
 #define CALCEPH_UNITS               (CALCEPH_UNIT_KM | CALCEPH_UNIT_DAY)
 
 /// Multiplicative normalization for the positions returned by CALCEPH to AU
@@ -89,28 +111,21 @@ namespace novas {
 /// \endcond
 
 /// Whether to force serialized (non-parallel CALCEPH queries)
-int serialized_calceph_queries;
+int serialized_calceph_queries = 1;
 
 static int compute_flags = CALCEPH_USE_NAIFID;
 
 /// CALCEPH ephemeris specifically for planets (and Sun and Moon) only
 static t_calcephbin *planets;
 
-/// (boolean) whether the planets ephemeris data is thread safe to access
-static int is_thread_safe_planets;
-
-/// Semaphore for thread-safe access of planet ephemeris (if needed)
-static pthread_mutex_t planet_mutex = PTHREAD_MUTEX_INITIALIZER;
-
 /// Generic CALCEPH ephemeris files for all types of Solar-system sources
 static t_calcephbin *bodies;
 
-/// (boolean) whether the generic solar-system bodies ephemeris data is thread safe to access
-static int is_thread_safe_bodies;
+/// Semaphore for thread-safe access of planet ephemeris (if needed)
+static mtx_t planet_mutex;
 
 /// Semaphore for thread-safe access of generic solar-system bodies ephemeris (if needed)
-static pthread_mutex_t ephem_mutex = PTHREAD_MUTEX_INITIALIZER;
-
+static mtx_t bodies_mutex;
 
 static int prep_ephem(t_calcephbin *eph) {
   static const char *fn = "prep_ephem";
@@ -122,6 +137,17 @@ static int prep_ephem(t_calcephbin *eph) {
     return novas_error(-1, EAGAIN, fn, "calceph_prefetch() failed");
 
   return 0;
+}
+
+/**
+ * Checks if the CALCEPH plugin is thread safe.
+ *
+ * @return      TRUE (1) if the lugin is thread safe, or else FALSE (0).
+ *
+ * @since 1.5
+ */
+int novas_calceph_is_thread_safe() {
+  return THREAD_SAFE;
 }
 
 /**
@@ -150,7 +176,6 @@ int novas_calceph_use_ids(enum novas_id_type idtype) {
       return novas_error(-1, EINVAL, "novas_calceph_use_ids", "Invalid body ID: %d\n", idtype);
   }
 }
-
 
 /**
  * Provides an interface between the CALCEPH C library and NOVAS-C for regular (reduced) precision
@@ -193,11 +218,13 @@ static short planet_calceph_hp(const double jd_tdb[restrict 2], enum novas_plane
         double *restrict position, double *restrict velocity) {
   static const char *fn = "planet_calceph_hp";
 
-  pthread_mutex_t *mutex = (planets == bodies) ? &ephem_mutex : &planet_mutex;
-  const int lock = !is_thread_safe_planets || serialized_calceph_queries;
+  t_calcephbin *ephem;
+  int parallel;
   double pv[6] = {0.0};
   int i, target, center, success;
 
+  if(!planets)
+    return novas_error(3, EAGAIN, fn, "No planet ephemerides have been configured");
   if(!jd_tdb)
     return novas_error(-1, EINVAL, fn, "jd_tdb input time array is NULL.");
 
@@ -228,13 +255,29 @@ static short planet_calceph_hp(const double jd_tdb[restrict 2], enum novas_plane
       return novas_error(2, EINVAL, fn, "Invalid origin type: %d", origin);
   }
 
-  if(lock)
-    prop_error(fn, pthread_mutex_lock(mutex), 0);
+  mtx_lock(&planet_mutex);
+  if(!planets) {
+    mtx_unlock(&planet_mutex);
+    return novas_error(3, EAGAIN, fn, "No planet ephemerides have been configured");
+  }
 
-  success = calceph_compute_unit(planets, jd_tdb[0], jd_tdb[1], target, center, CALCEPH_UNITS, pv);
+  ephem = planets;
 
-  if(lock)
-    pthread_mutex_unlock(mutex);
+  parallel = !serialized_calceph_queries && calceph_isthreadsafe(ephem);
+  if(parallel)
+    mtx_unlock(&planet_mutex);      // If CALCEPH itself is thread-safe we can release the lock here...
+  else if(ephem == bodies)
+    mtx_lock(&bodies_mutex);        // Otherwise, we might need to get exclusive on the bodies also....
+
+  success = calceph_compute_unit(ephem, jd_tdb[0], jd_tdb[1], target, center, CALCEPH_UNITS, pv);
+
+  // If CALCEPH is not thread-safe on its own, release the lock after the ephemeris access...
+  if(!parallel) {
+    if(ephem == bodies)
+      mtx_unlock(&bodies_mutex);    // If no separate planet ephemeris, then release the lock on the bodies also.
+
+    mtx_unlock(&planet_mutex);      // release the lock on planet ephemeris access.
+  }
 
   if(!success)
     return novas_error(3, EAGAIN, fn, "calceph_compute() failure (NOVAS ID=%d)", body);
@@ -320,7 +363,8 @@ static short planet_calceph(double jd_tdb, enum novas_planet body, enum novas_or
  *                      coordinates in AU/day. It may be NULL if velocities are not required.
  * @return              0 if successful, -1 if any of the pointer arguments are NULL, or some
  *                      non-zero value if the was an error s.t. the position and velocity
- *                      vector should not be used.
+ *                      vector should not be used (errno set to EINVAL); or if no
+ *                      ephemerides have been configured (errno set to EAGAIN).
  *
  * @author Attila Kovacs
  * @since 1.2
@@ -330,13 +374,16 @@ static short planet_calceph(double jd_tdb, enum novas_planet body, enum novas_or
 static int novas_calceph(const char *name, long id, double jd_tdb_high, double jd_tdb_low, enum novas_origin *origin, double *pos, double *vel) {
   static const char *fn = "novas_calceph";
 
+  t_calcephbin *ephem;
+  int parallel;
   double pv[6] = {0.0};
-  const int lock = !is_thread_safe_bodies || serialized_calceph_queries;
   int i, success, center;
+
+  if(!bodies)
+    return novas_error(-1, EAGAIN, fn, "No ephemerides have been configured");
 
   if(id == -1) {
     // Lookup by name...
-
     if(!name)
       return novas_error(-1, EINVAL, fn, "id=-1 and name is NULL");
 
@@ -356,13 +403,24 @@ static int novas_calceph(const char *name, long id, double jd_tdb_high, double j
 
   center = (compute_flags & CALCEPH_USE_NAIFID) ? NAIF_SSB : CALCEPH_SSB;
 
-  if(lock)
-    prop_error(fn, pthread_mutex_lock(&ephem_mutex), 0);
+  mtx_lock(&bodies_mutex);
+  if(!bodies) {
+    mtx_unlock(&bodies_mutex);
+    return novas_error(-1, EAGAIN, fn, "No ephemerides have been configured");
+  }
 
-  success = calceph_compute_unit(bodies, jd_tdb_high, jd_tdb_low, id, center, (compute_flags | CALCEPH_UNITS), pv);
+  ephem = bodies;
 
-  if(lock)
-    pthread_mutex_unlock(&ephem_mutex);
+  // If CALCEPH itself is thread-safe we can release the lock here...
+  parallel = !serialized_calceph_queries && calceph_isthreadsafe(ephem);
+  if(parallel)
+    mtx_unlock(&bodies_mutex);
+
+  success = calceph_compute_unit(ephem, jd_tdb_high, jd_tdb_low, id, center, (compute_flags | CALCEPH_UNITS), pv);
+
+  // If CALCEPH is not thread-safe on its own, release the lock after the ephemeris access...
+  if(!parallel)
+    mtx_unlock(&bodies_mutex);
 
   if(!success)
     return novas_error(3, EAGAIN, fn, "calceph_compute() failure (name='%s', NAIF=%ld)", name ? name : "<null>", id);
@@ -398,22 +456,27 @@ static int novas_calceph(const char *name, long id, double jd_tdb_high, double j
  */
 int novas_use_calceph(t_calcephbin *eph) {
   static const char *fn = "novas_use_calceph";
+  static int initialized = 0;
+
+  if(!initialized) {
+    mtx_init(&bodies_mutex, 0);
+    initialized = 1;
+  }
 
   prop_error(fn, prep_ephem(eph), 0);
 
   // Make sure we don't change the ephemeris provider while using it
-  prop_error(fn, pthread_mutex_lock(&ephem_mutex), 0);
-
-  is_thread_safe_bodies = calceph_isthreadsafe(eph);
+  mtx_lock(&bodies_mutex);
   bodies = eph;
-  pthread_mutex_unlock(&ephem_mutex);
+  mtx_unlock(&bodies_mutex);
 
   // Use CALCEPH as the default minor body ephemeris provider
   set_ephem_provider(novas_calceph);
 
   // If no planet provider is set (yet) use the same ephemeris for planets too
   // atleast until a dedicated planet provider is set.
-  if (!planets) novas_use_calceph_planets(eph);
+  if(!planets)
+    novas_use_calceph_planets(eph);
 
   return 0;
 }
@@ -433,15 +496,19 @@ int novas_use_calceph(t_calcephbin *eph) {
  */
 int novas_use_calceph_planets(t_calcephbin *eph) {
   static const char *fn = "novas_use_calceph_planets";
+  static int initialized = 0;
+
+  if(!initialized) {
+    mtx_init(&planet_mutex, 0);
+    initialized = 1;
+  }
 
   prop_error(fn, prep_ephem(eph), 0);
 
   // Make sure we don't change the ephemeris provider while using it
-  prop_error(fn, pthread_mutex_lock(&planet_mutex), 0);
-
-  is_thread_safe_planets = calceph_isthreadsafe(eph);
+  mtx_lock(&planet_mutex);
   planets = eph;
-  pthread_mutex_unlock(&planet_mutex);
+  mtx_unlock(&planet_mutex);
 
   // Use calceph as the default NOVAS planet provider
   set_planet_provider_hp(planet_calceph_hp);

--- a/src/timescale.c
+++ b/src/timescale.c
@@ -416,10 +416,14 @@ double get_utc_to_tt(int leap_seconds) {
  * </ol>
  *
  * @param leap_seconds  [s] Leap seconds at the time of observations
- * @param dut1          [s] UT1 - UTC time difference [-0.5:0.5], corrected for diurnal
- *                      variations due to libration and ocean tides.
- * @return              [s] The TT - UT1 time difference that is suitable for used with all
- *                      calls in this library that require a `ut1_to_tt` argument.
+ * @param dut1          [s] mean UT1-UTC time difference, e.g. as published in IERS Bulletin A
+ *                      (without diurnal corrections for libration and ocean tides), If the time
+ *                      offset is defined for a different ITRS realization than what is used for
+ *                      the coordinates of an Earth-based observer, you can use
+ *                      `novas_itrf_transform_eop()` to make it consistent.
+ * @return              [s] The TT - UT1 time difference that is suitable for use with all
+ *                      calls in this library that require a `ut1_to_tt` argument. It includes
+ *                      diurnal corrections for libration and ocean tides.
  *
  * @since 1.0
  * @author Attila Kovacs
@@ -834,11 +838,11 @@ double novas_diff_tcg(const novas_timespec *t1, const novas_timespec *t2) {
  * @param unix_time   [s] UNIX time (UTC) seconds
  * @param nanos       [ns] UTC sub-second component
  * @param leap        [s] Leap seconds, e.g. as published by IERS Bulletin C.
- * @param dut1        [s] UT1-UTC time difference, e.g. as published in IERS Bulletin A, and
- *                    possibly corrected for diurnal and semi-diurnal variations, e.g.
- *                    via `novas_diurnal_eop()`. If the time offset is defined for a different
- *                    ITRS realization than what is used for the coordinates of an Earth-based
- *                    observer, you can use `novas_itrf_transform_eop()` to make it consistent.
+ * @param dut1        [s] mean UT1-UTC time difference, e.g. as published in IERS Bulletin A
+ *                    (without diurnal corrections for libration and ocean tides), If the time
+ *                    offset is defined for a different ITRS realization than what is used for
+ *                    the coordinates of an Earth-based observer, you can use
+ *                    `novas_itrf_transform_eop()` to make it consistent.
  * @param[out] time   Pointer to the data structure that uniquely defines the astronomical time
  *                    for all applications.
  * @return            0 if successful, or else -1 if there was an error (errno will be set to
@@ -880,11 +884,11 @@ int novas_set_unix_time(time_t unix_time, long nanos, int leap, double dut1, nov
  * </ol>
  *
  * @param leap        [s] Leap seconds, e.g. as published by IERS Bulletin C.
- * @param dut1        [s] UT1-UTC time difference, e.g. as published in IERS Bulletin A, and
- *                    possibly corrected for diurnal and semi-diurnal variations, e.g.
- *                    via `novas_diurnal_eop()`. If the time offset is defined for a different
- *                    ITRS realization than what is used for the coordinates of an Earth-based
- *                    observer, you can use `novas_itrf_transform_eop()` to make it consistent.
+ * @param dut1        [s] mean UT1-UTC time difference, e.g. as published in IERS Bulletin A
+ *                    (without diurnal corrections for libration and ocean tides), If the time
+ *                    offset is defined for a different ITRS realization than what is used for
+ *                    the coordinates of an Earth-based observer, you can use
+ *                    `novas_itrf_transform_eop()` to make it consistent.
  * @param[out] time   Pointer to the data structure that uniquely defines the astronomical time
  *                    for all applications.
  * @return            0 if successful, or else -1 if there was an error (errno will be set to
@@ -898,7 +902,7 @@ int novas_set_unix_time(time_t unix_time, long nanos, int leap, double dut1, nov
 int novas_set_current_time(int leap, double dut1, novas_timespec *restrict time) {
   struct timespec t = {};
 
-#if !__ANDROID__ && (__STDC_VERSION__ >= 201112L || defined(_MSC_VER))
+#if (__STDC_VERSION__ >= 201112L && !defined(__ANDROID__)) || defined(_MSC_VER)
   timespec_get(&t, TIME_UTC);
 #else
   clock_gettime(CLOCK_REALTIME, &t);

--- a/test/src/test-calceph.c
+++ b/test/src/test-calceph.c
@@ -3,7 +3,7 @@
  * @author Attila Kovacs
  */
 
-#define _XOPEN_SOURCE 500           /// strdup()
+#define _DEFAULT_SOURCE             /// strdup()
 
 
 #include <stdio.h>

--- a/test/src/test-cspice.c
+++ b/test/src/test-cspice.c
@@ -3,7 +3,7 @@
  * @author Attila Kovacs
  */
 
-#define _XOPEN_SOURCE 500           /// strdup()
+#define _DEFAULT_SOURCE             /// strdup()
 
 
 #include <stdio.h>
@@ -197,8 +197,6 @@ static int test_remove_kernel() {
 
   return n;
 }
-
-
 
 static int init() {
   int n = 0;

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -2139,7 +2139,7 @@ static int test_set_current_time() {
   struct timespec now = {};
   novas_timespec t1 = {}, t2 = {};
 
-#if !__ANDROID__ && (__STDC_VERSION__ >= 201112L || defined(_MSC_VER))
+#if (__STDC_VERSION__ >= 201112L && !defined(__ANDROID__)) || defined(_MSC_VER)
   timespec_get(&now, TIME_UTC);
 #else
   clock_gettime(CLOCK_REALTIME, &now);


### PR DESCRIPTION
Update CALCEPH and CSPICE plugins to use portable mutexes beyond the POSIX pthread library.