### PR TITLE
Add caching to new functions in v1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,8 @@ Upcoming feature release, expected around 1 November 2025.
  
  - #265: CALCEPH and CSPICE plugins to use portable mutex code.
  
+ - #266: Add caching to `tt2tdb_hp()` and `novas_moon_phase()` functions.
+ 
  - Both CMake and GNU make now install only the headers for the components that were built. E.g. `novas-calceph.h` is 
    installed only if the library is built with the CALCEPH support option enabled.
  

--- a/src/frames.c
+++ b/src/frames.c
@@ -571,12 +571,8 @@ int novas_make_frame(enum novas_accuracy accuracy, const observer *obs, const no
   if(frame->gst < 0) frame->gst += DAY_HOURS;
 
   if(accuracy == NOVAS_FULL_ACCURACY) {
-    novas_delaunay_args a = {};
     double dxp = 0.0, dyp = 0.0;
-
-    fund_args((tdb2[0] + tdb2[1]) / (100.0 * NOVAS_JULIAN_YEAR_DAYS), &a);
-    novas_diurnal_eop(frame->gst, &a, &dxp, &dyp, NULL);
-
+    novas_diurnal_eop_at_time(&frame->time, &dxp, &dyp, NULL);
     frame->dx += 0.001 * dxp;
     frame->dy += 0.001 * dyp;
   }

--- a/src/timescale.c
+++ b/src/timescale.c
@@ -371,6 +371,11 @@ double tt2tdb_fp(double jd_tt, double limit) {
  * Returns the TDB-TT time difference with high precision. This implementation uses the full
  * series expansion by Fairhead &amp; Bretagnon 1990, resulting in an accuracy below 100 ns.
  *
+ * NOTES:
+ * <ol>
+ * <li>This function caches the result of the last calculation.</li>
+ * </ol>
+ *
  * REFERENCES:
  * <ol>
  * <li>Fairhead, L., &amp; Bretagnon, P. (1990) A&amp;A, 229, 240</li>
@@ -385,7 +390,14 @@ double tt2tdb_fp(double jd_tt, double limit) {
  * @sa tt2tdb_fp(), tt2tdb()
  */
 double tt2tdb_hp(double jd_tt) {
-  return tt2tdb_fp(jd_tt, 0.0);
+  static THREAD_LOCAL double last_tt = NAN, last_dt;
+
+  if(!novas_time_equals(jd_tt, last_tt)) {
+    last_dt = tt2tdb_fp(jd_tt, 0.0);
+    last_tt = jd_tt;
+  }
+
+  return last_dt;
 }
 
 /**

--- a/src/util.c
+++ b/src/util.c
@@ -207,7 +207,6 @@ double novas_vdot(const double *v1, const double *v2) {
  * for the highest accuracy calculations. As such it is safe to use the reduced accuracy time
  * check for cached precession-related quantities.
  *
- * @param accuracy  NOVAS_FULL_ACCURACY (0) or NOVAS_REDUCED_ACCURACY (1)
  * @param jd1       [day] a Julian date (in any time measure)
  * @param jd2       [day] a Julian date in the same time measure as the first argument
  * @return          TRUE (1) if the two dates are effectively the same at the precision of

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -4282,23 +4282,25 @@ static int test_ocean_tides() {
   return n;
 }
 
-static int test_diurnal_eop_at_time() {
+static int test_diurnal_eop() {
   int n = 0;
   novas_delaunay_args a = {};
   novas_timespec j2000 = {};
+  double gmst;
   double x[3], y[3], u[3];
 
   novas_set_time(NOVAS_TT, NOVAS_JD_J2000, 0.0, 0.0, &j2000);
+  gmst = novas_gmst(novas_get_time(&j2000, NOVAS_UT1), j2000.ut1_to_tt);
 
   if(!is_ok("diurnal_eop_at_time:args", fund_args(0.0, &a))) return 1;
 
   if(!is_ok("diurnal_eop_at_time", novas_diurnal_eop_at_time(&j2000, &x[0], &y[0], &u[0]))) return 1;
-  if(!is_ok("diurnal_eop_at_time:libration", novas_diurnal_libration(novas_gmst(NOVAS_JD_J2000, 0.0), &a, &x[1], &y[1], &u[1]))) return 1;
-  if(!is_ok("diurnal_eop_at_time:ocean_tides", novas_diurnal_ocean_tides(novas_gmst(NOVAS_JD_J2000, 0.0), &a, &x[2], &y[2], &u[2]))) return 1;
+  if(!is_ok("diurnal_eop_at_time:libration", novas_diurnal_libration(gmst, &a, &x[1], &y[1], &u[1]))) return 1;
+  if(!is_ok("diurnal_eop_at_time:ocean_tides", novas_diurnal_ocean_tides(gmst, &a, &x[2], &y[2], &u[2]))) return 1;
 
-  if(!is_equal("ocean_tides:x:only", x[0], x[1] + x[2], 1e-6)) n++;
-  if(!is_equal("ocean_tides:x:only", y[0], y[1] + y[2], 1e-6)) n++;
-  if(!is_equal("ocean_tides:x:only", u[0], u[1] + u[2], 1e-6)) n++;
+  if(!is_equal("diurnal_eop_at_time:check:x", x[0], x[1] + x[2], 1e-6)) n++;
+  if(!is_equal("diurnal_eop_at_time:check:y", y[0], y[1] + y[2], 1e-6)) n++;
+  if(!is_equal("diurnal_eop_at_time:check:z", u[0], u[1] + u[2], 1e-6)) n++;
 
   if(!is_ok("diurnal_eop_at_time", novas_diurnal_eop_at_time(&j2000, &x[1], NULL, NULL))) return 1;
   if(!is_equal("diurnal_eop_at_time:x:only", x[0], x[1], 1e-12)) n++;
@@ -4308,6 +4310,15 @@ static int test_diurnal_eop_at_time() {
 
   if(!is_ok("diurnal_eop_at_time", novas_diurnal_eop_at_time(&j2000, NULL, NULL, &u[1]))) return 1;
   if(!is_equal("diurnal_eop_at_time:x:only", u[0], u[1], 1e-12)) n++;
+
+  if(!is_ok("diurnal_eop", novas_diurnal_eop(gmst, &a, &x[1], NULL, NULL))) return 1;
+  if(!is_equal("diurnal_eop:x:only", x[0], x[1], 1e-12)) n++;
+
+  if(!is_ok("diurnal_eop", novas_diurnal_eop(gmst, &a, NULL, &y[1], NULL))) return 1;
+  if(!is_equal("diurnal_eop:x:only", y[0], y[1], 1e-12)) n++;
+
+  if(!is_ok("diurnal_eop", novas_diurnal_eop(gmst, &a, NULL, NULL, &u[1]))) return 1;
+  if(!is_equal("diurnal_eop:x:only", u[0], u[1], 1e-12)) n++;
 
   return n;
 }
@@ -4823,7 +4834,7 @@ int main(int argc, char *argv[]) {
   // v 1.5
   if(test_libration()) n++;
   if(test_ocean_tides()) n++;
-  if(test_diurnal_eop_at_time()) n++;
+  if(test_diurnal_eop()) n++;
 
   if(test_cartesian_to_geodetic()) n++;
   if(test_geodetic_to_cartesian()) n++;


### PR DESCRIPTION
Add caching to recently introduced intensive calculations, so that repeated calls with the same parameters as before can return fast.