### PR TITLE
Fixes and improvements to Moon's orbital modeling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Upcoming bug fix release.
    package dependencies and also __vcpkg__. Fixed by not renaming `core` target. (thanks to prookion).
 
  - #275: Error in `novas_sep()` formula. (thanks to prookyon)
+ 
+ - #276: Wrong eccentricity value in `novas_make_moon_orbit()`, resulting in errors up to a few degrees in the Moon's 
+   orbital modeling. (thanks to prookyon)
 
 ### Changed
 
@@ -31,6 +34,10 @@ Upcoming bug fix release.
  - #273: Removed unnecessary `POSITION_INDEPENDENT_CODE` from `CMakeLists.txt`. (It's automatic for shared libraries.)
 
  - #273: Updated `README.md` CMake snippet for building against the `supernovas` package.
+
+ - #276: Improved Lunar orbital modeling in `novas_make_moon_orbit()`, by updating to ELP200-85 model, and including 
+   the leading Solar perturbation terms for a typical accuracy at at 10 arcmin level for a day or so around the
+   reference epoch of the orbital parameters.
 
  - CMake: `cmake_minimum_required()` to include upper bound 4.0, in preparation to CMake 4.0 (see 
    https://fedoraproject.org/wiki/Changes/CMake4.0 for more explanation).

--- a/include/novas.h
+++ b/include/novas.h
@@ -1271,10 +1271,11 @@ typedef struct novas_orbital {
   double jd_tdb;                      ///< [day] Barycentri Dynamical Time (TDB) based Julian date of the parameters.
   double a;                           ///< [AU] semi-major axis
   double e;                           ///< eccentricity
-  double omega;                       ///< [deg] argument of periapsis / perihelion, at the reference time
-  double Omega;                       ///< [deg] argument of ascending node on the reference plane, at the reference time
+  double omega;                       ///< [deg] argument of periapsis / perihelion, at the reference time. I.e., distance
+                                      ///<       of apsis from ascending node.
+  double Omega;                       ///< [deg] argument of ascending node on the reference plane, at the reference time.
   double i;                           ///< [deg] inclination of orbit to the reference plane
-  double M0;                          ///< [deg] mean anomaly at the reference time
+  double M0;                          ///< [deg] mean anomaly at the reference time. I.e., time from periapsis as a periodic angle.
   double n;                           ///< [deg/day] mean daily motion, i.e. (_GM_/_a_<sup>3</sup>)<sup>1/2</sup> for the central body,
   ///< or 360/T, where T is orbital period in days.
   double apsis_period;                ///< [day] Precession period of the apsis, if known.

--- a/src/orbital.c
+++ b/src/orbital.c
@@ -173,15 +173,15 @@ static int orbit2gcrs(double jd_tdb, const novas_orbital_system *sys, enum novas
         jd = NOVAS_JD_J2000;
         break;
       case NOVAS_J2000:
-        eq = NOVAS_TRUE_EQUATOR;
+        eq = NOVAS_MEAN_EQUATOR;
         jd = NOVAS_JD_J2000;
+        break;
+      case NOVAS_MOD:
+        eq = NOVAS_MEAN_EQUATOR;
         break;
       case NOVAS_TOD:
       case NOVAS_CIRS:
         eq = NOVAS_TRUE_EQUATOR;
-        break;
-      case NOVAS_MOD:
-        eq = NOVAS_MEAN_EQUATOR;
         break;
       default:
         return novas_error(-1, EINVAL, fn, "invalid reference system: %d", sys->type);

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -2679,7 +2679,7 @@ static int test_orbit_place() {
   if(!is_ok("orbit_place:j2000", novas_orbit_posvel(tjd, &orbit, NOVAS_FULL_ACCURACY, p1, NULL))) n++;
   else {
     gcrs_to_j2000(p1, p1);
-    equ2ecl_vec(NOVAS_JD_J2000, NOVAS_TRUE_EQUATOR, NOVAS_FULL_ACCURACY, p1, p1);
+    equ2ecl_vec(NOVAS_JD_J2000, NOVAS_MEAN_EQUATOR, NOVAS_FULL_ACCURACY, p1, p1);
     if(!is_ok("orbit_place:j2000:check", check_equal_pos(p1, p0, 1e-8))) n++;
   }
 


### PR DESCRIPTION
Fix and improve Moon's orbital modeling:

- `novas_make_moon_orbit()` had wrong eccentricity, causing errors at the few degrees level.
- Updated mean orbital elements to ELP2000-85 (Chapront-Touze &amp; Chapron 1988).
- Now including the principal Solar perturbations for ~10 arcmin accuracy +/- a day or so from orbital reference epoch.
- Apsis period expressed w.r.t. the ascending node.