### PR TITLE
More tweaks to Moon orbital model.

### DIFF
--- a/.settings/language.settings.xml
+++ b/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="([^/\\\\]*)((g?cc)|([gc]\+\+)|(clang))" prefer-non-shared="true"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-260669110914231940" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-119924271906962170" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,9 @@ Upcoming bug fix release.
 
  - #273: Updated `README.md` CMake snippet for building against the `supernovas` package.
 
- - #276: Improved Lunar orbital modeling in `novas_make_moon_orbit()`, by updating to ELP/MPP02 model, and including 
-   the leading Solar perturbation terms for a typical accuracy at the 10 arcmin level for a day or so around the
-   reference epoch of the orbital parameters.
+ - #276, #280: Improved Lunar orbital modeling in `novas_make_moon_orbit()`, by using the leading terms from the 
+   ELP/MPP02 model, for a typical accuracy at the 10 arcmin level for a day or so around the reference epoch of the 
+   orbital parameters.
    
  - `novas_sep()` to use the Vincenty formula for calculating distances on a sphere, which is accurate for all 
    locations, unlike the law of cosines or the haversine formula used previously. 
@@ -45,6 +45,11 @@ Upcoming bug fix release.
 
  - CMake libraries (targets) built with transitive dependencies.
 
+### Added
+
+ - Added `NOVAS_ECLIPTIC_OF_DATE` orbital reference plane to `novas_reference_plane` enum. The existing 
+   `NOVAS_ECLIPTIC_PLANE` value now specifically refers to the mean ecliptic plane of J2000. Laskar 1986 is used for
+   converting the mean ecliptic of date to the mean ecliptic of J2000 before conversion to equatorial coordinates.
 
 ## [1.5.0] - 2025-10-29
 

--- a/include/novas.h
+++ b/include/novas.h
@@ -1108,7 +1108,7 @@ enum novas_nutation_direction {
  */
 enum novas_reference_plane {
   NOVAS_ECLIPTIC_PLANE = 0,     ///< the plane of the ecliptic
-  NOVAS_EQUATORIAL_PLANE        ///< The plane of the equator
+  NOVAS_EQUATORIAL_PLANE,       ///< the plane of the equator
 };
 
 /**
@@ -1215,12 +1215,13 @@ typedef struct novas_orbital_system {
   enum novas_planet center;          ///< major planet or barycenter at the center of the orbit.
   enum novas_reference_plane plane;  ///< reference plane NOVAS_ECLIPTIC_PLANE or NOVAS_EQUATORIAL_PLANE
   enum novas_reference_system type;  ///< the coordinate reference system used for the reference plane and orbitals.
-  ///< It must be a system, which does not co-rotate with Earth (i.e. not ITRS or
-  ///< TIRS).
-  double obl;                        ///< [rad] relative obliquity of orbital reference plane
-  ///<       (e.g. 90&deg; - &delta;<sub>pole</sub>)
-  double Omega;                      ///< [rad] relative argument of ascending node of the orbital reference plane
-  ///<       (e.g. &alpha;<sub>pole</sub> + 90&deg;)
+                                     ///< It must be a system, which does not co-rotate with Earth (i.e. not ITRS or
+                                     ///< TIRS).
+  double obl;                        ///< [deg] relative obliquity of orbital reference plane
+                                     ///<       (e.g. 90&deg; - &delta;<sub>pole</sub>)
+  double Omega;                      ///< [deg] relative argument of ascending node of the orbital reference plane
+                                     ///<       (e.g. &alpha;<sub>pole</sub> + 90&deg;). It is also the reference
+                                     ///<       longitude of the orbit defined in this system.
 } novas_orbital_system;
 
 
@@ -1280,10 +1281,14 @@ typedef struct novas_orbital {
   ///< or 360/T, where T is orbital period in days.
   double apsis_period;                ///< [day] Precession period of the apsis, if known.
   double node_period;                 ///< [day] Precession period of the ascending node, if known.
+
+  // TODO Add tidal perturbation terms for orbits in potential gradients, e.g. for improved Moon orbital model.
+  // double tide_angle;               ///< [deg] Tidal direction, measured from ascending node.
+  // double elongation;               ///< Tidal elongation as fraction of major axis.
 } novas_orbital;
 
 /**
- * Initializer for novas_orbital for heliocentric orbits using GCRS ecliptic pqrametrization.
+ * Initializer for novas_orbital for heliocentric orbits using GCRS ecliptic parametrization.
  *
  * @hideinitializer
  * @author Attila Kovacs
@@ -3328,11 +3333,10 @@ double novas_gmst_prec(double jd_tdb);
 double novas_cio_gcrs_ra(double jd_tdb);
 void novas_set_max_iter(int n);
 
-/*
 int novas_Rx(double angle, double *v);
 int novas_Ry(double angle, double *v);
 int novas_Rz(double angle, double *v);
-*/
+
 
 /**
  * Deprecated.

--- a/src/orbital.c
+++ b/src/orbital.c
@@ -74,17 +74,18 @@ namespace novas {
 
 /**
  * Change _xyz_ vectors to the new polar orientation. &theta, &phi define the orientation of the
- * input pole in the output system.
+ * input pole in the output system. (The origin of the orbital system is at the rising node,
+ * defined by the angle &Omega; in the output system.
  *
  * @param in        input 3-vector in the original system (pole = z)
- * @param theta     [deg] polar angle of original pole in the new system
- * @param phi       [deg] azimuthal angle of original pole in the new system
+ * @param obl       [deg] Obliquity of input system in output system
+ * @param Omega     [deg] Argument of the ascending node in output system
  * @param[out] out  output 3-vector in the new (rotated) system. It may be the same vector as the
  *                  input.
  * @return          0
  *
  */
-static int change_pole(const double *in, double theta, double phi, double *out) {
+static int change_pole(const double *in, double obl, double Omega, double *out) {
   double x, y, z;
   double ca, sa, cb, sb;
 
@@ -92,17 +93,17 @@ static int change_pole(const double *in, double theta, double phi, double *out) 
   y = in[1];
   z = in[2];
 
-  theta *= DEGREE;
-  phi *= DEGREE;
+  obl *= DEGREE;
+  Omega *= DEGREE;
 
-  ca = cos(phi);
-  sa = sin(phi);
-  cb = cos(theta);
-  sb = sin(theta);
+  ca = cos(Omega);
+  sa = sin(Omega);
+  cb = cos(obl);
+  sb = sin(obl);
 
   out[0] = ca * x - sa * (cb * y + sb * z);
   out[1] = sa * x + ca * (cb * y - sb * z);
-  out[2] = sb * y + cb * z;
+  out[2] =                sb * y + cb * z;
 
   return 0;
 }
@@ -142,7 +143,9 @@ static int equ2gcrs(double jd_tdb, enum novas_reference_system sys, double *vec)
 }
 
 /**
- * Convert coordinates in an orbital system to GCRS equatorial coordinates
+ * Convert coordinates in an orbital system to GCRS equatorial coordinates. For orbits defined w.r.t.
+ * the ecliptic of date, but for a reference system based in J2000, the conversion includes transforming
+ * the mean ecliptic of date to the mean ecliptic of J2000, using Laskar 1986.
  *
  * @param jd_tdb        [day] Barycentric Dynamic Time (TDB) based Julian Date
  * @param sys           Orbital system specification
@@ -402,7 +405,7 @@ int novas_orbit_posvel(double jd_tdb, const novas_orbital *restrict orbit, enum 
  * </ol>
  *
  * @param type  Coordinate reference system in which `ra` and `dec` are defined (e.g. NOVAS_GCRS).
- * @param ra    [h] the R.A. of the pole of the oribtal reference plane.
+ * @param ra    [h] the R.A. of the pole of the orbital reference plane.
  * @param dec   [deg] the declination of the pole of the oribtal reference plane.
  * @param[out]  sys   Orbital system
  * @return      0 if successful, or else -1 (errno will be set to EINVAL) if the output `sys`

--- a/src/system.c
+++ b/src/system.c
@@ -47,9 +47,9 @@ namespace novas {
  *                    NOVAS_GCRS_EQUATOR(2), the input GCRS coordinates are converted to
  *                    J2000 ecliptic coordinates.
  * @param accuracy    NOVAS_FULL_ACCURACY (0) or NOVAS_REDUCED_ACCURACY (1)
- * @param elon        [deg] Ecliptic longitude in degrees, referred to specified ecliptic and
+ * @param elon        [deg] Ecliptic longitude in degrees, referred to the specified ecliptic and
  *                    equinox of date.
- * @param elat        [deg] Ecliptic latitude in degrees, referred to specified ecliptic and
+ * @param elat        [deg] Ecliptic latitude in degrees, referred to the specified ecliptic and
  *                    equinox of date.
  * @param[out] ra     [h] Right ascension in hours, referred to specified equator and equinox
  *                    of date.
@@ -366,9 +366,9 @@ int equ2gal(double ra, double dec, double *restrict glon, double *restrict glat)
  *                    NOVAS_GCRS_EQUATOR(2), the input GCRS coordinates are converted to
  *                    J2000 ecliptic coordinates.
  * @param accuracy    NOVAS_FULL_ACCURACY (0) or NOVAS_REDUCED_ACCURACY (1)
- * @param ra          [h] Right ascension in hours, referred to specified equator and equinox
+ * @param ra          [h] Right ascension in hours, referred to the specified equator and equinox
  *                    of date.
- * @param dec         [deg] Declination in degrees, referred to specified equator and equinox
+ * @param dec         [deg] Declination in degrees, referred to the specified equator and equinox
  *                    of date.
  * @param[out] elon   [deg] Ecliptic longitude in degrees, referred to specified ecliptic and
  *                    equinox of date.
@@ -421,8 +421,8 @@ short equ2ecl(double jd_tt, enum novas_equator_type coord_sys, enum novas_accura
  *                    is NOVAS_GCRS_EQUATOR[2])
  * @param coord_sys   The astrometric reference system type of the coordinates.
  * @param accuracy    NOVAS_FULL_ACCURACY (0) or NOVAS_REDUCED_ACCURACY (1)
- * @param in          Position vector, referred to specified equator and equinox of date.
- * @param[out] out    Position vector, referred to specified ecliptic and equinox of date.
+ * @param in          Position vector, referred to the specified equator and equinox of date.
+ * @param[out] out    Position vector, referred to the specified ecliptic and equinox of date.
  *                    It can be the same vector as the input. If 'coord_sys' is
  *                    NOVAS_GCRS_EQUATOR(2), the input GCRS coordinates are converted to
  *                    J2000 ecliptic coordinates.
@@ -500,8 +500,8 @@ short equ2ecl_vec(double jd_tt, enum novas_equator_type coord_sys, enum novas_ac
  *                    is NOVAS_GCRS_EQUATOR[2])
  * @param coord_sys   The astrometric reference system type of the coordinates
  * @param accuracy    NOVAS_FULL_ACCURACY (0) or NOVAS_REDUCED_ACCURACY (1)
- * @param in          Position vector, referred to specified ecliptic and equinox of date.
- * @param[out] out    Position vector, referred to specified equator and equinox of date. It
+ * @param in          Position vector, referred to the specified ecliptic and equinox of date.
+ * @param[out] out    Position vector, referred to the specified equator and equinox of date. It
  *                    can be the same vector as the input.
  * @return            0 if successful, -1 if either vector argument is NULL or the accuracy
  *                    is invalid, or else 1 if the value of 'coord_sys' is invalid.

--- a/src/util.c
+++ b/src/util.c
@@ -267,7 +267,7 @@ void novas_tiny_rotate(const double *in, double ax, double ay, double az, double
 }
 
 /**
- * Sets the maximum number of iterations allowed for convergent inverese calculations.
+ * Sets the maximum number of iterations allowed for convergent inverse calculations.
  *
  * @param n   Maximum number of iterations allowed.
  *
@@ -277,6 +277,63 @@ void novas_tiny_rotate(const double *in, double ax, double ay, double az, double
 void novas_set_max_iter(int n) {
   novas_inv_max_iter = n;
 }
+
+static int novas_rot(double angle, double *x, double *y) {
+  const double s = sin(angle);
+  const double c = cos(angle);
+  const double x0 = *x;
+
+  *x =  c * x0 + s * (*y);
+  *y = -s * x0 + c * (*y);
+
+  return 0;
+}
+
+/**
+ * Rotates a vector around the _x_-axis, counter clockwise when looking out from
+ * the origin along _x_.
+ *
+ * @param angle       [rad] rotation angle
+ * @param[in,out] v   Vector to rotate
+ * @return            0 if successful, or else -1 if the vector argument is NULL
+ *                    (errno set to EINVAL).
+ */
+int novas_Rx(double angle, double *v) {
+  if(!v)
+    return novas_error(-1, EINVAL, "novas_Rx", "input/output vector is NULL");
+  return novas_rot(angle, &v[1], &v[2]);
+}
+
+/**
+ * Rotates a vector around the _y_-axis, counter clockwise when looking out from
+ * the origin along _y_.
+ *
+ * @param angle       [rad] rotation angle
+ * @param[in,out] v   Vector to rotate
+ * @return            0 if successful, or else -1 if the vector argument is NULL
+ *                    (errno set to EINVAL).
+ */
+int novas_Ry(double angle, double *v) {
+  if(!v)
+    return novas_error(-1, EINVAL, "novas_Ry", "input/output vector is NULL");
+  return novas_rot(angle, &v[2], &v[0]);
+}
+
+/**
+ * Rotates a vector around the _z_-axis, counter clockwise when looking out from
+ * the origin along _z_.
+ *
+ * @param angle       [rad] rotation angle
+ * @param[in,out] v   Vector to rotate
+ * @return            0 if successful, or else -1 if the vector argument is NULL
+ *                    (errno set to EINVAL).
+ */
+int novas_Rz(double angle, double *v) {
+  if(!v)
+    return novas_error(-1, EINVAL, "novas_Rz", "input/output vector is NULL");
+  return novas_rot(angle, &v[0], &v[1]);
+}
+
 
 /// \endcond PROTECTED
 

--- a/test/src/test-errors.c
+++ b/test/src/test-errors.c
@@ -2485,6 +2485,16 @@ static int test_transform_geodetic() {
   return n;
 }
 
+static int test_rot() {
+  int n = 0;
+
+  if(check("rot:Rx", -1, novas_Rx(0.0, NULL))) n++;
+  if(check("rot:Ry", -1, novas_Ry(0.0, NULL))) n++;
+  if(check("rot:Rz", -1, novas_Rz(0.0, NULL))) n++;
+
+  return n;
+}
+
 int main(int argc, const char *argv[]) {
   int n = 0;
 
@@ -2696,6 +2706,8 @@ int main(int argc, const char *argv[]) {
   if(test_set_default_weather()) n++;
   if(test_itrf_transform_site()) n++;
   if(test_transform_geodetic()) n++;
+
+  if(test_rot()) n++;
 
   if(n) fprintf(stderr, " -- FAILED %d tests\n", n);
   else fprintf(stderr, " -- OK\n");

--- a/test/src/test-super.c
+++ b/test/src/test-super.c
@@ -4097,60 +4097,110 @@ static int test_make_moon_orbit() {
   object moon = {};
   sky_pos pos = {};
   double jd = NOVAS_JD_J2000;
+  double sumx = 0.0, sumy = 0.0, rms;
 
-  //double b0, b1, l0, l1;
+  double jpl[52][3] = { //
+          { 2451544.5,     216.67576,  -8.99703 },
+          { 2452264.5,     342.36276, -12.90842 },
+          { 2452984.5,     103.29512,  26.98992 },
+          { 2453704.5,     223.82514, -19.76069 },
+          { 2454424.5,     353.01741,  -1.12209 },
+          { 2455144.5,     129.95454,  17.06337 },
+          { 2455864.5,     259.20091, -22.57588 },
+          { 2456584.5,      23.47711,  10.95540 },
+          { 2457304.5,     152.92399,   8.41774 },
+          { 2458024.5,     273.71177, -19.44667 },
+          { 2458744.5,      35.78456,   9.29532 },
+          { 2459464.5,     167.05508,  10.92245 },
+          { 2460184.5,     293.21493, -26.87518 },
+          { 2460904.5,      61.34374,  26.00650 },
+          { 2461624.5,     193.47181, -10.99723 },
+          { 2462344.5,     322.31292, -10.82091 },
+          { 2463064.5,      85.59313,  20.85130 },
+          { 2463784.5,     206.16268,  -9.77217 },
+          { 2464504.5,     332.90633, -10.61694 },
+          { 2465224.5,     100.92869,  21.39741 },
+          { 2465944.5,     226.71784, -14.50273 },
+          { 2466664.5,       2.21811,  -3.01084 },
+          { 2467384.5,     136.57748,  20.96113 },
+          { 2468104.5,     254.81795, -27.49122 },
+          { 2468824.5,      16.62860,  12.48050 },
+          { 2469544.5,     143.11761,   9.40655 },
+          { 2470264.5,     265.50603, -19.10177 },
+          { 2470984.5,      35.42012,  10.39975 },
+          { 2471704.5,     168.33755,   7.67623 },
+          { 2472424.5,     299.37536, -22.22046 },
+          { 2473144.5,      66.54787,  22.38175 },
+          { 2473864.5,     191.10386,  -3.89302 },
+          { 2474584.5,     317.66613, -18.82552 },
+          { 2475304.5,      76.20722,  26.76212 },
+          { 2476024.5,     197.84292, -12.82374 },
+          { 2476744.5,     333.68438,  -5.50634 },
+          { 2477464.5,     106.16260,  17.55346 },
+          { 2478184.5,     232.74963, -13.92513 },
+          { 2478904.5,       5.10081,  -3.02749 },
+          { 2479624.5,     130.09104,  22.53349 },
+          { 2480344.5,     246.45525, -24.29337 },
+          { 2481064.5,      11.71903,   6.09685 },
+          { 2481784.5,     140.16308,  16.12728 },
+          { 2482504.5,     270.15019, -24.68580 },
+          { 2483224.5,      40.81044,  17.73999 },
+          { 2483944.5,     170.40302,   0.81585 },
+          { 2484664.5,     299.55050, -16.43272 },
+          { 2485384.5,      60.21242,  15.51971 },
+          { 2486104.5,     184.73889,   3.52971 },
+          { 2486824.5,     312.51612, -22.68359 },
+          { 2487544.5,      72.33317,  26.71028 },
+          { 2488264.5,     203.01589, -13.75745 }
+  };
 
   const double tol = 0.2; // [deg]
+  int i;
 
   // Compare to JPL Horizons...
-  // 24.8E, 59.4N
-  make_gps_observer(59.4, 24.8, 0.0, &obs);
+  make_observer_at_geocenter(&obs);
 
-  // 2000-01-01 12 UTC
-  novas_set_time(NOVAS_UTC, jd, 32, 0.0, &t);
-  novas_make_frame(NOVAS_REDUCED_ACCURACY, &obs, &t, 0.0, 0.0, &f);
-  novas_make_moon_orbit(jd, &moon_orbit);
-  make_orbital_object("Moon", -1, &moon_orbit, &moon);
-  novas_sky_pos(&moon, &f, NOVAS_ICRS, &pos);
+  for(i = 0; i < 52; i++) {
+    double elon0, elon1, elat0, elat1, dlon, dlat;
 
-  if(!is_equal("make_moon_orbit:2000:ra", 15.0 * pos.ra, 221.99023, tol)) n++;
-  if(!is_equal("make_moon_orbit:2000:dec", pos.dec, -11.67702, tol)) n++;
+    jd = jpl[i][0];
 
-  //equ2ecl(jd, NOVAS_GCRS_EQUATOR, NOVAS_FULL_ACCURACY, 221.99023 / 15.0, -11.67702, &b0, &l0);
-  //equ2ecl(jd, NOVAS_GCRS_EQUATOR, NOVAS_FULL_ACCURACY, pos.ra, pos.dec, &b1, &l1);
-  //printf("### 2000:  %8.1f   %8.1f\n", (b1 - b0) * cos(l0 * DEGREE) * 3600.0, (l1 - l0) * 3600.0);
+    novas_set_time(NOVAS_UTC, jd, 32, 0.0, &t);
+    novas_make_frame(NOVAS_REDUCED_ACCURACY, &obs, &t, 0.0, 0.0, &f);
+    novas_make_moon_orbit(jd, &moon_orbit);
+    make_orbital_object("Moon", -1, &moon_orbit, &moon);
+    novas_sky_pos(&moon, &f, NOVAS_ICRS, &pos);
+
+    if(!is_equal("make_moon_orbit:2000:ra", 15.0 * pos.ra, jpl[i][1], tol)) n++;
+    if(!is_equal("make_moon_orbit:2000:dec", pos.dec, jpl[i][2], tol)) n++;
+
+    equ2ecl(jd, NOVAS_GCRS_EQUATOR, NOVAS_FULL_ACCURACY, jpl[i][1] / 15.0, jpl[i][2], &elon0, &elat0);
+    equ2ecl(jd, NOVAS_GCRS_EQUATOR, NOVAS_FULL_ACCURACY, pos.ra, pos.dec, &elon1, &elat1);
+
+    dlon = (elon1 - elon0) * cos(elat0 * DEGREE) * 3600.0;
+    dlat = (elat1 - elat0) * 3600.0;
+
+    //printf("### %2d:  %10.3f   %10.3f\n", i, dlon, dlat);
+
+    sumx += dlon * dlon;
+    sumy += dlat * dlat;
+  }
+
+  rms = sqrt((sumx + sumy) / 20);
+
+  sumx = sqrt(sumx / 20);
+  sumy = sqrt(sumy / 20);
 
 
-  // 2025-01-16 0 UTC
-  jd = julian_date(2025, 1, 16, 0.0);
-  novas_set_time(NOVAS_UTC, jd, 37, 0.0, &t);
-  novas_make_frame(NOVAS_REDUCED_ACCURACY, &obs, &t, 0.0, 0.0, &f);
-  novas_make_moon_orbit(jd, &moon_orbit);
-  make_orbital_object("Moon", -1, &moon_orbit, &moon);
-  novas_sky_pos(&moon, &f, NOVAS_ICRS, &pos);
 
-  if(!is_equal("make_moon_orbit:2025:ra", 15.0 * pos.ra, 144.25406, tol)) n++;
-  if(!is_equal("make_moon_orbit:2025:dec", pos.dec, 16.90456, tol)) n++;
+  if(rms > 500.0) {
+    printf("  ERROR! make_moon_orbit: RMS = %8.3f (x: %8.3f, y: %8.3f)\n", rms, sumx, sumy);
+    n++;
+  }
+  else {
+    printf("  ... make_moon_orbit: RMS = %8.3f (x: %8.3f, y: %8.3f)\n", rms, sumx, sumy);
+  }
 
-  //equ2ecl(jd, NOVAS_GCRS_EQUATOR, NOVAS_FULL_ACCURACY, 144.25406 / 15.0, 16.90456, &b0, &l0);
-  //equ2ecl(jd, NOVAS_GCRS_EQUATOR, NOVAS_FULL_ACCURACY, pos.ra, pos.dec, &b1, &l1);
-  //printf("### 2025:  %8.1f   %8.1f\n", (b1 - b0) * cos(l0 * DEGREE) * 3600.0, (l1 - l0) * 3600.0);
-
-
-  // 2050-07-01 0 UTC
-  jd = julian_date(2050, 7, 1, 0.0);
-  novas_set_time(NOVAS_UTC, jd, 37, 0.0, &t);
-  novas_make_frame(NOVAS_REDUCED_ACCURACY, &obs, &t, 0.0, 0.0, &f);
-  novas_make_moon_orbit(jd, &moon_orbit);
-  make_orbital_object("Moon", -1, &moon_orbit, &moon);
-  novas_sky_pos(&moon, &f, NOVAS_ICRS, &pos);
-
-  if(!is_equal("make_moon_orbit:2050:ra", 15.0 * pos.ra, 227.18480, tol)) n++;
-  if(!is_equal("make_moon_orbit:2050:dec", pos.dec, -18.48617, tol)) n++;
-
-  //equ2ecl(jd, NOVAS_GCRS_EQUATOR, NOVAS_FULL_ACCURACY, 227.18480 / 15.0, -18.48617, &b0, &l0);
-  //equ2ecl(jd, NOVAS_GCRS_EQUATOR, NOVAS_FULL_ACCURACY, pos.ra, pos.dec, &b1, &l1);
-  //printf("### 2050:  %8.1f   %8.1f\n", (b1 - b0) * cos(l0 * DEGREE) * 3600.0, (l1 - l0) * 3600.0);
 
   return n;
 }
@@ -4773,6 +4823,51 @@ static int test_geodetic_transform_site() {
   return n;
 }
 
+static int test_Rx() {
+  int n = 0;
+
+  double p[3] = {1.0, -2.0, 3.0};
+  double angle = 19.5 * DEGREE;
+
+  novas_Rx(angle, p);
+
+  if(!is_equal("Rx:x", p[0], 1.0, 1e-15)) n++;
+  if(!is_equal("Rx:y", p[1], -2.0 * cos(angle) + 3.0 * sin(angle), 1e-15)) n++;
+  if(!is_equal("Rx:z", p[2], 2.0 * sin(angle) + 3.0 * cos(angle), 1e-15)) n++;
+
+  return n;
+}
+
+static int test_Ry() {
+  int n = 0;
+
+  double p[3] = {1.0, -2.0, 3.0};
+  double angle = 19.5 * DEGREE;
+
+  novas_Ry(angle, p);
+
+  if(!is_equal("Ry:x", p[0], 1.0 * cos(angle) - 3.0 * sin(angle) , 1e-15)) n++;
+  if(!is_equal("Ry:y", p[1], -2.0, 1e-15)) n++;
+  if(!is_equal("Ry:z", p[2], 1.0 * sin(angle) + 3.0 * cos(angle), 1e-15)) n++;
+
+  return n;
+}
+
+static int test_Rz() {
+  int n = 0;
+
+  double p[3] = {1.0, -2.0, 3.0};
+  double angle = 19.5 * DEGREE;
+
+  novas_Rz(angle, p);
+
+  if(!is_equal("Rz:x", p[0], 1.0 * cos(angle) - 2.0 * sin(angle), 1e-15)) n++;
+  if(!is_equal("Rz:y", p[1], -1.0 * sin(angle) - 2.0 * cos(angle), 1e-15)) n++;
+  if(!is_equal("Rz:z", p[2], 3.0, 1e-15)) n++;
+
+  return n;
+}
+
 int main(int argc, char *argv[]) {
   int n = 0;
 
@@ -4925,6 +5020,10 @@ int main(int argc, char *argv[]) {
   if(test_set_default_weather()) n++;
   if(test_itrf_transform_site()) n++;
   if(test_geodetic_transform_site()) n++;
+
+  if(test_Rx()) n++;
+  if(test_Ry()) n++;
+  if(test_Rz()) n++;
 
   n += test_dates();
 


### PR DESCRIPTION
Use ELP/MPP02 semi-analytic model of the Moon to improve its short-term Keplerian model. However, the Moon's motion is strongly non-Keplerian, so the best we can do is about 8 arcmin RMS accuracy with a purely Keplerian model.