### PR TITLE
Cleaning up and pruning of the C++ API

### DIFF
--- a/include/novas.h
+++ b/include/novas.h
@@ -334,7 +334,7 @@
 /// [m] Default distance at which sidereal sources are assumed when not specified otherwise
 /// Historically NOVAS placed sources with no parallax at 1 Gpc distance, and so we follow.
 /// @since 1.5
-/// @ingroup source
+/// @c_source
 #define NOVAS_DEFAULT_DISTANCE    (1e9 * NOVAS_PARSEC)
 
 /// [m<sup>3</sup>/s<sup>2</sup>] Heliocentric gravitational constant (GM<sub>sun</sub>) from DE440,
@@ -1739,7 +1739,7 @@ typedef struct novas_ra_of_cio {
 
 
 /**
- * Constants to reference various astrnomical timescales used
+ * Constants to reference various astronomical timescales used
  *
  * @since 1.1
  *
@@ -3172,7 +3172,7 @@ int novas_orbit_native_posvel(double jd_tdb, const novas_orbital *restrict orbit
 /// @c_source
 int novas_make_planet_orbit(enum novas_planet id, double jd_tdb, novas_orbital *restrict orbit);
 
-/// @ingroup source
+/// @c_source
 int novas_make_moon_orbit(double jd_tdb, novas_orbital *restrict orbit);
 
 /// @c_geometric
@@ -3299,7 +3299,7 @@ int novas_set_default_weather(on_surface *site);
 
 // ---------------------- Added in 1.5.1 -------------------------
 
-/// @ingroup source
+/// @c_source
 int novas_make_moon_mean_orbit(double jd_tdb, novas_orbital *restrict orbit);
 
 

--- a/include/supernovas.h
+++ b/include/supernovas.h
@@ -278,7 +278,8 @@ public:
  * co-rotating systems (TIRS and ITRS).
  *
  * @sa CatalogEntry, Equatorial, Ecliptic, Apparent, Geometric
- * @ingroup source
+ *
+ * @ingroup util
  */
 class Equinox : public Validating {
 private:
@@ -875,17 +876,11 @@ public:
 
   Equatorial to_hip() const;
 
-  Equatorial to_mod(double jd_tdb) const;
-
   Equatorial to_mod(const Time& time) const;
 
   Equatorial to_mod_at_besselian_epoch(double year) const;
 
-  Equatorial to_tod(double jd_tdb) const;
-
   Equatorial to_tod(const Time& time) const;
-
-  Equatorial to_cirs(double jd_tdb) const;
 
   Equatorial to_cirs(const Time& time) const;
 
@@ -953,11 +948,7 @@ public:
 
   Ecliptic to_j2000() const;
 
-  Ecliptic to_mod(double jd_tdb) const;
-
   Ecliptic to_mod(const Time& time) const;
-
-  Ecliptic to_tod(double jd_tdb) const;
 
   Ecliptic to_tod(const Time& time) const;
 
@@ -1128,7 +1119,7 @@ public:
 };
 
 /**
- * Mean (inerpolated) IERS Earth Orientation Parameters (%EOP), without diurnal variations. IERS
+ * Mean (interpolated) IERS Earth Orientation Parameters (%EOP), without diurnal variations. IERS
  * publishes daily values, short-term and medium term forecasts, and historical data for the
  * measured, unmodelled (by the IAU 2006 precession-nutation model), _x_<sub>p</sub>,
  * _y_<sub>p</sub> pole offsets, leap-seconds (UTC - TAI difference), and the current UT1 - UTC
@@ -1852,6 +1843,7 @@ public:
 
   Equatorial equatorial() const;
 
+  /// @ingroup source
   CatalogSource to_source() const;
 
   CatalogEntry& proper_motion(double ra, double dec);
@@ -2031,7 +2023,7 @@ public:
  *     or referencing it in parallel threads unmodified.
  *
  * @sa Orbital
- * @ingroup source
+ * @ingroup util
  */
 class OrbitalSystem : public Validating {
 private:
@@ -2093,7 +2085,7 @@ public:
  *     the orbital first, before using in parallel threads unmodified.
  *
  * @sa EphemerisSource, Planet::orbit()
- * @ingroup source
+ * @ingroup util
  */
 class Orbital : public Validating {
 private:
@@ -2148,6 +2140,7 @@ public:
 
   Velocity velocity(const Time& time, enum novas_accuracy accuracy = NOVAS_FULL_ACCURACY) const;
 
+  /// @ingroup source
   OrbitalSource to_source(const std::string& name) const;
 
   Orbital& eccentricity(double e, double periapsis_rad);
@@ -2179,6 +2172,10 @@ public:
   std::string to_string() const;
 
   static Orbital from_novas_orbit(const novas_orbital *orbit);
+
+  static Orbital moon_orbit_at(const Time& time);
+
+  static Orbital moon_mean_orbit_at(const Time& time);
 };
 
 /**
@@ -2409,7 +2406,7 @@ public:
 
   const Angle& elevation() const;
 
-  const Angle zenith_angle() const;
+  Angle zenith_angle() const;
 
   /// @ingroup refract
   Horizontal to_refracted(RefractionModel ref, const Weather& weather = Weather::standard(), const Time &time = Time::undefined());
@@ -2576,7 +2573,7 @@ public:
  * validity, at very low computational cost.
  *
  * @sa Apparent::horizontal(), EquatorialTrack
- * @ingroup tracking nonequatorial
+ * @ingroup tracking
  */
 class HorizontalTrack : public Track<Horizontal> {
 private:
@@ -2606,7 +2603,7 @@ public:
  * of validity, at very low computational cost.
  *
  * @sa Apparent::equatorial(), HorizontalTrack
- * @ingroup tracking apparent
+ * @ingroup tracking
  */
 class EquatorialTrack : public Track<Equatorial> {
 private:

--- a/src/cpp/Ecliptic.cpp
+++ b/src/cpp/Ecliptic.cpp
@@ -294,59 +294,21 @@ Ecliptic Ecliptic::to_j2000() const {
  * Converts these ecliptic coordinates to Mean-of-Date (MOD) ecliptic coordinates at the
  * specified epch.
  *
- * @param jd_tdb  [day] the (TDB-based) Julian date specifying the coordinate epoch.
- * @return        the equivalent MOD ecliptic coordinates at the specified date.
- *
- * @sa to_system(), to_mod(), to_tod(), to_icrs(), to_j2000()
- */
-Ecliptic Ecliptic::to_mod(double jd_tdb) const {
-  if(!isfinite(jd_tdb))
-    novas_set_errno(EINVAL, "Ecliptic::to_mod()", "input Julian Date is NAN or infinite");
-
-  if(jd_tdb == NOVAS_JD_J2000)
-    return to_j2000();
-
-  if(_equator == NOVAS_MEAN_EQUATOR && _jd == jd_tdb)
-    return (*this);
-
-  Ecliptic e = to_equatorial().to_mod(jd_tdb).to_ecliptic();
-  if(!e.is_valid())
-    novas_trace_invalid("Ecliptic::to_mod()");
-  return e;
-}
-
-/**
- * Converts these ecliptic coordinates to Mean-of-Date (MOD) ecliptic coordinates at the
- * specified epch.
- *
  * @param time    the astronomical time specifying the coordinate epoch.
  * @return        the equivalent MOD ecliptic coordinates at the specified date.
  *
  * @sa to_system(), to_mod(), to_tod(), to_icrs(), to_j2000()
  */
 Ecliptic Ecliptic::to_mod(const Time& time) const {
-  return to_mod(time.jd(NOVAS_TDB));
-}
+  if(time == Time::j2000())
+    return to_j2000();
 
-/**
- * Converts these ecliptic coordinates to True-of-Date (TOD) ecliptic coordinates at the
- * specified epch.
- *
- * @param jd_tdb  [day] the (TDB-based) Julian date specifying the coordinate epoch.
- * @return        the equivalent TOD ecliptic coordinates at the specified date.
- *
- * @sa to_system(), to_tod(), to_mod(), to_icrs(), to_j2000()
- */
-Ecliptic Ecliptic::to_tod(double jd_tdb) const {
-  if(!isfinite(jd_tdb))
-      novas_set_errno(EINVAL, "Ecliptic::to_tod()", "input Julian Date is NAN or infinite");
-
-  if(_equator == NOVAS_TRUE_EQUATOR && _jd == jd_tdb)
+  if(_equator == NOVAS_MEAN_EQUATOR && _jd == time.jd())
     return (*this);
 
-  Ecliptic e = to_equatorial().to_tod(jd_tdb).to_ecliptic();
+  Ecliptic e = to_equatorial().to_mod(time).to_ecliptic();
   if(!e.is_valid())
-    novas_trace_invalid("Ecliptic::to_tod()");
+    novas_trace_invalid("Ecliptic::to_mod()");
   return e;
 }
 
@@ -360,7 +322,13 @@ Ecliptic Ecliptic::to_tod(double jd_tdb) const {
  * @sa to_system(), to_tod(), to_mod(), to_icrs(), to_j2000()
  */
 Ecliptic Ecliptic::to_tod(const Time& time) const {
-  return to_tod(time.jd(NOVAS_TDB));
+  if(_equator == NOVAS_TRUE_EQUATOR && _jd == time.jd())
+    return (*this);
+
+  Ecliptic e = to_equatorial().to_tod(time).to_ecliptic();
+  if(!e.is_valid())
+    novas_trace_invalid("Ecliptic::to_tod()");
+  return e;
 }
 
 /**

--- a/src/cpp/Equatorial.cpp
+++ b/src/cpp/Equatorial.cpp
@@ -316,29 +316,9 @@ Equatorial Equatorial::to_j2000() const {
  * @sa to_system(), to_icrs(), to_j2000()
  */
 Equatorial Equatorial::to_hip() const {
-  Equatorial e = to_system(Equinox::mod(NOVAS_JD_HIP));
+  Equatorial e = to_system(Equinox::hip());
   if(!e.is_valid())
     novas_trace_invalid("Equatorial::to_hip()");
-  return e;
-}
-
-/**
- * Converts these equatorial coordinates to the Mean-of-Date (MOD) catalog coordinate system, at
- * the specified coordinate epoch.
- *
- * @param jd_tdb    [day] (TDB-based) Julian date of the coordinate epoch.
- * @return          new equatorial coordinates, which represent the same equatorial position as
- *                  this, but expressed in the MOD catalog system of date.
- *
- * @sa to_mod_at_besselian_epoch(), to_system(), to_j2000(), to_tod()
- */
-Equatorial Equatorial::to_mod(double jd_tdb) const {
-  if(!isfinite(jd_tdb))
-      novas_set_errno(EINVAL, "Equatorial::to_mod()", "input Julian Date is NAN or infinite");
-
-  Equatorial e = to_system(Equinox::mod(jd_tdb));
-  if(!e.is_valid())
-    novas_trace_invalid("Equatorial::to_mod()");
   return e;
 }
 
@@ -353,7 +333,10 @@ Equatorial Equatorial::to_mod(double jd_tdb) const {
  * @sa to_mod_at_besselian_epoch(), to_system(), to_j2000(), to_tod()
  */
 Equatorial Equatorial::to_mod(const Time& time) const {
-  return to_mod(time.jd(NOVAS_TDB));
+  Equatorial e = to_system(Equinox::mod(time));
+  if(!e.is_valid())
+    novas_trace_invalid("Equatorial::to_mod()");
+  return e;
 }
 
 /**
@@ -381,27 +364,6 @@ Equatorial Equatorial::to_mod_at_besselian_epoch(double year) const {
  * specified coordinate epoch. TOD is defined on the true dynamical equator of date, with its
  * origin at the true equinox of date.
  *
- * @param jd_tdb    [day] (TDB-based) Julian date of the coordinate epoch.
- * @return          new equatorial coordinates, which represent the same equatorial position as
- *                  this, but expressed with respect to the true equator and equinox of date.
- *
- * @sa to_system(), to_cirs(), to_j2000(), to_mod()
- */
-Equatorial Equatorial::to_tod(double jd_tdb) const {
-  if(!isfinite(jd_tdb))
-      novas_set_errno(EINVAL, "Equatorial::to_tod()", "input Julian Date is NAN or infinite");
-
-  Equatorial e = to_system(Equinox::tod(jd_tdb));
-  if(!e.is_valid())
-    novas_trace_invalid("Equatorial::to_tod()");
-  return e;
-}
-
-/**
- * Converts these equatorial coordinates to the True-of-Date (TOD) coordinate system, at the
- * specified coordinate epoch. TOD is defined on the true dynamical equator of date, with its
- * origin at the true equinox of date.
- *
  * @param time      [day] the astronomical time specification for the coordinate epoch.
  * @return          new equatorial coordinates, which represent the same equatorial position as
  *                  this, but expressed with respect to the true equator and equinox of date.
@@ -409,27 +371,9 @@ Equatorial Equatorial::to_tod(double jd_tdb) const {
  * @sa to_system(), to_cirs(), to_j2000(), to_mod()
  */
 Equatorial Equatorial::to_tod(const Time& time) const {
-  return to_tod(time.jd(NOVAS_TDB));
-}
-
-/**
- * Converts these equatorial coordinates to the Celestial Intermediate Reference System (CIRS)
- * coordinate system, at the specified coordinate epoch. CIRS is defined on the true dynamical
- * equator of date, with its origin at the Celestial Intermediate Origin (CIO).
- *
- * @param jd_tdb    [day] (TDB-based) Julian date of the coordinate epoch.
- * @return          new equatorial coordinates, which represent the same equatorial position as this,
- *                  but with respect to the true equator and CIO of date.
- *
- * @sa to_system(), to_tod(), to_icrs()
- */
-Equatorial Equatorial::to_cirs(double jd_tdb) const {
-  if(!isfinite(jd_tdb))
-      novas_set_errno(EINVAL, "Equatorial::to_cirs()", "input Julian Date is NAN or infinite");
-
-  Equatorial e = to_system(Equinox::cirs(jd_tdb));
+  Equatorial e = to_system(Equinox::tod(time));
   if(!e.is_valid())
-    novas_trace_invalid("Equatorial::to_cirs()");
+    novas_trace_invalid("Equatorial::to_tod()");
   return e;
 }
 
@@ -445,7 +389,10 @@ Equatorial Equatorial::to_cirs(double jd_tdb) const {
  * @sa to_system(), to_tod(), to_icrs()
  */
 Equatorial Equatorial::to_cirs(const Time& time) const {
-  return to_cirs(time.jd(NOVAS_TDB));
+  Equatorial e = to_system(Equinox::cirs(time));
+  if(!e.is_valid())
+    novas_trace_invalid("Equatorial::to_cirs()");
+  return e;
 }
 
 /**

--- a/src/cpp/Horizontal.cpp
+++ b/src/cpp/Horizontal.cpp
@@ -94,7 +94,7 @@ const Angle& Horizontal::elevation() const {
  *
  * @sa elevation(), azimuth()
  */
-const Angle Horizontal::zenith_angle() const {
+Angle Horizontal::zenith_angle() const {
   Angle a(Constant::half_pi - latitude().rad());
   if(!a.is_valid())
     novas_trace_invalid("Horizontal::zenith_angle()");

--- a/src/cpp/Orbital.cpp
+++ b/src/cpp/Orbital.cpp
@@ -1046,6 +1046,71 @@ Orbital Orbital::from_novas_orbit(const novas_orbital *orbit) {
   return o;
 }
 
+/**
+ * Returns an approximation of the `current` Keplerian orbital of the Moon relative to the
+ * geocenter for the specified epoch of observation. The orbit includes the most dominant Solar
+ * perturbation terms to produce results with an accuracy at the ~10 arcmin level near (+- 0.5
+ * days) the reference time argument of the orbit. The perturbed orbit is based on the ELP/MPP02
+ * model.
+ *
+ * While, the ELP/MPP02 model itself can be highly precise, the Moon's orbit is strongly
+ * non-Keplerian, and so any attempt to describe it in purely Keplerian terms is inherently flawed,
+ * which is the reason for the generally poor accuracy of this model.
+ *
+ * REFERENCES:
+ *
+ *  - Chapront, J. et al., 2002, A&amp;A 387, 700–709
+ *  - Chapront-Touze, M, and Chapront, J. 1988, Astronomy and Astrophysics, vol. 190, p. 342-352.
+ *  - Chapront J., Francou G., 2003, A&amp;A, 404, 735
+ *
+ *
+ * @param time        Astrometric time for which to calculate the secular orbital parameters
+ *                    of the moon.
+ * @return            the Moon orbital defined with the mean orbital elements of date.
+ *
+ * @sa moon_mean_orbit_at()
+ */
+Orbital Orbital::moon_orbit_at(const Time& time) {
+  novas_orbital orbit = {};
+  novas_make_moon_orbit(time.jd(NOVAS_TDB), &orbit);
+  Orbital o = Orbital::from_novas_orbit(&orbit);
+  if(!o.is_valid())
+    novas_trace_invalid("Orbit::moon_orbit_at()");
+  return o;
+}
+
+/**
+ * Returns the mean Keplerian orbital for the Moon relative to the geocenter for the specified
+ * epoch of observation. It is based on the secular parameters of the ELP2000-85 model, but does
+ * not include the harmonic series and the perturbation terms. As such it has accuracy at the few
+ * degrees level only, however it is 'valid' for long-term projections (i.e. for years around the
+ * orbit's reference epoch) at that coarse level.
+ *
+ * For the short-term , `Orbital::moon_orbit_at()` can provide somewhat more accurate
+ * predictions for up to a day or so around the reference epoch of the orbit.
+ *
+ * REFERENCES:
+ *
+ *  - Chapront, J. et al., 2002, A&amp;A 387, 700–709
+ *  - Chapront-Touze, M, and Chapront, J. 1988, Astronomy and Astrophysics, vol. 190, p. 342-352.
+ *  - Chapront J., Francou G., 2003, A&amp;A, 404, 735
+ *  - Laskar J., 1986, A&amp;A, 157, 59
+ *
+ * @param time        Astrometric time for which to calculate the secular orbital parameters
+ *                    of the moon.
+ * @return            the Moon orbital defined with the mean orbital elements of date.
+ *
+ * @sa moon_orbit_at()
+ */
+Orbital Orbital::moon_mean_orbit_at(const Time& time) {
+  novas_orbital orbit = {};
+  novas_make_moon_mean_orbit(time.jd(NOVAS_TDB), &orbit);
+  Orbital o = Orbital::from_novas_orbit(&orbit);
+  if(!o.is_valid())
+    novas_trace_invalid("Orbit::moon_mean_orbit_at()");
+  return o;
+}
+
 
 
 } // namespace supernovas

--- a/test/cpp/EclipticTest.cpp
+++ b/test/cpp/EclipticTest.cpp
@@ -61,8 +61,8 @@ int main() {
   if(!test.check("system(J2000)", b.system() == Equinox::j2000())) n++;
   if(!test.equals("jd(J2000)", b.jd(), NOVAS_JD_J2000)) n++;
   if(!test.check("to_j2000(J2000)", b.to_j2000() == b)) n++;
-  if(!test.check("to_mod(J2000)", b.to_mod(NOVAS_JD_J2000) == b)) n++;
-  if(!test.check("operator >> (B1950)", (b >> Equinox::b1950()) == b.to_mod(NOVAS_JD_B1950))) n++;
+  if(!test.check("to_mod(J2000)", b.to_mod(Time::j2000()) == b)) n++;
+  if(!test.check("operator >> (B1950)", (b >> Equinox::b1950()) == b.to_mod(Time::b1950()))) n++;
   if(!test.equals("to_string(J2000)", b.to_string(NOVAS_SEP_COLONS), "ECL   45:00:00.000   30:00:00.000  J2000")) n++;
 
   Ecliptic c = Ecliptic(Angle(45.0 * Unit::deg), Angle(30.0 * Unit::deg), Equinox::b1950());
@@ -72,8 +72,8 @@ int main() {
   if(!test.equals("equator(B1950)", c.equator_type(), NOVAS_MEAN_EQUATOR)) n++;
   if(!test.check("system(B1950)", c.system() == Equinox::b1950())) n++;
   if(!test.equals("jd(B1950)", c.jd(), NOVAS_JD_B1950)) n++;
-  if(!test.check("to_mod(B1950)", c.to_mod(NOVAS_JD_B1950) == c)) n++;
-  if(!test.check("to_mod(NAN)", !c.to_mod(NAN).is_valid())) n++;
+  if(!test.check("to_mod(B1950)", c.to_mod(Time::b1950()) == c)) n++;
+  if(!test.check("to_mod(time invalid)", !c.to_mod(Time::undefined()).is_valid())) n++;
   if(!test.equals("to_string(B1950)", c.to_string(NOVAS_SEP_COLONS), "ECL   45:00:00.000   30:00:00.000  B1950")) n++;
 
   Ecliptic d = Ecliptic(Angle(45.0 * Unit::deg), Angle(30.0 * Unit::deg), Equinox::tod(Time::b1900()));
@@ -83,8 +83,8 @@ int main() {
   if(!test.equals("equator(TOD)", d.equator_type(), NOVAS_TRUE_EQUATOR)) n++;
   if(!test.check("system(TOD)", d.system() == Equinox::tod(Time::b1900()))) n++;
   if(!test.equals("jd(B1900)", d.jd(), NOVAS_JD_B1900)) n++;
-  if(!test.check("to_tod(B1900)", d.to_tod(NOVAS_JD_B1900) == d)) n++;
-  if(!test.check("to_tod(NAN)", !c.to_tod(NAN).is_valid())) n++;
+  if(!test.check("to_tod(B1900)", d.to_tod(Time::b1900()) == d)) n++;
+  if(!test.check("to_tod(time invalid)", !c.to_tod(Time::undefined()).is_valid())) n++;
   if(!test.equals("to_string(TOD B1900)", d.to_string(NOVAS_SEP_COLONS), "ECL   45:00:00.000   30:00:00.000  TOD B1900")) n++;
 
   Ecliptic e = Ecliptic(Angle(20.0 * Unit::deg), Angle(15.0 * Unit::deg), Equinox::icrs());

--- a/test/cpp/EquatorialTest.cpp
+++ b/test/cpp/EquatorialTest.cpp
@@ -74,7 +74,7 @@ int main() {
   if(!test.equals("to_cirs(HIP) sys", a1.system_type(), NOVAS_CIRS)) n++;
   if(!test.check("to_cirs(HIP) pos", pos == a1.xyz(Coordinate(Unit::AU)))) n++;
   if(!test.check("to_cirs(HIP).to_icrs()", a1.to_icrs() == a)) n++;
-  if(!test.check("to_cirs(NAN)", !a.to_cirs(NAN).is_valid())) n++;
+  if(!test.check("to_cirs(time invalid)", !a.to_cirs(Time::undefined()).is_valid())) n++;
 
 
   a1 = a.to_tod(Time::b1950());
@@ -104,9 +104,9 @@ int main() {
   if(!test.equals("reference_system(J2000)", b.system_type(), NOVAS_J2000)) n++;
   if(!test.equals("jd(J2000)", b.system().jd(), NOVAS_JD_J2000)) n++;
   if(!test.check("to_j2000(J2000)", b.to_j2000() == b)) n++;
-  if(!test.check("to_mod(J2000)", b.to_mod(NOVAS_JD_J2000) == b)) n++;
-  if(!test.check("to_mod(NAN)", !b.to_mod(NAN).is_valid())) n++;
-  if(!test.check("operator >> (B1950)", (b >> Equinox::b1950()) == b.to_mod(NOVAS_JD_B1950))) n++;
+  if(!test.check("to_mod(J2000)", b.to_mod(Time::j2000()) == b)) n++;
+  if(!test.check("to_mod(time invalid)", !b.to_mod(Time::undefined()).is_valid())) n++;
+  if(!test.check("operator >> (B1950)", (b >> Equinox::b1950()) == b.to_mod(Time::b1950()))) n++;
   if(!test.equals("to_string(J2000)", b.to_string(NOVAS_SEP_COLONS), "EQU 03:00:00.0000    30:00:00.000  J2000")) n++;
 
   Equatorial c = Equatorial(Angle(45.0 * Unit::deg), Angle(30.0 * Unit::deg), Equinox::b1950());
@@ -115,7 +115,7 @@ int main() {
   if(!test.equals("to_icrs().to_mod().latitude()", c1.latitude().deg(), c.latitude().deg(), 1e-12)) n++;
   if(!test.equals("reference_system(B1950)", c.system_type(), NOVAS_MOD)) n++;
   if(!test.equals("jd(B1950)", c.system().jd(), NOVAS_JD_B1950)) n++;
-  if(!test.check("to_mod(B1950)", c.to_mod(NOVAS_JD_B1950) == c)) n++;
+  if(!test.check("to_mod(B1950)", c.to_mod(Time::b1950()) == c)) n++;
   if(!test.equals("to_string(B1950)", c.to_string(NOVAS_SEP_COLONS), "EQU 03:00:00.0000    30:00:00.000  B1950")) n++;
 
   Equatorial d = Equatorial(Angle(45.0 * Unit::deg), Angle(30.0 * Unit::deg), Equinox::tod(Time::b1900()));
@@ -124,8 +124,8 @@ int main() {
   if(!test.equals("to_icrs().to_tod().latitude()", d1.latitude().deg(), d.latitude().deg(), 1e-12)) n++;
   if(!test.equals("reference_system(TOD)", d.system_type(), NOVAS_TRUE_EQUATOR)) n++;
   if(!test.equals("jd(B1900)", d.system().jd(), NOVAS_JD_B1900)) n++;
-  if(!test.check("to_tod(B1900)", d.to_tod(NOVAS_JD_B1900) == d)) n++;
-  if(!test.check("to_tod(NAN)", !d.to_tod(NAN).is_valid())) n++;
+  if(!test.check("to_tod(B1900)", d.to_tod(Time::b1900()) == d)) n++;
+  if(!test.check("to_tod(time invalid)", !d.to_tod(Time::undefined()).is_valid())) n++;
   if(!test.equals("to_string(TOD B1900)", d.to_string(NOVAS_SEP_COLONS), "EQU 03:00:00.0000    30:00:00.000  TOD J1900.001")) n++;
 
   Equatorial e = Equatorial(Angle(20.0 * Unit::deg), Angle(15.0 * Unit::deg), Equinox::icrs());

--- a/test/cpp/OrbitalTest.cpp
+++ b/test/cpp/OrbitalTest.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <iostream>
+#include <string.h>
 
 #include "TestUtil.hpp"
 
@@ -303,6 +304,21 @@ int main() {
   if(!test.check("from_novas_orbit(node period = NAN)", !Orbital::from_novas_orbit(&no).is_valid())) n++;
   no.node_period = -1.0 / Unit::julian_century;
   if(!test.check("from_novas_orbit(node period = OK)", Orbital::from_novas_orbit(&no).is_valid())) n++;
+
+
+  novas_orbital mo = {};
+  novas_make_moon_orbit(Time::b1950().jd(NOVAS_TDB), &mo);
+  Orbital m = Orbital::moon_orbit_at(Time::b1950());
+  if(!test.check("moon_orbit_at(time invalid)", !Orbital::moon_orbit_at(Time::undefined()).is_valid())) n++;
+  if(!test.check("moon_orbit_at()", m.is_valid())) n++;
+  if(!test.check("moon_orbit_at() ==", memcmp(m._novas_orbital(), &mo, sizeof(novas_orbital)) == 0)) n++;
+
+  novas_make_moon_mean_orbit(Time::b1950().jd(NOVAS_TDB), &mo);
+  m = Orbital::moon_mean_orbit_at(Time::b1950());
+  if(!test.check("moon_mean_orbit_at(time invalid)", !Orbital::moon_mean_orbit_at(Time::undefined()).is_valid())) n++;
+  if(!test.check("moon_mean_orbit_at()", m.is_valid())) n++;
+  if(!test.check("moon_mean_orbit_at() ==", memcmp(m._novas_orbital(), &mo, sizeof(novas_orbital)) == 0)) n++;
+
 
   std::cout << "Orbital.cpp: " << (n > 0 ? "FAILED" : "OK") << "\n";
   return n;

--- a/test/cpp/VelocityTest.cpp
+++ b/test/cpp/VelocityTest.cpp
@@ -11,7 +11,6 @@
 #include "TestUtil.hpp"
 
 
-
 int main() {
   TestUtil test = TestUtil("Velocity");
 


### PR DESCRIPTION
### Added

 - static `Orbital::moon_orbit_at()` and `Orbital::moon_mean_orbit_at()` methods.

### Removed
 
 - `Equatorial()` conversions with `double` Julian Dates.
 - `Ecliptic()` conversions with `double` Julian Dates.

### Changed

 - Many documentation fixes and tweaks.
