### PR TITLE
Add `cspice_clear_kernels()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Upcoming feature release, introducing a proper C++ API for the first time, and b
  - #281: Added a truncated version of semi-analytic ELP/MPP02 model of the Moon's position relative to the geocenter 
    by Chapront &amp; Francou (2003), usng up to about 3400 terms, and reaching accuracies to the 1 arcsec / 1km
    level (or better for the present era). 
+   
+ - #298: Added `cspice_clear_kernels()` to CSPICE plugin to close all kernels and free up the resources they use 
+   (thanks to aleberti)
 
  - Added `novas_enu_to_itrs()` and `novas_itrs_to_enu()` functions to help convert between local East-North-Up (ENU)
    coordinates and ITRS. ENU is a natural local cartesian coordinate system of an observer at or near the Earth's 

--- a/examples/c99/example-calceph.c
+++ b/examples/c99/example-calceph.c
@@ -185,13 +185,11 @@ int main(int argc, const char *argv[]) {
   printf(" Az = %.6f deg, El = %.6f deg\n", az, el);
 
 
-
   // -------------------------------------------------------------------------
   // Clean up before we exit...
   calceph_close(de440);
   //calceph_close(jovian);
   //calceph_close(moons);
-
 
   return 0;
 }

--- a/examples/c99/example-cspice.c
+++ b/examples/c99/example-cspice.c
@@ -173,6 +173,11 @@ int main(int argc, const char *argv[]) {
   // Let's print the calculated azimuth and elevation
   printf(" Az = %.6f deg, El = %.6f deg\n", az, el);
 
+
+  // -------------------------------------------------------------------------
+  // Clean up before we exit...
+  cspice_clear_kernels();
+
   return 0;
 }
 

--- a/examples/cpp/example-cspice.cpp
+++ b/examples/cpp/example-cspice.cpp
@@ -53,7 +53,6 @@ int main(int argc, const char *argv[]) {
   novas_debug(NOVAS_DEBUG_ON);
 
 
-
   // -------------------------------------------------------------------------
   // We'll use the NAIF CSPICE Toolkit to provide ephemeris data
 
@@ -73,7 +72,6 @@ int main(int argc, const char *argv[]) {
   novas_use_cspice();
 
 
-
   // -------------------------------------------------------------------------
   // Define a Solar-system source
 
@@ -86,7 +84,6 @@ int main(int argc, const char *argv[]) {
   // -------------------------------------------------------------------------
   // If the object uses CALCEPH IDs instead of NAIF, then
   //novas_calceph_use_ids(NOVAS_ID_CALCEPH);
-
 
 
   // -------------------------------------------------------------------------
@@ -140,7 +137,6 @@ int main(int argc, const char *argv[]) {
   //auto frame = obs.reduced_accuracy_frame_at(t);
 
 
-
   // -------------------------------------------------------------------------
   // Calculate the precise apparent position.
   Apparent apparent = source.apparent_in(frame);
@@ -163,6 +159,10 @@ int main(int argc, const char *argv[]) {
   // Let's print the calculated azimuth and elevation
   std::cout << hor.to_string() << "\n";
 
+
+  // -------------------------------------------------------------------------
+  // Clean up before we exit...
+  cspice_clear_kernels();
 
   return 0;
 }

--- a/include/novas-cspice.h
+++ b/include/novas-cspice.h
@@ -32,6 +32,10 @@ int cspice_add_kernel(const char *filename);
 /// @ingroup solar-system
 int cspice_remove_kernel(const char *filename);
 
+// ----------------- Added in v1.6.0 --------------------
+/// @ingroup solar-system
+int cspice_clear_kernels();
+
 #if __cplusplus
 } // extern "C"
 #endif

--- a/src/c99/solsys-cspice.c
+++ b/src/c99/solsys-cspice.c
@@ -202,7 +202,7 @@ static int get_cspice_error(char *msg, int len) {
  * @author Attila Kovacs
  * @since 1.2
  *
- * @sa cspice_remove_kernel(), novas_use_cspice()
+ * @sa cspice_remove_kernel(), cspice_clear_kernels(), novas_use_cspice()
  */
 int cspice_add_kernel(const char *filename) {
   static const char *fn = "cspice_add_kernel";
@@ -248,7 +248,7 @@ int cspice_add_kernel(const char *filename) {
  * @author Attila Kovacs
  * @since 1.2
  *
- * @sa cspice_add_kernel()
+ * @sa cspice_add_kernel(), cspice_clear_kernels()
  */
 int cspice_remove_kernel(const char *filename) {
   static const char *fn = "cspice_remove_kernel";
@@ -271,6 +271,36 @@ int cspice_remove_kernel(const char *filename) {
 
   if(err)
     return novas_error(-1, EINVAL, fn, "unload_c(%s): %s", filename, msg);
+
+  return 0;
+}
+
+
+/**
+ * Closes and removes all SPICE kernels currently configured, freeing up the associated resources.
+ * However CSPICE will remain your ephemeris provider for planets and/or ephemeris type objects,
+ * as configured before.
+ *
+ * @return      0 if successful, or else -1 (errno will be set to EAGAIN).
+ *
+ * @author Attila Kovacs
+ * @since 1.6
+ *
+ * @sa cspice_remove_kernel(), cspice_add_kernel()
+ */
+int cspice_clear_kernels() {
+  char msg[100];
+  int err;
+
+  mutex_lock();
+  reset_c();
+  kclear_c();
+  err = get_cspice_error(msg, sizeof(msg));
+
+  mutex_unlock();
+
+  if(err)
+    return novas_error(-1, EAGAIN, "novas_cspice_clear()", "kclear_c(): %s", msg);
 
   return 0;
 }
@@ -638,4 +668,6 @@ int novas_use_cspice() {
   novas_use_cspice_ephem();
   return 0;
 }
+
+
 

--- a/test/c99/test-cspice.c
+++ b/test/c99/test-cspice.c
@@ -194,11 +194,42 @@ static int unload_eph(const char *name) {
 static int test_remove_kernel() {
   int n = 0;
 
+  double pos[3], vel[3];
+  double jd = NOVAS_JD_J2000;
+  double jd2[2] = { jd, 0.0 };
+  enum novas_origin origin = NOVAS_BARYCENTER;
+  novas_planet_provider_hp pl = get_planet_provider_hp();
+  novas_ephem_provider eph = get_ephem_provider();
+
   if(!is_ok("remove_kernel:planets", unload_eph(PLANET_EPH))) n++;
+  if(check("remove_kernel:planets:check", 3, pl(jd2, NOVAS_JUPITER, NOVAS_BARYCENTER, pos, vel))) n++;
+
   if(!is_ok("remove_kernel:mars", unload_eph(MARS_EPH))) n++;
+  if(check("remove_kernel:mars:check", 3, eph("Phobos", 401, jd2[0], jd2[1], &origin, pos, vel))) n++;
 
   if(check("remove_kernel:null", -1, cspice_remove_kernel(NULL))) n++;
   if(check("remove_kernel:empty", -1, cspice_remove_kernel(""))) n++;
+
+  return n;
+}
+
+static int test_cspice_clear_kernels() {
+  int n = 0;
+
+  double pos[3], vel[3];
+  double jd = NOVAS_JD_J2000;
+  double jd2[2] = { jd, 0.0 };
+  enum novas_origin origin = NOVAS_BARYCENTER;
+  novas_planet_provider_hp pl = get_planet_provider_hp();
+  novas_ephem_provider eph = get_ephem_provider();
+
+  load_eph(PLANET_EPH);
+  load_eph(MARS_EPH);
+
+  if(!is_ok("clear_kernels", cspice_clear_kernels())) n++;
+
+  if(check("clear_kernels:jupiter", 3, pl(jd2, NOVAS_JUPITER, NOVAS_BARYCENTER, pos, vel))) n++;
+  if(check("clear_kernels:phobos", 3, eph("Phobos", 401, jd2[0], jd2[1], &origin, pos, vel))) n++;
 
   return n;
 }
@@ -241,6 +272,8 @@ int main(int argc, char *argv[]) {
   if(test_remove_kernel()) n++;
 
   if(test_cspice_is_thread_safe()) n++;
+
+  if(test_cspice_clear_kernels()) n++;
 
   if(n) fprintf(stderr, " -- FAILED %d tests\n", n);
   else fprintf(stderr, " -- OK\n");


### PR DESCRIPTION
### Added

 - `cspice_clear_kernels()` to CSPICE plugin to free up resources used by SPICE kernels that are no longer needed.
 
### Changed

 - Updated examples to clean up kernels before exit.
 - More proper testing of `cspice_remove_kernel()`
