### PR TITLE
Various tweaks and simplifications to Frame and EOP handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # SuperNOVAS
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14584983.svg)]("https://doi.org/10.5281/zenodo.14584983)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14584983.svg)](https://doi.org/10.5281/zenodo.14584983)
 
 The NOVAS C astrometry library, made better.
 

--- a/include/supernovas.h
+++ b/include/supernovas.h
@@ -1697,11 +1697,11 @@ public:
  */
 class Frame : public Validating {
 private:
-  const Observer *_observer = NULL;
-  Time _time;
-  novas_frame _frame = {}; ///< Stored frame data
+  const Observer* _observer = NULL; ///< Pointer to copied observer data
+  Time _time;                       ///< Astrometric time of observation
+  novas_frame _frame = {};          ///< Stored frame data
 
-  /// Intantiates an undefined observing frame
+  /// Instantiates an undefined observing frame
   Frame() : _observer(Observer::undefined().copy()), _time(Time::undefined()) {}
 
   void diurnal_correct();
@@ -1709,29 +1709,29 @@ private:
 public:
   Frame(const Observer& obs, const Time& time, enum novas_accuracy accuracy = NOVAS_FULL_ACCURACY);
 
-  ~Frame() {
-    delete _observer;
-  }
-
   Frame(const Frame& frame);
 
   Frame& operator=(const Frame& frame);
 
   const novas_frame* _novas_frame() const;
 
+  enum novas_accuracy accuracy() const;
+
   const Observer& observer() const;
 
   const Time& time() const;
 
-  enum novas_accuracy accuracy() const;
+  const EOP eop() const;
+
+  double jd(enum novas_timescale = NOVAS_TT) const;
 
   double clock_skew(enum novas_timescale = NOVAS_TT) const;
 
   Geometric geometric(const Position& p, const Velocity& v, enum novas_reference_system system = NOVAS_TOD) const;
 
-  Position observer_position() const;
+  Position observer_ssb_position() const;
 
-  Velocity observer_velocity() const;
+  Velocity observer_ssb_velocity() const;
 
   /// @ingroup geometric
   Geometric geometric_moon_elp2000(double limit_term = 0.0) const;
@@ -2385,7 +2385,7 @@ public:
 
   Geometric to_tirs() const;
 
-  Geometric to_itrs(const EOP& eop = EOP::undefined()) const;
+  Geometric to_itrs() const;
 
   std::string to_string(int decimals = 3) const;
 

--- a/src/c99/frames.c
+++ b/src/c99/frames.c
@@ -1634,7 +1634,7 @@ static double novas_cross_el_date(double el, int sign, const object *source, con
 double novas_transit_time(const object *restrict source, const novas_frame *restrict frame) {
   double utc = novas_cross_el_date(NAN, 0, source, frame, NULL);
   if(isnan(utc))
-    return novas_trace_nan("novas_rises_above");
+    return novas_trace_nan("novas_transit_time");
   return utc;
 }
 

--- a/src/cpp/Apparent.cpp
+++ b/src/cpp/Apparent.cpp
@@ -41,7 +41,7 @@ Apparent::Apparent(const Frame& f)
   else
     _valid = true;
 
-  cirs2tod_ra = -ira_equinox(f.time().jd(), NOVAS_TRUE_EQUINOX, f.accuracy());
+  cirs2tod_ra = -ira_equinox(f.jd(), NOVAS_TRUE_EQUINOX, f.accuracy());
 }
 
 Apparent::Apparent(const Frame& frame, enum novas_reference_system sys, double ra_rad, double dec_rad, double rv_ms)
@@ -306,18 +306,15 @@ Galactic Apparent::galactic() const {
  * @sa Horizontal::to_apparent(), GeodeticObserver
  */
 Horizontal Apparent::to_horizontal() const {
-
-  if(!_frame.observer().is_geodetic()) {
-    novas_set_errno(EINVAL, "Apparent::to_horizontal()", "cannot convert for non-geodetic observer frame");
-    return Horizontal::undefined();
-  }
-
   double ra = 0.0, dec = 0.0, az = 0.0, el = 0.0;
 
   // pos.ra / pos.dec may be NAN for ITRS / TIRS...
   vector2radec(_pos.r_hat, &ra, &dec);
 
-  novas_app_to_hor(_frame._novas_frame(), NOVAS_TOD, ra, dec, NULL, &az, &el);
+  if(novas_app_to_hor(_frame._novas_frame(), NOVAS_TOD, ra, dec, NULL, &az, &el) != 0) {
+    novas_trace_invalid("Apparent::to_horizontal()");
+    return Horizontal::undefined();
+  }
 
   Horizontal h(az * Unit::deg, el * Unit::deg);
   if(!h.is_valid())

--- a/src/cpp/AstrometricPosition.cpp
+++ b/src/cpp/AstrometricPosition.cpp
@@ -62,7 +62,7 @@ AstrometricPosition::AstrometricPosition(const Position& equ_pos, const Time &ti
  *                      position and observer location (default: TOD).
  */
 AstrometricPosition::AstrometricPosition(const Position& equ_pos, const Frame &frame, enum novas_reference_system system) :
-        AstrometricPosition(equ_pos, frame.time(), frame.observer_position(), system) {
+        AstrometricPosition(equ_pos, frame.time(), frame.observer_ssb_position(), system) {
 }
 
 /**

--- a/src/cpp/Frame.cpp
+++ b/src/cpp/Frame.cpp
@@ -43,7 +43,7 @@ namespace supernovas {
  * In either case, you can obtain more information on why things went wrong, when they do, by
  * enabling debug mode is enabled via `novas_debug()` prior to constructing a Frame.
  *
- * @param obs         observer location (copied)
+ * @param obs         observer location
  * @param time        time of observation
  * @param accuracy    (optional) NOVAS_FULL_ACCURACY (default) or NOVAS_REDUCED_ACCURACY.
  *
@@ -53,9 +53,17 @@ Frame::Frame(const Observer& obs, const Time& time, enum novas_accuracy accuracy
 : _observer(obs.copy()), _time(time) {
   static const char *fn = "Frame()";
 
+  double xp = NAN, yp = NAN;
+
   errno = 0;
 
-  if(novas_make_frame(accuracy, obs._novas_observer(), time._novas_timespec(), 0.0, 0.0, &_frame) != 0)
+  if(obs.is_geodetic()) {
+    const GeodeticObserver *go = dynamic_cast<const GeodeticObserver *>(_observer);
+    xp = go->eop().xp().mas();
+    yp = go->eop().yp().mas();
+  }
+
+  if(novas_make_frame(accuracy, obs._novas_observer(), time._novas_timespec(), xp, yp, &_frame) != 0)
     novas_trace_invalid(fn);
   if(!obs.is_valid())
     novas_set_errno(EINVAL, fn, "input observer is invalid");
@@ -63,12 +71,6 @@ Frame::Frame(const Observer& obs, const Time& time, enum novas_accuracy accuracy
     novas_set_errno(EINVAL, fn, "input time is invalid");
 
   _valid = (errno == 0);
-
-  if(!obs.is_geodetic()) {
-    // Force NANs if one tries to used EOP for a non-geodetic observer.
-    _frame.dx = NAN;
-    _frame.dy = NAN;
-  }
 }
 
 /**
@@ -77,7 +79,7 @@ Frame::Frame(const Observer& obs, const Time& time, enum novas_accuracy accuracy
  * @param frame   the frame to be copied.
  */
 Frame::Frame(const Frame& frame)
-: Validating(frame), _observer(frame._observer->copy()), _time(frame._time), _frame(frame._frame) {}
+: Validating(frame), _observer(frame._observer->copy()), _time(frame.time()), _frame(frame._frame) {}
 
 /**
  * Custom copy-assignment operator, which updates the observer pointer to
@@ -119,17 +121,6 @@ enum novas_accuracy Frame::accuracy() const {
 }
 
 /**
- * Returns the astrometric time of observation of this observing frame.
- *
- * @return    the astrometric time of observation
- *
- * @sa observer()
- */
-const Time& Frame::time() const {
-  return _time;
-}
-
-/**
  * Returns the observer location (and motion) of this observing frame
  *
  * @return    the observer location (and motion).
@@ -138,6 +129,47 @@ const Time& Frame::time() const {
  */
 const Observer& Frame::observer() const {
   return *_observer;
+}
+
+/**
+ * Returns the astrometric time of observation of this observing frame.
+ *
+ * @return    the astrometric time of observation
+ *
+ * @sa jd(), observer()
+ */
+const Time& Frame::time() const {
+  return _time;
+}
+
+/**
+ * Returns the Earth Orientation Parameters contained in this frame. The returned parameters are
+ * valid only if this frame was defined for a geodetic observer location such as an observer at a
+ * fixed site on Earth or an airborne observer location.
+ *
+ * @return    The Earth orientation parameters of this observing frame, or an undefined (invalid)
+ *            EOP if the observer is not on or near Earth's surface.
+ *
+ * @sa GeodeticObserver
+ */
+const EOP Frame::eop() const {
+  EOP eop = EOP(novas_time_leap(&_frame.time), _frame.time.dut1, _frame.dx * Unit::mas, _frame.dy * Unit::mas);
+  if(!eop.is_valid())
+    novas_trace_invalid("Frame::eop()");
+  return eop;
+}
+
+/**
+ * Returns the precise Julian Date of this observing frame, in the specific timescale of choice.
+ * It is but a shorthand for `time().jd(timescale)`.
+ *
+ * @param timescale   (optional) the timescale in which to return the result (default: TT).
+ * @return            [day] the precise Julian date in the requested timescale.
+ *
+ * @sa Time::jd(), time()
+ */
+double Frame::jd(enum novas_timescale timescale) const {
+  return _time.jd(timescale);
 }
 
 /**
@@ -202,30 +234,30 @@ Geometric Frame::geometric(const Position& p, const Velocity& v, enum novas_refe
 }
 
 /**
- * Returns the observer's position w.r.t. the Solar System Barycenter (SSB).
+ * Returns the observer's ICRS position relative to the Solar System Barycenter (SSB).
  *
  * @return      The Solar system barycentric position of the observer at the time of observation.
  *
- * @sa observer_velocity(), observer()
+ * @sa observer_ssb_velocity(), observer()
  */
-Position Frame::observer_position() const {
+Position Frame::observer_ssb_position() const {
   if(!is_valid()) {
-    novas_trace_invalid("Frame::observer_position()");
+    novas_trace_invalid("Frame::observer_ssb_position()");
     return Position::undefined();
   }
   return Position(_novas_frame()->obs_pos, Unit::AU);
 }
 
 /**
- * Returns the observer's velocity w.r.t. the Solar System Barycenter (SSB).
+ * Returns the observer's ICRS velocity relative to the Solar System Barycenter (SSB).
  *
  * @return      The Solar system barycentric velocity of the observer at the time of observation.
  *
- * @sa observer_position(), observer()
+ * @sa observer_ssb_position(), observer()
  */
-Velocity Frame::observer_velocity() const {
+Velocity Frame::observer_ssb_velocity() const {
   if(!is_valid()) {
-    novas_trace_invalid("Frame::observer_velocity()");
+    novas_trace_invalid("Frame::observer_ssb_velocity()");
     return Velocity::undefined();
   }
   return Velocity(_novas_frame()->obs_vel, Unit::AU / Unit::day);
@@ -322,7 +354,6 @@ Frame Frame::reduced_accuracy(const Observer& obs, const Time& time) {
     novas_trace_invalid("Frame::reduced_accuracy()");
   return f;
 }
-
 
 /**
  * Returns a human-readable string representation of this observing frame.

--- a/src/cpp/Geometric.cpp
+++ b/src/cpp/Geometric.cpp
@@ -119,7 +119,7 @@ const Velocity& Geometric::velocity() const {
  * @sa Apparent::equatorial(), ecliptic(), galactic(), position(), velocity()
  */
 Equatorial Geometric::equatorial() const {
-  Equatorial e = Equatorial(_pos, Equinox::from_system_type(_system, _frame.time().jd()));
+  Equatorial e = Equatorial(_pos, Equinox::from_system_type(_system, _frame.jd()));
   if(!e.is_valid())
     novas_trace_invalid("Geometric::equatorial");
   return e;
@@ -169,26 +169,6 @@ Galactic Geometric::galactic() const {
   return g;
 }
 
-Geometric Geometric::to_system(const novas_frame *f, enum novas_reference_system system) const {
-  static const char *fn = "Geometric::to_system()";
-
-  novas_transform T = {};
-  double p[3] = {0.0}, v[3] = {0.0};
-
-  if(novas_make_transform(f, _system, system, &T) != 0) {
-    novas_trace_invalid(fn);
-    return Geometric::undefined();
-  }
-
-  novas_transform_vector(_pos._array(), &T, p);
-  novas_transform_vector(_vel._array(), &T, v);
-
-  Geometric g(_frame, Position(p), Velocity(v), system);
-  if(!g.is_valid())
-    novas_trace_invalid(fn);
-  return g;
-}
-
 /**
  * Returns new geometric coordinates that are transformed from these into a different coordinate
  * reference system. For dynamical coordinate systems, the result is in the coordinate epoch
@@ -206,17 +186,26 @@ Geometric Geometric::to_system(const novas_frame *f, enum novas_reference_system
  * @sa operator>>(), to_icrs(), to_j2000(), to_mod(), to_tod(), to_cirs(), to_tirs(), to_itrs()
  */
 Geometric Geometric::to_system(enum novas_reference_system system) const {
+  static const char *fn = "Geometric::to_system()";
+
   if(system == _system)
     return *this;
 
-  if(system == NOVAS_ITRS) {
-    Geometric itrs = to_itrs();
-    if(!itrs.is_valid())
-      novas_trace_invalid("Geometric::to_system()");
-    return itrs;
+  novas_transform T = {};
+  double p[3] = {0.0}, v[3] = {0.0};
+
+  if(novas_make_transform(_frame._novas_frame(), _system, system, &T) != 0) {
+    novas_trace_invalid(fn);
+    return Geometric::undefined();
   }
 
-  return to_system(_frame._novas_frame(), system);
+  novas_transform_vector(_pos._array(), &T, p);
+  novas_transform_vector(_vel._array(), &T, v);
+
+  Geometric g(_frame, Position(p), Velocity(v), system);
+  if(!g.is_valid())
+    novas_trace_invalid(fn);
+  return g;
 }
 
 /**
@@ -334,47 +323,17 @@ Geometric Geometric::to_tirs() const {
  *  }
  * ```
  *
- * @param eop       Earth Orientation Parameters (EOP) appropriate for the date, such as obtained
- *                  from the IERS bulletins or web service.
  * @return          geometric coordinates for the same position and velocity as this, but
  *                  expressed in the ITRS. The returned instance may be invalid if an invalid EOP
  *                  was supplied and the observer also does not define its own valid EOP.
  *
  * @sa to_system(), to_icrs(), to_j2000(), to_mod(), to_tod(), to_cirs(), to_tirs()
  */
-Geometric Geometric::to_itrs(const EOP& eop) const {
-  if(_system == NOVAS_ITRS)
-    return Geometric(*this);
-
-  // Apply specified EOP to frame
-  if(eop.is_valid()) {
-    novas_frame f = * _frame._novas_frame();
-
-    f.dx = eop.xp().mas();
-    f.dy = eop.yp().mas();
-
-    if(_frame.accuracy() == NOVAS_FULL_ACCURACY) {
-      // Add diurnal corrections
-      double xp = 0.0, yp = 0.0;
-      novas_diurnal_eop_at_time(_frame.time()._novas_timespec(), &xp, &yp, NULL);
-
-      f.dx += 1000.0 * xp;
-      f.dy += 1000.0 * yp;
-    }
-
-    Geometric g = to_system(&f, NOVAS_ITRS);
-    if(!g.is_valid())
+Geometric Geometric::to_itrs() const {
+  Geometric g = to_system(NOVAS_ITRS);
+  if(!g.is_valid())
       novas_trace_invalid("Geometric::to_itrs()");
-    return g;
-  }
-
-  // Or, use observer's EOP
-  if(_frame.observer().is_geodetic())
-    return to_itrs(dynamic_cast<const GeodeticObserver &>(_frame.observer()).eop());
-
-  // Or, we can't really convert to ITRS
-  novas_set_errno(EINVAL, "Geometric::to_itrs()", "Needs valid EOP for non geodetic observer frame");
-  return Geometric::undefined();
+  return g;
 }
 
 /**

--- a/src/cpp/Source.cpp
+++ b/src/cpp/Source.cpp
@@ -154,11 +154,6 @@ Geometric Source::geometric_in(const Frame& frame, enum novas_reference_system s
   return Geometric::undefined();
 }
 
-static const EOP& extract_eop(const Frame &frame) {
-  const GeodeticObserver& eobs = dynamic_cast<const GeodeticObserver&>(frame.observer());
-  return eobs.eop();
-}
-
 /**
  * Returns the time when the source rises above the specified elevation next for an observer
  * located on or near Earth's surface, or else `std::nullopt` if the observer is not near Earth's
@@ -178,22 +173,10 @@ static const EOP& extract_eop(const Frame &frame) {
  * @sa sets_below(), transits_in()
  */
 Time Source::rises_above(const Angle& el, const Frame &frame, RefractionModel ref, const Weather& weather) const {
-  static const char *fn = "Source::rises_above()";
-
-  if(frame.observer().is_geodetic()) {
-    novas_frame f = *frame._novas_frame();
-    on_surface *s = &f.observer.on_surf;
-
-    s->temperature = weather.temperature().celsius();
-    s->pressure = weather.pressure().mbar();
-    s->humidity = weather.humidity();
-
-    Time t(novas_check_nan(fn, novas_rises_above(el.deg(), &_object, &f, ref)), extract_eop(frame));
-    return t;
-  }
-
-  novas_set_errno(ENOSYS, fn, "Cannot calculate rise time for a non-geodetic observer.");
-  return Time::undefined();
+  Time t(novas_rises_above(el.deg(), &_object, frame._novas_frame(), ref), frame.eop());
+  if(!t.is_valid())
+    novas_trace_invalid("Source::rises_above()");
+  return t;
 }
 
 /**
@@ -207,15 +190,10 @@ Time Source::rises_above(const Angle& el, const Frame &frame, RefractionModel re
  * @sa sets_below(), transits_in()
  */
 Time Source::transits_in(const Frame &frame) const {
-  static const char *fn = "Source::transits_in()";
-
-  if(frame.observer().is_geodetic())
-    return Time(
-          novas_check_nan(fn, novas_transit_time(&_object, frame._novas_frame())),
-          extract_eop(frame));
-
-  novas_set_errno(ENOSYS, fn, "Cannot calculate transit time for a non-geodetic observer.");
-  return Time::undefined();
+  Time t(novas_transit_time(&_object, frame._novas_frame()), frame.eop());
+  if(!t.is_valid())
+    novas_trace_invalid("Source::transits_in()");
+  return t;
 }
 
 /**
@@ -237,23 +215,10 @@ Time Source::transits_in(const Frame &frame) const {
  * @sa rises_above(), transits_in()
  */
 Time Source::sets_below(const Angle& el, const Frame &frame, RefractionModel ref, const Weather& weather) const {
-  static const char *fn = "Source::sets_below()";
-
-  if(frame.observer().is_geodetic()) {
-    novas_frame f = *frame._novas_frame();
-    on_surface *s = &f.observer.on_surf;
-
-    s->temperature = weather.temperature().celsius();
-    s->pressure = weather.pressure().mbar();
-    s->humidity = weather.humidity();
-
-    return Time(
-            novas_check_nan(fn, novas_sets_below(el.deg(), &_object, &f, ref)),
-            extract_eop(frame));
-  }
-
-  novas_set_errno(ENOSYS, fn, "Cannot calculate setting time for a non-geodetic observer.");
-  return Time::undefined();
+  Time t(novas_sets_below(el.deg(), &_object, frame._novas_frame(), ref), frame.eop());
+  if(!t.is_valid())
+    novas_trace_invalid("Source::sets_below()");
+  return t;
 }
 
 
@@ -279,7 +244,7 @@ Time Source::sets_below(const Angle& el, const Frame &frame, RefractionModel ref
 EquatorialTrack Source::equatorial_track(const Frame &frame, double range_seconds) const {
   novas_track track = {};
   novas_equ_track(_novas_object(), frame._novas_frame(), range_seconds, &track);
-  EquatorialTrack et = EquatorialTrack::from_novas_track(Equinox::tod(frame.time().jd()), &track, Interval(range_seconds));
+  EquatorialTrack et = EquatorialTrack::from_novas_track(Equinox::tod(frame.jd()), &track, Interval(range_seconds));
   if(!et.is_valid())
     novas_trace_invalid("Source::equatorial_track()");
   return et;
@@ -776,7 +741,7 @@ Apparent Planet::approx_apparent_in(const Frame& frame) const {
 Geometric Planet::approx_geometric_in(const Frame& frame) const {
   double p[3] = {0.0}, v[3] = {0.0};
 
-  novas_approx_heliocentric(novas_id(), frame.time().jd(NOVAS_TDB), p, v);
+  novas_approx_heliocentric(novas_id(), frame.jd(NOVAS_TDB), p, v);
 
   for(int i = 0; i < 3; i++) {
     const novas_frame *f = frame._novas_frame();

--- a/test/cpp/ApparentTest.cpp
+++ b/test/cpp/ApparentTest.cpp
@@ -72,7 +72,7 @@ int main() {
   if(!test.check("astrometric_position() ==", rp == Position(v, Unit::AU))) n++;
   if(!test.check("astrometric_position(frame invalid)", !x.astrometric_position().is_valid())) n++;
 
-  double ra_cirs = app_to_cirs_ra(frame.time().jd(), NOVAS_REDUCED_ACCURACY, p.ra);
+  double ra_cirs = app_to_cirs_ra(frame.jd(), NOVAS_REDUCED_ACCURACY, p.ra);
   if(!test.check("to_cirs()", tod.cirs() == Equatorial(ra_cirs * Unit::hour_angle, p.dec * Unit::deg, Equinox::cirs(Time::j2000())))) n++;
 
   Apparent tod2 = Apparent::from_tod(Angle::undefined(), Angle(p.dec * Unit::deg), frame, ScalarVelocity(p.rv * Unit::km / Unit::s));
@@ -82,7 +82,7 @@ int main() {
   if(!test.check("from_tod()", tod2.equatorial() == tod.equatorial())) n++;
 
   Apparent cirs = Apparent::from_cirs_sky_pos(frame, &p);
-  double ra_tod = cirs_to_app_ra(frame.time().jd(), NOVAS_REDUCED_ACCURACY, p.ra);
+  double ra_tod = cirs_to_app_ra(frame.jd(), NOVAS_REDUCED_ACCURACY, p.ra);
   if(!test.check("to_cirs(CIRS)", cirs.cirs() == Equatorial(p.ra * Unit::hour_angle, p.dec * Unit::deg, Equinox::cirs(Time::j2000())))) n++;
   if(!test.check("equatorial(CIRS)", cirs.equatorial() == Equatorial(ra_tod * Unit::hour_angle, p.dec * Unit::deg, Equinox::tod(Time::j2000())))) n++;
 
@@ -96,11 +96,11 @@ int main() {
 
   sky_pos p1 = p; p1.ra = NAN;
   if(!test.check("invalid p.ra", !Apparent::from_tod_sky_pos(frame, &p1).is_valid())) n++;
-  if(!test.check("to_horizontral(invalid RA)", !x.to_horizontal().is_valid())) n++;
+  if(!test.check("to_horizontal(invalid RA)", !x.to_horizontal().is_valid())) n++;
 
   p1 = p; p1.dec = NAN;
   if(!test.check("invalid p.dec", !Apparent::from_tod_sky_pos(frame, &p1).is_valid())) n++;
-  if(!test.check("to_horizontral(invalid Dec)", !x.to_horizontal().is_valid())) n++;
+  if(!test.check("to_horizontal(invalid Dec)", !x.to_horizontal().is_valid())) n++;
 
   p1 = p; p1.rv = NAN;
   if(!test.check("invalid p.rv", !Apparent::from_tod_sky_pos(frame, &p1).is_valid())) n++;

--- a/test/cpp/AstrometricPositionTest.cpp
+++ b/test/cpp/AstrometricPositionTest.cpp
@@ -36,17 +36,17 @@ int main() {
   if(!test.check("is_valid()", a.is_valid())) n++;
   if(!test.check(" == position", a == p)) n++;
   if(!test.equals("system_type()", a.system_type(), NOVAS_TOD)) n++;
-  if(!test.check("reference()", a.reference() == frame.observer_position())) n++;
+  if(!test.check("reference()", a.reference() == frame.observer_ssb_position())) n++;
   if(!test.check("obs_time()", a.obs_time() == Time::b1950())) n++;
   if(!test.check("emit_time()", a.emit_time() == (Time::b1950() - (a.distance().m() / Constant::c)))) n++;
-  if(!test.check("origin(0)", a.reference() == frame.observer_position())) n++;
+  if(!test.check("origin(0)", a.reference() == frame.observer_ssb_position())) n++;
 
   Position r = Position(1.3 * Unit::AU, -2.2 * Unit::AU, 3.1 * Unit::AU);
   Observer o2 = Observer::in_solar_system(r, Velocity::stationary());
   AstrometricPosition b(p, o2.reduced_accuracy_frame_at(Time::b1950()));
   if(!test.check("reference()", b.reference() == r)) n++;
 
-  if(!test.check("referenced_to()", a.referenced_to(r) == (p + frame.observer_position() - r))) n++;
+  if(!test.check("referenced_to()", a.referenced_to(r) == (p + frame.observer_ssb_position() - r))) n++;
   if(!test.check("referenced_to().reference()", a.referenced_to(r).reference() == r)) n++;
   if(!test.check("referenced_to(invalid pos)", !a.referenced_to(Position::undefined()).is_valid())) n++;
 

--- a/test/cpp/FrameTest.cpp
+++ b/test/cpp/FrameTest.cpp
@@ -21,8 +21,8 @@ int main() {
 
   Frame x = Frame::undefined();
   if(!test.check("invalid", !x.is_valid())) n++;
-  if(!test.check("observer_position(invalid)", !x.observer_position().is_valid())) n++;
-  if(!test.check("observer_velocity(invalid)", !x.observer_velocity().is_valid())) n++;
+  if(!test.check("observer_ssb_position(invalid)", !x.observer_ssb_position().is_valid())) n++;
+  if(!test.check("observer_ssb_velocity(invalid)", !x.observer_ssb_velocity().is_valid())) n++;
   if(!test.check("geometric_moon_elp2000(invalid)", !x.geometric_moon_elp2000().is_valid())) n++;
   if(!test.check("apparent_moon_elp2000(invalid)", !x.apparent_moon_elp2000().is_valid())) n++;
 
@@ -33,8 +33,8 @@ int main() {
   Frame a = Frame::reduced_accuracy(gc, Time::j2000());
   if(!test.equals("accuracy()", a.accuracy(), NOVAS_REDUCED_ACCURACY)) n++;
   if(!test.check("time()", a.time() == Time::j2000())) n++;
-  if(!test.check("observer_position()", a.observer_position() == Position(a._novas_frame()->obs_pos, Unit::AU))) n++;
-  if(!test.check("observer_velocity()", a.observer_velocity() == Velocity(a._novas_frame()->obs_vel, Unit::AU / Unit::day))) n++;
+  if(!test.check("observer_ssb_position()", a.observer_ssb_position() == Position(a._novas_frame()->obs_pos, Unit::AU))) n++;
+  if(!test.check("observer_ssb_velocity()", a.observer_ssb_velocity() == Velocity(a._novas_frame()->obs_vel, Unit::AU / Unit::day))) n++;
   if(!test.equals("observer() type", a.observer().type(), NOVAS_OBSERVER_AT_GEOCENTER)) n++;
   if(!test.equals("clock_skew()", a.clock_skew(NOVAS_TT), novas_clock_skew(a._novas_frame(), NOVAS_TT))) n++;
   if(!test.equals("to_string()", a.to_string(), "Frame for Geocentric Observer at 2000-01-01T11:58:55.816 UTC")) n++;

--- a/test/cpp/GeometricTest.cpp
+++ b/test/cpp/GeometricTest.cpp
@@ -32,7 +32,7 @@ int main() {
   if(!test.check("invalid to_tod()", !x.to_tod().is_valid())) n++;
   if(!test.check("invalid to_cirs()", !x.to_cirs().is_valid())) n++;
   if(!test.check("invalid to_tirs()", !x.to_tirs().is_valid())) n++;
-  if(!test.check("invalid to_itrs()", !x.to_itrs(EOP(32, 0.0, 0.0, 0.0)).is_valid())) n++;
+  if(!test.check("invalid to_itrs()", !x.to_itrs().is_valid())) n++;
   if(!test.check("invalid operator>>(icrs)", !(x >> NOVAS_ICRS).is_valid())) n++;
 
   Frame frame = Observer::at_geocenter().reduced_accuracy_frame_at(Time::j2000());
@@ -71,32 +71,32 @@ int main() {
   if(!test.check("operator>>().velocity()", a1.velocity() == a.to_icrs().velocity())) n++;
 
   double pos1[3] = {0.0}, vel1[3] = {0.0};
-  tod_to_gcrs(frame.time().jd(NOVAS_TDB), frame.accuracy(), pos._array(), pos1);
-  tod_to_gcrs(frame.time().jd(NOVAS_TDB), frame.accuracy(), vel._array(), vel1);
+  tod_to_gcrs(frame.jd(NOVAS_TDB), frame.accuracy(), pos._array(), pos1);
+  tod_to_gcrs(frame.jd(NOVAS_TDB), frame.accuracy(), vel._array(), vel1);
 
   if(!test.equals("to_icrs().system_type()", a1.system_type(), NOVAS_ICRS)) n++;
   if(!test.check("to_icrs().position()", a1.position() == Position(pos1))) n++;
   if(!test.check("to_icrs().velocity()", a1.velocity() == Velocity(vel1))) n++;
 
   Geometric a2 = a.to_j2000();
-  tod_to_j2000(frame.time().jd(NOVAS_TDB), frame.accuracy(), pos._array(), pos1);
-  tod_to_j2000(frame.time().jd(NOVAS_TDB), frame.accuracy(), vel._array(), vel1);
+  tod_to_j2000(frame.jd(NOVAS_TDB), frame.accuracy(), pos._array(), pos1);
+  tod_to_j2000(frame.jd(NOVAS_TDB), frame.accuracy(), vel._array(), vel1);
 
   if(!test.equals("to_j2000().system_type()", a2.system_type(), NOVAS_J2000)) n++;
   if(!test.check("to_j2000().position()", a2.position() == Position(pos1))) n++;
   if(!test.check("to_j2000().velocity()", a2.velocity() == Velocity(vel1))) n++;
 
   Geometric a3 = a.to_mod();
-  nutation(frame.time().jd(NOVAS_TDB), NUTATE_TRUE_TO_MEAN, frame.accuracy(), pos._array(), pos1);
-  nutation(frame.time().jd(NOVAS_TDB), NUTATE_TRUE_TO_MEAN, frame.accuracy(), vel._array(), vel1);
+  nutation(frame.jd(NOVAS_TDB), NUTATE_TRUE_TO_MEAN, frame.accuracy(), pos._array(), pos1);
+  nutation(frame.jd(NOVAS_TDB), NUTATE_TRUE_TO_MEAN, frame.accuracy(), vel._array(), vel1);
 
   if(!test.equals("to_mod().system_type()", a3.system_type(), NOVAS_MOD)) n++;
   if(!test.check("to_mod().position()", a3.position() == Position(pos1))) n++;
   if(!test.check("to_mod().velocity()", a3.velocity() == Velocity(vel1))) n++;
 
   Geometric a4 = a.to_cirs();
-  tod_to_cirs(frame.time().jd(), frame.accuracy(), pos._array(), pos1);
-  tod_to_cirs(frame.time().jd(), frame.accuracy(), vel._array(), vel1);
+  tod_to_cirs(frame.jd(), frame.accuracy(), pos._array(), pos1);
+  tod_to_cirs(frame.jd(), frame.accuracy(), vel._array(), vel1);
 
   if(!test.equals("to_cirs().system_type()", a4.system_type(), NOVAS_CIRS)) n++;
   if(!test.check("to_cirs().position()", a4.position() == Position(pos1))) n++;
@@ -128,7 +128,7 @@ int main() {
   Geometric opt = a.to_itrs();
   if(!test.check("to_itrs(gc).is_valid()", !opt.is_valid())) n++;
 
-  opt = b.to_itrs(eop);
+  opt = b.to_itrs();
   if(!test.check("to_itrs().is_valid()", opt.is_valid())) n++;
   else {
     Geometric b2 = opt;
@@ -143,7 +143,7 @@ int main() {
     if(!test.check("to_itrs().position()", b2.position() == Position(pos1))) n++;
     if(!test.check("to_itrs().velocity()", b2.velocity() == Velocity(vel1))) n++;
 
-    Geometric b3 = b2.to_itrs(eop);
+    Geometric b3 = b2.to_itrs();
     if(!test.equals("to_itrs(ITRS).system_type()", b3.system_type(), NOVAS_ITRS)) n++;
     if(!test.check("to_itrs(ITRS).position()", b3.position() == b2.position())) n++;
     if(!test.check("to_itrs(ITRS).velocity()", b3.velocity() == b2.velocity())) n++;
@@ -174,11 +174,8 @@ int main() {
     Geometric b2 = opt;
     novas_frame f = {};
 
-    double xp, yp;
-    novas_diurnal_eop_at_time(frame.time()._novas_timespec(), &xp, &yp, NULL);
-
     novas_make_frame(NOVAS_REDUCED_ACCURACY, frame.observer()._novas_observer(), frame.time()._novas_timespec(),
-            eop.xp().mas() + 1000.0 * xp, eop.yp().mas() + 1000.0 * yp, &f);
+            eop.xp().mas(), eop.yp().mas(), &f);
 
     f.accuracy = NOVAS_FULL_ACCURACY;
 

--- a/test/cpp/Makefile
+++ b/test/cpp/Makefile
@@ -1,6 +1,7 @@
 # Flags for measuring test coverage
 
 CPPFLAGS += -I../../include
+CFLAGS += -g
 LDFLAGS += --coverage -lm 
 
 include ../../config.mk

--- a/test/cpp/PlanetTest.cpp
+++ b/test/cpp/PlanetTest.cpp
@@ -100,7 +100,7 @@ int main() {
 
   Geometric geom = Planet::jupiter().approx_geometric_in(frame);
   double p[3] = {0.0}, v[3] = {0.0};
-  novas_approx_heliocentric(NOVAS_JUPITER, frame.time().jd(NOVAS_TDB), p, v);
+  novas_approx_heliocentric(NOVAS_JUPITER, frame.jd(NOVAS_TDB), p, v);
   const novas_frame *f = frame._novas_frame();
 
   if(!test.check("approx_geometric_in(invalid)", !Planet::mars().approx_geometric_in(Frame::undefined()).is_valid())) n++;

--- a/test/cpp/SourceTest.cpp
+++ b/test/cpp/SourceTest.cpp
@@ -197,10 +197,10 @@ int main() {
   if(!test.check("_novas_orbital()", memcmp(os._novas_orbital(), orb._novas_orbital(), sizeof(novas_orbital)) == 0)) n++;
   if(!test.check("orbital()", memcmp(os.orbital()._novas_orbital(), orb._novas_orbital(), sizeof(novas_orbital)) == 0)) n++;
   if(!test.equals("solar_illumination()", os.solar_illumination(frame), novas_solar_illum(os._novas_object(), frame._novas_frame()), 1e-9)) n++;
-  if(!test.equals("solar_power()", os.solar_power(frame.time()), novas_solar_power(frame.time().jd(NOVAS_TDB), os._novas_object()), 1e-9)) n++;
+  if(!test.equals("solar_power()", os.solar_power(frame.time()), novas_solar_power(frame.jd(NOVAS_TDB), os._novas_object()), 1e-9)) n++;
 
   double rate = 0.0;
-  if(!test.equals("helio_distance()", os.helio_distance(frame.time()).au(), novas_helio_dist(frame.time().jd(NOVAS_TDB), os._novas_object(), &rate), 1e-9)) n++;
+  if(!test.equals("helio_distance()", os.helio_distance(frame.time()).au(), novas_helio_dist(frame.jd(NOVAS_TDB), os._novas_object(), &rate), 1e-9)) n++;
   if(!test.equals("helio_distance()", os.helio_rate(frame.time()).au_per_day(), rate, 1e-9)) n++;
   if(!test.equals("to_string()", os.to_string(), "OrbitalSource test")) n++;
 

--- a/test/cpp/TimeTest.cpp
+++ b/test/cpp/TimeTest.cpp
@@ -47,6 +47,7 @@ int main() {
   if(!test.check("invalid dUT1()", !x.dUT1().is_valid())) n++;
   if(!test.equals("invalid day_of_week()", x.day_of_week(), -1)) n++;
   if(!test.check("invalid moon_phase()", !x.moon_phase().is_valid())) n++;
+  if(!test.check("invalid moon_phase()", !x.next_moon_phase(Angle(0.0)).is_valid())) n++;
   if(!test.check("invalid to_calendar_date()", !x.to_calendar_date().is_valid())) n++;
   if(!test.equals("invalid to_string()", x.to_string(), "<invalid time>")) n++;
   if(!test.equals("invalid to_iso_string()", x.to_iso_string(), "<invalid time>")) n++;


### PR DESCRIPTION
- Added `Frame::eop()` to return the EOP data stored in the frame for a geodetic observer, or else an invalid EOP.
- Simplified `Geometric::to_itrs()` and related implementation
- Simplified rise / set / transit time calculations for `Source`
- Simplified `Apparent::to_horizontal()`
- Added `Frame::jd()` convenience shortcut.